### PR TITLE
GH-20: Improve text classifier

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -125,7 +125,7 @@ class Token:
         return 'Token: %d %s' % (self.idx, self.text)
 
     def set_embedding(self, name: str, vector: torch.autograd.Variable):
-        self._embeddings[name] = vector
+        self._embeddings[name] = vector.cpu()
 
     def clear_embeddings(self):
         self._embeddings: Dict = {}
@@ -193,10 +193,9 @@ class Sentence:
             token.idx = len(self.tokens)
 
     def set_embedding(self, name: str, vector):
-        self._embeddings[name] = vector
+        self._embeddings[name] = vector.cpu()
 
     def clear_embeddings(self, also_clear_word_embeddings: bool = True):
-
         self._embeddings: Dict = {}
 
         if also_clear_word_embeddings:

--- a/flair/data_fetcher.py
+++ b/flair/data_fetcher.py
@@ -368,8 +368,6 @@ class NLPTaskDataFetcher:
         label_prefix = '__label__'
         sentences = []
 
-        print(path_to_file)
-
         with open(path_to_file) as f:
             lines = f.readlines()
 

--- a/flair/data_fetcher.py
+++ b/flair/data_fetcher.py
@@ -387,6 +387,7 @@ class NLPTaskDataFetcher:
 
                 text = line[l_len:].strip()
 
-                sentences.append(Sentence(text, labels=labels, use_tokenizer=True))
+                if text and labels:
+                    sentences.append(Sentence(text, labels=labels, use_tokenizer=True))
 
         return sentences

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -475,7 +475,7 @@ class DocumentMeanEmbeddings(DocumentEmbeddings):
 
                 mean_embedding = torch.mean(word_embeddings, 0)
 
-                sentence.set_embedding(self.name, mean_embedding.cpu())
+                sentence.set_embedding(self.name, mean_embedding.unsqueeze(0))
 
     def _add_embeddings_internal(self, sentences: List[Sentence]):
         pass

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -522,6 +522,8 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
                                  bidirectional=self.bidirectional)
         self.dropout = torch.nn.Dropout(0.5)
 
+        torch.nn.init.xavier_uniform_(self.word_reprojection_map.weight)
+
         if torch.cuda.is_available():
             self.cuda()
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -525,7 +525,7 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
         # bidirectional LSTM on top of embedding layer
         self.word_reprojection_map = torch.nn.Linear(self.length_of_all_token_embeddings,
                                                      self.embeddings_dimension)
