### PR TITLE
GH-5: Make use of subword embeddings if supported

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -189,8 +189,6 @@ class WordEmbeddings(TokenEmbeddings):
 
         self.precomputed_word_embeddings = gensim.models.KeyedVectors.load(embeddings)
 
-        self.known_words = set(self.precomputed_word_embeddings.index2word)
-
         self.__embedding_length: int = self.precomputed_word_embeddings.vector_size
         super().__init__()
 
@@ -205,13 +203,13 @@ class WordEmbeddings(TokenEmbeddings):
             for token, token_idx in zip(sentence.tokens, range(len(sentence.tokens))):
                 token: Token = token
 
-                if token.text in self.known_words:
+                if token.text in self.precomputed_word_embeddings:
                     word_embedding = self.precomputed_word_embeddings[token.text]
-                elif token.text.lower() in self.known_words:
+                elif token.text.lower() in self.precomputed_word_embeddings:
                     word_embedding = self.precomputed_word_embeddings[token.text.lower()]
-                elif re.sub('\d', '#', token.text.lower()) in self.known_words:
+                elif re.sub('\d', '#', token.text.lower()) in self.precomputed_word_embeddings:
                     word_embedding = self.precomputed_word_embeddings[re.sub('\d', '#', token.text.lower())]
-                elif re.sub('\d', '0', token.text.lower()) in self.known_words:
+                elif re.sub('\d', '0', token.text.lower()) in self.precomputed_word_embeddings:
                     word_embedding = self.precomputed_word_embeddings[re.sub('\d', '0', token.text.lower())]
                 else:
                     word_embedding = np.zeros(self.embedding_length, dtype='float')


### PR DESCRIPTION
This is an attempt at implementing https://github.com/zalandoresearch/flair/issues/5.
No extra classes were neccessary, this PR just changes the approach taken for checking if a word is OOV.

Previously, flair would store a set of all known words from the Gensim `KeyedVectors` class.
I changed this to use the `__contains__` implementation on `KeyedVectors`, which does just that, without any extra data structures. However, if the embeddings are of type `FastTextKeyedVectors`, Gensim will also use the subword-embeddings in case of an OOV (https://github.com/RaRe-Technologies/gensim/blob/develop/gensim/models/keyedvectors.py#L1928).

Unfortunately, this can't currently be used with the FastText-embeddings shipped with flair, since they don't actually have any subword-embeddings, the `KeyedVectors` class is just `Word2VecKeyedVectors` (i.e., only word embeddings).