### PR TITLE
GH-26 docs: fix initialization of `WordEmbeddings` in experiments section

### DIFF
--- a/resources/docs/EXPERIMENTS.md
+++ b/resources/docs/EXPERIMENTS.md
@@ -127,7 +127,7 @@ print(tag_dictionary.idx2item)
 # initialize embeddings
 embedding_types: List[TextEmbeddings] = [
 
-    WordEmbeddings('ft-crawl')
+    WordEmbeddings('crawl')
     ,
     CharLMEmbeddings('news-forward')
     ,
@@ -195,7 +195,7 @@ print(tag_dictionary.idx2item)
 # initialize embeddings
 embedding_types: List[TextEmbeddings] = [
 
-    WordEmbeddings('ft-german')
+    WordEmbeddings('de-fasttext')
     ,
     CharLMEmbeddings('german-forward')
     ,
@@ -261,7 +261,7 @@ print(tag_dictionary.idx2item)
 # initialize embeddings
 embedding_types: List[TextEmbeddings] = [
 
-    WordEmbeddings('ft-german')
+    WordEmbeddings('de-fasttext')
     ,
     CharLMEmbeddings('german-forward')
     ,


### PR DESCRIPTION
Hi,

this PR fixes the initialization of `WordEmbeddings` in the experiments section: old attributes `ft-crawl` and `ft-german` are replaced.

Related to #26.