-        self.rnn = torch.nn.LSTM(self.embeddings_dimension, hidden_states, num_layers=num_layers,
+        self.rnn = torch.nn.GRU(self.embeddings_dimension, hidden_states, num_layers=num_layers,
                                  bidirectional=self.bidirectional)
         self.dropout = torch.nn.Dropout(0.5)
 
@@ -608,11 +608,11 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
         # EXTRACT EMBEDDINGS FROM LSTM
         # --------------------------------------------------------------------
         for sentence_no, length in enumerate(lengths):
-            last_rep = outputs[length - 1, sentence_no, :].unsqueeze(0)
+            last_rep = outputs[length - 1, sentence_no].unsqueeze(0)
 
             embedding = last_rep
             if self.use_first_representation:
-                first_rep = outputs[0, sentence_no, :].unsqueeze(0)
+                first_rep = outputs[0, sentence_no].unsqueeze(0)
                 embedding = torch.cat([first_rep, last_rep], 1)
 
             sentence = sentences[sentence_no]

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -513,10 +513,11 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
         self.name = 'document_lstm'
         self.static_embeddings = False
 
+        self.__embedding_length: int = hidden_states
         if self.bidirectional:
-            self.__embedding_length: int = hidden_states * 2
-        else:
-            self.__embedding_length: int = hidden_states
+            self.__embedding_length *= 2
+        if self.use_first_representation:
+            self.__embedding_length *= 2
 
         self.embeddings_dimension: int = self.length_of_all_token_embeddings
         if self.reproject_words and reproject_words_dimension is not None:

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -55,7 +55,7 @@ class TextClassifier(nn.Module):
     def forward(self, sentences):
         self.document_embeddings.embed(sentences)
 
-        text_embedding_list = [sentence.get_embedding().unsqueeze(0) for sentence in sentences]
+        text_embedding_list = [sentence.get_embedding() for sentence in sentences]
         text_embedding_tensor = torch.cat(text_embedding_list, 0)
 
         if torch.cuda.is_available():

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -78,7 +78,10 @@ class TextClassifier(nn.Module):
         # ATTENTION: suppressing torch serialization warnings. This needs to be taken out once we sort out recursive
         # serialization of torch objects
         warnings.filterwarnings("ignore")
-        state = torch.load(model_file)
+        if torch.cuda.is_available():
+            state = torch.load(model_file)
+        else:
+            state = torch.load(model_file, map_location={'cuda:0': 'cpu'})
         warnings.filterwarnings("default")
 
         model = TextClassifier(

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -18,28 +18,17 @@ class TextClassifier(nn.Module):
     """
 
     def __init__(self,
-                 token_embeddings: List[flair.embeddings.TokenEmbeddings],
-                 hidden_states: int,
-                 num_layers: int,
-                 reproject_words: bool,
-                 reproject_words_dimension: int,
-                 bidirectional: bool,
+                 document_embeddings: flair.embeddings.DocumentEmbeddings,
                  label_dictionary: Dictionary,
                  multi_label: bool):
 
         super(TextClassifier, self).__init__()
 
-        self.token_embeddings = token_embeddings
-        self.hidden_states = hidden_states
-        self.num_layers = num_layers
-        self.reproject_words = reproject_words
-        self.reproject_words_dimension = reproject_words_dimension
-        self.bidirectional = bidirectional
+        self.document_embeddings = document_embeddings
         self.label_dictionary: Dictionary = label_dictionary
         self.multi_label = multi_label
 
-        self.document_embeddings: flair.embeddings.DocumentLSTMEmbeddings = flair.embeddings.DocumentLSTMEmbeddings(
-            token_embeddings, hidden_states, num_layers, reproject_words, reproject_words_dimension, bidirectional)
+        self.document_embeddings: flair.embeddings.DocumentLSTMEmbeddings = document_embeddings
 
         self.decoder = nn.Linear(self.document_embeddings.embedding_length, len(self.label_dictionary))
 
@@ -72,12 +61,7 @@ class TextClassifier(nn.Module):
         """
         model_state = {
             'state_dict': self.state_dict(),
-            'token_embeddings': self.token_embeddings,
-            'hidden_states': self.hidden_states,
-            'num_layers': self.num_layers,
-            'reproject_words': self.reproject_words,
-            'reproject_words_dimension': self.reproject_words_dimension,
-            'bidirectional': self.bidirectional,
+            'document_embeddings': self.document_embeddings,
             'label_dictionary': self.label_dictionary,
             'multi_label': self.multi_label,
         }
@@ -98,12 +82,7 @@ class TextClassifier(nn.Module):
         warnings.filterwarnings("default")
 
         model = TextClassifier(
-            token_embeddings=state['token_embeddings'],
-            hidden_states=state['hidden_states'],
-            num_layers=state['num_layers'],
-            reproject_words=state['reproject_words'],
-            reproject_words_dimension=state['reproject_words_dimension'],
-            bidirectional=state['bidirectional'],
+            document_embeddings=state['document_embeddings'],
             label_dictionary=state['label_dictionary'],
             multi_label=state['multi_label']
         )

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -22,6 +22,7 @@ class TextClassifier(nn.Module):
                  hidden_states: int,
                  num_layers: int,
                  reproject_words: bool,
+                 reproject_words_dimension: int,
                  bidirectional: bool,
                  label_dictionary: Dictionary,
                  multi_label: bool):
@@ -32,12 +33,13 @@ class TextClassifier(nn.Module):
         self.hidden_states = hidden_states
         self.num_layers = num_layers
         self.reproject_words = reproject_words
+        self.reproject_words_dimension = reproject_words_dimension
         self.bidirectional = bidirectional
         self.label_dictionary: Dictionary = label_dictionary
         self.multi_label = multi_label
 
         self.document_embeddings: flair.embeddings.DocumentLSTMEmbeddings = flair.embeddings.DocumentLSTMEmbeddings(
-            token_embeddings, hidden_states, num_layers, reproject_words, bidirectional)
+            token_embeddings, hidden_states, num_layers, reproject_words, reproject_words_dimension, bidirectional)
 
         self.decoder = nn.Linear(self.document_embeddings.embedding_length, len(self.label_dictionary))
 
@@ -74,6 +76,7 @@ class TextClassifier(nn.Module):
             'hidden_states': self.hidden_states,
             'num_layers': self.num_layers,
             'reproject_words': self.reproject_words,
+            'reproject_words_dimension': self.reproject_words_dimension,
             'bidirectional': self.bidirectional,
             'label_dictionary': self.label_dictionary,
             'multi_label': self.multi_label,
@@ -99,6 +102,7 @@ class TextClassifier(nn.Module):
             hidden_states=state['hidden_states'],
             num_layers=state['num_layers'],
             reproject_words=state['reproject_words'],
+            reproject_words_dimension=state['reproject_words_dimension'],
             bidirectional=state['bidirectional'],
             label_dictionary=state['label_dictionary'],
             multi_label=state['multi_label']

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -94,7 +94,7 @@ class TextClassifier(nn.Module):
         # ATTENTION: suppressing torch serialization warnings. This needs to be taken out once we sort out recursive
         # serialization of torch objects
         warnings.filterwarnings("ignore")
-        state = torch.load(model_file, map_location={'cuda:0': 'cpu'})
+        state = torch.load(model_file)
         warnings.filterwarnings("default")
 
         model = TextClassifier(
@@ -159,8 +159,9 @@ class TextClassifier(nn.Module):
 
         results = list(map(lambda x: sigmoid(x), label_scores))
         for idx, conf in enumerate(results):
-            label = self.label_dictionary.get_item_for_index(idx)
-            labels.append(label)
+            if conf > 0.5:
+                label = self.label_dictionary.get_item_for_index(idx)
+                labels.append(label)
 
         return labels
 

--- a/flair/trainers/text_classification_trainer.py
+++ b/flair/trainers/text_classification_trainer.py
@@ -144,9 +144,11 @@ class TextClassifierTrainer:
 
             if save_model:
                 self.model = TextClassifier.load_from_file(base_path + "/model.pt")
+
             test_metrics, test_loss = self.evaluate(
                 self.corpus.test, mini_batch_size=mini_batch_size, eval_class_metrics=True,
                 embeddings_in_memory=embeddings_in_memory)
+
             for metric in test_metrics.values():
                 metric.print()
 

--- a/flair/trainers/text_classification_trainer.py
+++ b/flair/trainers/text_classification_trainer.py
@@ -45,6 +45,8 @@ class TextClassifierTrainer:
         """
 
         loss_txt = init_output_file(base_path, 'loss.txt')
+        with open(loss_txt, 'a') as f:
+            f.write('EPOCH\tITERATION\tDEV_LOSS\tTRAIN_LOSS\tDEV_F_SCORE\tTRAIN_F_SCORE\tDEV_ACC\tTRAIN_ACC\n')
         weights_txt = init_output_file(base_path, 'weights.txt')
 
         weights_index = defaultdict(lambda: defaultdict(lambda: list()))
@@ -66,6 +68,7 @@ class TextClassifierTrainer:
             best_score = 0
 
             for epoch in range(max_epochs):
+                print('-' * 100)
                 if not self.test_mode:
                     random.shuffle(train_data)
 
@@ -103,6 +106,7 @@ class TextClassifierTrainer:
                 # IMPORTANT: Switch to eval mode
                 self.model.eval()
 
+                print('-' * 100)
                 train_metrics, train_loss = self.evaluate(self.corpus.train, mini_batch_size=mini_batch_size,
                                                           embeddings_in_memory=embeddings_in_memory)
                 train_f_score = train_metrics['MICRO_AVG'].f_score()
@@ -145,12 +149,17 @@ class TextClassifierTrainer:
             if save_model:
                 self.model = TextClassifier.load_from_file(base_path + "/model.pt")
 
+            print('-' * 100)
+            print('testing...')
+
             test_metrics, test_loss = self.evaluate(
                 self.corpus.test, mini_batch_size=mini_batch_size, eval_class_metrics=True,
                 embeddings_in_memory=embeddings_in_memory)
 
             for metric in test_metrics.values():
                 metric.print()
+
+            print('-' * 100)
 
         except KeyboardInterrupt:
             print('-' * 89)

--- a/flair/trainers/text_classification_trainer.py
+++ b/flair/trainers/text_classification_trainer.py
@@ -105,8 +105,8 @@ class TextClassifierTrainer:
 
                 train_metrics, train_loss = self.evaluate(self.corpus.train, mini_batch_size=mini_batch_size,
                                                           embeddings_in_memory=embeddings_in_memory)
-                train_f_score = train_metrics['OVERALL'].f_score()
-                train_acc = train_metrics['OVERALL'].accuracy()
+                train_f_score = train_metrics['MICRO_AVG'].f_score()
+                train_acc = train_metrics['MICRO_AVG'].accuracy()
                 print("{0:<7} epoch {1} - loss {2:.8f} - f-score {3:.4f} - acc {4:.4f}".format(
                     'TRAIN:', epoch, train_loss, train_f_score, train_acc))
 
@@ -114,8 +114,8 @@ class TextClassifierTrainer:
                 if not train_with_dev:
                     dev_metrics, dev_loss = self.evaluate(self.corpus.dev, mini_batch_size=mini_batch_size,
                                                           embeddings_in_memory=embeddings_in_memory)
-                    dev_f_score = dev_metrics['OVERALL'].f_score()
-                    dev_acc = dev_metrics['OVERALL'].accuracy()
+                    dev_f_score = dev_metrics['MICRO_AVG'].f_score()
+                    dev_acc = dev_metrics['MICRO_AVG'].accuracy()
                     print("{0:<7} epoch {1} - loss {2:.8f} - f-score {3:.4f} - acc {4:.4f}".format(
                         'DEV:', epoch, dev_loss, dev_f_score, dev_acc))
 

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -63,8 +63,7 @@ def clear_embeddings(sentences: List[Sentence]):
     :param sentences: list of sentences
     """
     for sentence in sentences:
-        for token in sentence.tokens:
-            token.clear_embeddings()
+        sentence.clear_embeddings(also_clear_word_embeddings=True)
 
 
 def init_output_file(base_path: str, file_name: str):

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -110,7 +110,7 @@ def calculate_micro_avg_metric(y_true: List[List[int]], y_pred: List[List[int]],
     :param labels: the label dictionary
     :return: the overall metrics
     """
-    metric = Metric("OVERALL")
+    metric = Metric("MICRO_AVG")
 
     for pred, true in zip(y_pred, y_true):
         for i in range(len(labels)):

--- a/tests/resources/tasks/ag_news/dev.txt
+++ b/tests/resources/tasks/ag_news/dev.txt
@@ -8,3 +8,7 @@ __label__Business Exxon boosted by oil price boom Exxon Mobil becomes the latest
 __label__Business General Mills Says Its Costs Pinch Its Profit Profit in the fourth quarter rose less than 1 percent, hurt by soaring grain costs, despite a 7 percent increase in sales.
 __label__Sci/Tech Big Video Game Producer Receives More Subpoenas Take-Two Interactive Software said it received additional grand jury subpoenas seeking information about its financial activities.
 __label__World On video, British hostage faults Blair LONDON -- A videotape broadcast yesterday showed a British hostage in Iraq shackled in a cage and wearing an orange jumpsuit, pleading with Prime Minister Tony Blair to help save his life and accusing him of not doing enough to secure his freedom.
+
+__label__dummy
+
+test

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -102,7 +102,7 @@ def test_document_lstm_embeddings():
     embeddings.embed(sentence)
 
     assert (len(sentence.get_embedding()) != 0)
-    assert (sentence.get_embedding().shape[1] == 128)
+    assert (sentence.get_embedding().shape[1] == embeddings.embedding_length)
 
     sentence.clear_embeddings()
 
@@ -118,7 +118,7 @@ def test_document_bidirectional_lstm_embeddings():
     embeddings.embed(sentence)
 
     assert (len(sentence.get_embedding()) != 0)
-    assert (sentence.get_embedding().shape[1] == 128 * 2)
+    assert (sentence.get_embedding().shape[1] == embeddings.embedding_length)
 
     sentence.clear_embeddings()
 
@@ -134,7 +134,7 @@ def test_document_bidirectional_lstm_embeddings_using_first_representation():
     embeddings.embed(sentence)
 
     assert (len(sentence.get_embedding()) != 0)
-    assert (sentence.get_embedding().shape[1] == 128 * 4)
+    assert (sentence.get_embedding().shape[1] == embeddings.embedding_length)
 
     sentence.clear_embeddings()
 
@@ -150,7 +150,7 @@ def test_document_lstm_embeddings_using_first_representation():
     embeddings.embed(sentence)
 
     assert (len(sentence.get_embedding()) != 0)
-    assert (sentence.get_embedding().shape[1] == 128 * 2)
+    assert (sentence.get_embedding().shape[1] == embeddings.embedding_length)
 
     sentence.clear_embeddings()
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,3 +1,5 @@
+import pytest
+
 from flair.embeddings import WordEmbeddings, TokenEmbeddings, CharLMEmbeddings, StackedEmbeddings, \
     DocumentLSTMEmbeddings, DocumentMeanEmbeddings
 
@@ -80,18 +82,75 @@ def test_stacked_embeddings():
         assert(len(token.get_embedding()) == 0)
 
 
-def test_document_lstm_embeddings():
+@pytest.fixture
+def init_document_embeddings():
     text = 'I love Berlin. Berlin is a great place to live.'
     sentence: Sentence = Sentence(text)
 
     glove: TokenEmbeddings = WordEmbeddings('en-glove')
     charlm: TokenEmbeddings = CharLMEmbeddings('mix-backward')
 
-    embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove, charlm], bidirectional=False)
+    return sentence, glove, charlm
+
+
+def test_document_lstm_embeddings():
+    sentence, glove, charlm = init_document_embeddings()
+
+    embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove, charlm], hidden_states=128,
+                                                                bidirectional=False, use_first_representation=False)
 
     embeddings.embed(sentence)
 
     assert (len(sentence.get_embedding()) != 0)
+    assert (sentence.get_embedding().shape[1] == 128)
+
+    sentence.clear_embeddings()
+
+    assert (len(sentence.get_embedding()) == 0)
+
+
+def test_document_bidirectional_lstm_embeddings():
+    sentence, glove, charlm = init_document_embeddings()
+
+    embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove, charlm], hidden_states=128,
+                                                                bidirectional=True, use_first_representation=False)
+
+    embeddings.embed(sentence)
+
+    assert (len(sentence.get_embedding()) != 0)
+    assert (sentence.get_embedding().shape[1] == 128 * 2)
+
+    sentence.clear_embeddings()
+
+    assert (len(sentence.get_embedding()) == 0)
+
+
+def test_document_bidirectional_lstm_embeddings_using_first_representation():
+    sentence, glove, charlm = init_document_embeddings()
+
+    embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove, charlm], hidden_states=128,
+                                                                bidirectional=True, use_first_representation=True)
+
+    embeddings.embed(sentence)
+
+    assert (len(sentence.get_embedding()) != 0)
+    assert (sentence.get_embedding().shape[1] == 128 * 4)
+
+    sentence.clear_embeddings()
+
+    assert (len(sentence.get_embedding()) == 0)
+
+
+def test_document_lstm_embeddings_using_first_representation():
+    sentence, glove, charlm = init_document_embeddings()
+
+    embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove, charlm], hidden_states=128,
+                                                                bidirectional=False, use_first_representation=True)
+
+    embeddings.embed(sentence)
+
+    assert (len(sentence.get_embedding()) != 0)
+    assert (sentence.get_embedding().shape[1] == 128 * 2)
 
     sentence.clear_embeddings()
 

--- a/tests/test_text_classifier.py
+++ b/tests/test_text_classifier.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 from flair.data import Dictionary, TaggedCorpus
 from flair.data_fetcher import NLPTaskDataFetcher, NLPTask
-from flair.embeddings import WordEmbeddings
+from flair.embeddings import WordEmbeddings, DocumentLSTMEmbeddings
 from flair.models.text_classification_model import TextClassifier
 
 
@@ -13,7 +13,9 @@ def init() -> Tuple[TaggedCorpus, Dictionary, TextClassifier]:
     label_dict = corpus.make_label_dictionary()
 
     glove_embedding: WordEmbeddings = WordEmbeddings('en-glove')
-    model = TextClassifier([glove_embedding], 128, 1, False, 64, False, label_dict, False)
+    document_embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove_embedding], 128, 1, False, 64, False, False)
+
+    model = TextClassifier(document_embeddings, label_dict, False)
 
     return corpus, label_dict, model
 

--- a/tests/test_text_classifier.py
+++ b/tests/test_text_classifier.py
@@ -13,7 +13,7 @@ def init() -> Tuple[TaggedCorpus, Dictionary, TextClassifier]:
     label_dict = corpus.make_label_dictionary()
 
     glove_embedding: WordEmbeddings = WordEmbeddings('en-glove')
-    model = TextClassifier(glove_embedding, 128, 1, False, False, label_dict, False)
+    model = TextClassifier([glove_embedding], 128, 1, False, 64, False, label_dict, False)
 
     return corpus, label_dict, model
 

--- a/tests/test_text_classifier_trainer.py
+++ b/tests/test_text_classifier_trainer.py
@@ -6,7 +6,7 @@ from flair.models.text_classification_model import TextClassifier
 from flair.trainers.text_classification_trainer import TextClassifierTrainer
 
 
-def test_training():
+def test_text_classifier():
     corpus = NLPTaskDataFetcher.fetch_data(NLPTask.IMDB)
     label_dict = corpus.make_label_dictionary()
 

--- a/tests/test_text_classifier_trainer.py
+++ b/tests/test_text_classifier_trainer.py
@@ -10,8 +10,7 @@ def test_training():
     corpus = NLPTaskDataFetcher.fetch_data(NLPTask.IMDB)
     label_dict = corpus.make_label_dictionary()
 
-    document_embedding = DocumentMeanEmbeddings([WordEmbeddings('en-glove')])
-    model = TextClassifier(document_embedding, 128, 1, False, False, label_dict, False)
+    model = TextClassifier([WordEmbeddings('en-glove')], 128, 1, False, 64, False, label_dict, False)
 
     trainer = TextClassifierTrainer(model, corpus, label_dict, False)
     trainer.train('./results', max_epochs=2)

--- a/tests/test_text_classifier_trainer.py
+++ b/tests/test_text_classifier_trainer.py
@@ -6,11 +6,24 @@ from flair.models.text_classification_model import TextClassifier
 from flair.trainers.text_classification_trainer import TextClassifierTrainer
 
 
-def test_text_classifier():
+def test_text_classifier_single_label():
     corpus = NLPTaskDataFetcher.fetch_data(NLPTask.IMDB)
     label_dict = corpus.make_label_dictionary()
 
     model = TextClassifier([WordEmbeddings('en-glove')], 128, 1, False, 64, False, label_dict, False)
+
+    trainer = TextClassifierTrainer(model, corpus, label_dict, False)
+    trainer.train('./results', max_epochs=2)
+
+    # clean up results directory
+    shutil.rmtree('./results')
+
+
+def test_text_classifier_mulit_label():
+    corpus = NLPTaskDataFetcher.fetch_data(NLPTask.IMDB)
+    label_dict = corpus.make_label_dictionary()
+
+    model = TextClassifier([WordEmbeddings('en-glove')], 128, 1, False, 64, False, label_dict, True)
 
     trainer = TextClassifierTrainer(model, corpus, label_dict, False)
     trainer.train('./results', max_epochs=2)

--- a/tests/test_text_classifier_trainer.py
+++ b/tests/test_text_classifier_trainer.py
@@ -1,7 +1,7 @@
 import shutil
 
 from flair.data_fetcher import NLPTaskDataFetcher, NLPTask
-from flair.embeddings import WordEmbeddings, DocumentMeanEmbeddings
+from flair.embeddings import WordEmbeddings, DocumentMeanEmbeddings, DocumentLSTMEmbeddings
 from flair.models.text_classification_model import TextClassifier
 from flair.trainers.text_classification_trainer import TextClassifierTrainer
 
@@ -10,7 +10,10 @@ def test_text_classifier_single_label():
     corpus = NLPTaskDataFetcher.fetch_data(NLPTask.IMDB)
     label_dict = corpus.make_label_dictionary()
 
-    model = TextClassifier([WordEmbeddings('en-glove')], 128, 1, False, 64, False, label_dict, False)
+    glove_embedding: WordEmbeddings = WordEmbeddings('en-glove')
+    document_embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove_embedding], 128, 1, False, 64, False, False)
+
+    model = TextClassifier(document_embeddings, label_dict, False)
 
     trainer = TextClassifierTrainer(model, corpus, label_dict, False)
     trainer.train('./results', max_epochs=2)
@@ -23,7 +26,10 @@ def test_text_classifier_mulit_label():
     corpus = NLPTaskDataFetcher.fetch_data(NLPTask.IMDB)
     label_dict = corpus.make_label_dictionary()
 
-    model = TextClassifier([WordEmbeddings('en-glove')], 128, 1, False, 64, False, label_dict, True)
+    glove_embedding: WordEmbeddings = WordEmbeddings('en-glove')
+    document_embeddings: DocumentMeanEmbeddings = DocumentMeanEmbeddings([glove_embedding], True)
+
+    model = TextClassifier(document_embeddings, label_dict, True)
 
     trainer = TextClassifierTrainer(model, corpus, label_dict, False)
     trainer.train('./results', max_epochs=2)


### PR DESCRIPTION
closes #20 

- use ReduceLROnPlateau in TextClassifier
- Fix bugs in training TextClassifier on GPU
- TextClassifier now takes a DocumentEmbeddings instead of a list of TokenEmbeddings
- DocumentLSTMEmbedding now takes additional parameters to define (1) the output dimension of the reprojection of words and (2) whether only the last representation or a combination of last and first representation of the LSTM should be taken as document embedding