### PR TITLE
GH-54: token offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Please cite the following paper when using Flair:
   title={Contextual String Embeddings for Sequence Labeling},
   author={Akbik, Alan and Blythe, Duncan and Vollgraf, Roland},
   booktitle = {{COLING} 2018, 27th International Conference on Computational Linguistics},
-  pages     = {1756--1765},
+  pages     = {1638--1649},
   year      = {2018}
 }
 ```

--- a/flair/data.py
+++ b/flair/data.py
@@ -382,13 +382,13 @@ class Sentence:
     def __str__(self) -> str:
         return 'Sentence: "' + ' '.join([t.text for t in self.tokens]) + '" - %d Tokens' % len(self)
 
-    def to_plain_string(self) -> str:
-        return ' '.join([t.text for t in self.tokens])
-
     def __len__(self) -> int:
         return len(self.tokens)
 
-    def to_real_string(self):
+    def to_tokenized_string(self) -> str:
+        return ' '.join([t.text for t in self.tokens])
+
+    def to_plain_string(self):
         plain = ''
         for token in self.tokens:
             plain += token.text

--- a/flair/data.py
+++ b/flair/data.py
@@ -216,7 +216,7 @@ class Sentence:
                 # determine offsets for whitespace_after field
                 index = text.index
                 running_offset = 0
-                last_word_offset = -2
+                last_word_offset = -1
                 last_token = None
                 for word in tokens:
                     token = Token(word)
@@ -224,8 +224,8 @@ class Sentence:
                     try:
                         word_offset = index(word, running_offset)
                     except:
-                        word_offset = last_word_offset = +1
-                    if word_offset - 1 == last_word_offset:
+                        word_offset = last_word_offset + 1
+                    if word_offset - 1 == last_word_offset and last_token is not None:
                         last_token.whitespace_after = False
                     word_len = len(word)
                     running_offset = word_offset + word_len

--- a/flair/data_fetcher.py
+++ b/flair/data_fetcher.py
@@ -177,8 +177,8 @@ class NLPTaskDataFetcher:
             column_format: Dict[int, str],
             train_file: str,
             test_file: str,
-            dev_file = None,
-            tag_to_biloes = None) -> TaggedCorpus:
+            dev_file=None,
+            tag_to_biloes=None) -> TaggedCorpus:
         """
         Helper function to get a TaggedCorpus from CoNLL column-formatted task data such as CoNLL03 or CoNLL2000.
 
@@ -214,7 +214,9 @@ class NLPTaskDataFetcher:
         return TaggedCorpus(sentences_train, sentences_dev, sentences_test)
 
     @staticmethod
-    def read_column_data(path_to_column_file: str, column_name_map: Dict[int, str]):
+    def read_column_data(path_to_column_file: str,
+                         column_name_map: Dict[int, str],
+                         infer_whitespace_after: bool = True):
         """
         Reads a file in column format and produces a list of Sentence with tokenlevel annotation as specified in the
         column_name_map. For instance, by passing "{0: 'text', 1: 'pos', 2: 'np', 3: 'ner'}" as column_name_map you
@@ -222,6 +224,7 @@ class NLPTaskDataFetcher:
         the chunk and the forth the NER tag.
         :param path_to_column_file: the path to the column file
         :param column_name_map: a map of column number to token annotation name
+        :param infer_whitespace_after: if True, tries to infer whitespace_after field for Teach oken
         :return: list of sentences
         """
         sentences: List[Sentence] = []
@@ -242,6 +245,7 @@ class NLPTaskDataFetcher:
 
             if line == '':
                 if len(sentence) > 0:
+                    sentence._infer_space_after()
                     sentences.append(sentence)
                 sentence: Sentence = Sentence()
 
@@ -255,6 +259,7 @@ class NLPTaskDataFetcher:
                 sentence.add_token(token)
 
         if len(sentence.tokens) > 0:
+            sentence._infer_space_after()
             sentences.append(sentence)
 
         return sentences

--- a/flair/data_fetcher.py
+++ b/flair/data_fetcher.py
@@ -224,7 +224,7 @@ class NLPTaskDataFetcher:
         the chunk and the forth the NER tag.
         :param path_to_column_file: the path to the column file
         :param column_name_map: a map of column number to token annotation name
-        :param infer_whitespace_after: if True, tries to infer whitespace_after field for Teach oken
+        :param infer_whitespace_after: if True, tries to infer whitespace_after field for Token
         :return: list of sentences
         """
         sentences: List[Sentence] = []

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -383,7 +383,7 @@ class CharLMEmbeddings(TokenEmbeddings):
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
 
         # get text sentences
-        text_sentences = [sentence.to_plain_string() for sentence in sentences]
+        text_sentences = [sentence.to_tokenized_string() for sentence in sentences]
 
         longest_character_sequence_in_batch: int = len(max(text_sentences, key=len))
 
@@ -407,7 +407,7 @@ class CharLMEmbeddings(TokenEmbeddings):
 
         # take first or last hidden states from language model as word representation
         for i, sentence in enumerate(sentences):
-            sentence_text = sentence.to_plain_string()
+            sentence_text = sentence.to_tokenized_string()
 
             offset_forward: int = extra_offset
             offset_backward: int = len(sentence_text) + extra_offset

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from flair.data import Sentence, Label, Token, Dictionary, TaggedCorpus
+from flair.data_fetcher import NLPTaskDataFetcher, NLPTask
 
 
 def test_get_head():
@@ -43,6 +44,22 @@ def test_sentence_to_plain_string():
     sentence: Sentence = Sentence('I love Berlin.', use_tokenizer=True)
 
     assert ('I love Berlin .' == sentence.to_plain_string())
+
+
+def test_sentence_to_real_string():
+
+    sentence: Sentence = Sentence('I love Berlin.', use_tokenizer=True)
+    assert ('I love Berlin.' == sentence.to_real_string())
+
+    corpus = NLPTaskDataFetcher.fetch_data(NLPTask.GERMEVAL)
+
+    sentence = corpus.train[0]
+    assert ('Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in einer Weise aufgetreten , die alles andere als überzeugend war " .' == sentence.to_plain_string())
+    assert ('Schartau sagte dem "Tagesspiegel" vom Freitag, Fischer sei "in einer Weise aufgetreten, die alles andere als überzeugend war".' == sentence.to_real_string())
+
+    sentence = corpus.train[1]
+    assert ('Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf .' == sentence.to_plain_string())
+    assert ('Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter, als er einen fliegenden Händler aus dem Libanon traf.' == sentence.to_real_string())
 
 
 def test_sentence_get_item():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -43,23 +43,23 @@ def test_create_sentence_with_tokenizer():
 def test_sentence_to_plain_string():
     sentence: Sentence = Sentence('I love Berlin.', use_tokenizer=True)
 
-    assert ('I love Berlin .' == sentence.to_plain_string())
+    assert ('I love Berlin .' == sentence.to_tokenized_string())
 
 
 def test_sentence_to_real_string():
 
     sentence: Sentence = Sentence('I love Berlin.', use_tokenizer=True)
-    assert ('I love Berlin.' == sentence.to_real_string())
+    assert ('I love Berlin.' == sentence.to_plain_string())
 
     corpus = NLPTaskDataFetcher.fetch_data(NLPTask.GERMEVAL)
 
     sentence = corpus.train[0]
-    assert ('Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in einer Weise aufgetreten , die alles andere als überzeugend war " .' == sentence.to_plain_string())
-    assert ('Schartau sagte dem "Tagesspiegel" vom Freitag, Fischer sei "in einer Weise aufgetreten, die alles andere als überzeugend war".' == sentence.to_real_string())
+    assert ('Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in einer Weise aufgetreten , die alles andere als überzeugend war " .' == sentence.to_tokenized_string())
+    assert ('Schartau sagte dem "Tagesspiegel" vom Freitag, Fischer sei "in einer Weise aufgetreten, die alles andere als überzeugend war".' == sentence.to_plain_string())
 
     sentence = corpus.train[1]
-    assert ('Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf .' == sentence.to_plain_string())
-    assert ('Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter, als er einen fliegenden Händler aus dem Libanon traf.' == sentence.to_real_string())
+    assert ('Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf .' == sentence.to_tokenized_string())
+    assert ('Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter, als er einen fliegenden Händler aus dem Libanon traf.' == sentence.to_plain_string())
 
 
 def test_sentence_get_item():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -16,18 +16,18 @@ def test_get_head():
     sentence.add_token(token2)
     sentence.add_token(token3)
 
-    assert(token2 == token3.get_head())
-    assert(token1 == token2.get_head())
-    assert(None == token1.get_head())
+    assert (token2 == token3.get_head())
+    assert (token1 == token2.get_head())
+    assert (None == token1.get_head())
 
 
 def test_create_sentence_without_tokenizer():
     sentence: Sentence = Sentence('I love Berlin.')
 
-    assert(3 == len(sentence.tokens))
-    assert('I' == sentence.tokens[0].text)
-    assert('love' == sentence.tokens[1].text)
-    assert('Berlin.' == sentence.tokens[2].text)
+    assert (3 == len(sentence.tokens))
+    assert ('I' == sentence.tokens[0].text)
+    assert ('love' == sentence.tokens[1].text)
+    assert ('Berlin.' == sentence.tokens[2].text)
 
 
 def test_create_sentence_with_tokenizer():
@@ -47,20 +47,39 @@ def test_sentence_to_plain_string():
 
 
 def test_sentence_to_real_string():
-
     sentence: Sentence = Sentence('I love Berlin.', use_tokenizer=True)
     assert ('I love Berlin.' == sentence.to_plain_string())
 
     corpus = NLPTaskDataFetcher.fetch_data(NLPTask.GERMEVAL)
 
     sentence = corpus.train[0]
-    assert ('Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in einer Weise aufgetreten , die alles andere als überzeugend war " .' == sentence.to_tokenized_string())
-    assert ('Schartau sagte dem "Tagesspiegel" vom Freitag, Fischer sei "in einer Weise aufgetreten, die alles andere als überzeugend war".' == sentence.to_plain_string())
+    assert (
+                'Schartau sagte dem " Tagesspiegel " vom Freitag , Fischer sei " in einer Weise aufgetreten , die alles andere als überzeugend war " .' == sentence.to_tokenized_string())
+    assert (
+                'Schartau sagte dem "Tagesspiegel" vom Freitag, Fischer sei "in einer Weise aufgetreten, die alles andere als überzeugend war".' == sentence.to_plain_string())
 
     sentence = corpus.train[1]
-    assert ('Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf .' == sentence.to_tokenized_string())
-    assert ('Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter, als er einen fliegenden Händler aus dem Libanon traf.' == sentence.to_plain_string())
+    assert (
+                'Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter , als er einen fliegenden Händler aus dem Libanon traf .' == sentence.to_tokenized_string())
+    assert (
+                'Firmengründer Wolf Peter Bree arbeitete Anfang der siebziger Jahre als Möbelvertreter, als er einen fliegenden Händler aus dem Libanon traf.' == sentence.to_plain_string())
 
+
+def test_sentence_infer_tokenization():
+    sentence: Sentence = Sentence()
+    sentence.add_token(Token('xyz'))
+    sentence.add_token(Token('"'))
+    sentence.add_token(Token('abc'))
+    sentence.add_token(Token('"'))
+    sentence._infer_space_after()
+
+    assert ('xyz " abc "' == sentence.to_tokenized_string())
+    assert ('xyz "abc"' == sentence.to_plain_string())
+
+    sentence: Sentence = Sentence('xyz " abc "')
+    sentence._infer_space_after()
+    assert ('xyz " abc "' == sentence.to_tokenized_string())
+    assert ('xyz "abc"' == sentence.to_plain_string())
 
 def test_sentence_get_item():
     sentence: Sentence = Sentence('I love Berlin.', use_tokenizer=True)
@@ -95,11 +114,11 @@ def test_dictionary_get_items_with_unk():
 
     items = dictionary.get_items()
 
-    assert(4 == len(items))
-    assert('<unk>' == items[0])
-    assert('class_1' == items[1])
-    assert('class_2' == items[2])
-    assert('class_3' == items[3])
+    assert (4 == len(items))
+    assert ('<unk>' == items[0])
+    assert ('class_1' == items[1])
+    assert ('class_2' == items[2])
+    assert ('class_3' == items[3])
 
 
 def test_dictionary_get_items_without_unk():
@@ -111,10 +130,10 @@ def test_dictionary_get_items_without_unk():
 
     items = dictionary.get_items()
 
-    assert(3 == len(items))
-    assert('class_1' == items[0])
-    assert('class_2' == items[1])
-    assert('class_3' == items[2])
+    assert (3 == len(items))
+    assert ('class_1' == items[0])
+    assert ('class_2' == items[1])
+    assert ('class_3' == items[2])
 
 
 def test_dictionary_get_idx_for_item():
@@ -126,7 +145,7 @@ def test_dictionary_get_idx_for_item():
 
     idx = dictionary.get_idx_for_item('class_2')
 
-    assert(1 == idx)
+    assert (1 == idx)
 
 
 def test_dictionary_get_item_for_index():
@@ -138,7 +157,7 @@ def test_dictionary_get_item_for_index():
 
     item = dictionary.get_item_for_index(0)
 
-    assert('class_1' == item)
+    assert ('class_1' == item)
 
 
 def test_dictionary_save_and_load():
@@ -153,8 +172,8 @@ def test_dictionary_save_and_load():
     dictionary.save(file_path)
     loaded_dictionary = dictionary.load_from_file(file_path)
 
-    assert(len(dictionary) == len(loaded_dictionary))
-    assert(len(dictionary.get_items()) == len(loaded_dictionary.get_items()))
+    assert (len(dictionary) == len(loaded_dictionary))
+    assert (len(dictionary.get_items()) == len(loaded_dictionary.get_items()))
 
     # clean up file
     os.remove(file_path)
@@ -169,7 +188,7 @@ def test_tagged_corpus_get_all_sentences():
 
     all_sentences = corpus.get_all_sentences()
 
-    assert(3 == len(all_sentences))
+    assert (3 == len(all_sentences))
 
 
 def test_tagged_corpus_make_vocab_dictionary():
@@ -179,21 +198,21 @@ def test_tagged_corpus_make_vocab_dictionary():
 
     vocab = corpus.make_vocab_dictionary(max_tokens=2, min_freq=-1)
 
-    assert(3 == len(vocab))
-    assert('<unk>' in vocab.get_items())
-    assert('training' in vocab.get_items())
-    assert('.' in vocab.get_items())
+    assert (3 == len(vocab))
+    assert ('<unk>' in vocab.get_items())
+    assert ('training' in vocab.get_items())
+    assert ('.' in vocab.get_items())
 
     vocab = corpus.make_vocab_dictionary(max_tokens=-1, min_freq=-1)
 
-    assert(7 == len(vocab))
+    assert (7 == len(vocab))
 
     vocab = corpus.make_vocab_dictionary(max_tokens=-1, min_freq=2)
 
-    assert(3 == len(vocab))
-    assert('<unk>' in vocab.get_items())
-    assert('training' in vocab.get_items())
-    assert('.' in vocab.get_items())
+    assert (3 == len(vocab))
+    assert ('<unk>' in vocab.get_items())
+    assert ('training' in vocab.get_items())
+    assert ('.' in vocab.get_items())
 
 
 def test_label_set_confidence():
@@ -219,10 +238,10 @@ def test_tagged_corpus_make_label_dictionary():
 
     label_dict = corpus.make_label_dictionary()
 
-    assert(2 == len(label_dict))
-    assert('<unk>' not in label_dict.get_items())
-    assert('class_1' in label_dict.get_items())
-    assert('class_2' in label_dict.get_items())
+    assert (2 == len(label_dict))
+    assert ('<unk>' not in label_dict.get_items())
+    assert ('class_1' in label_dict.get_items())
+    assert ('class_2' in label_dict.get_items())
 
 
 def test_tagged_corpus_statistics():
@@ -232,17 +251,17 @@ def test_tagged_corpus_statistics():
 
     class_to_count_dict = TaggedCorpus._get_classes_to_count([train_sentence, dev_sentence, test_sentence])
 
-    assert('class_1' in class_to_count_dict)
-    assert('class_2' in class_to_count_dict)
-    assert(2 == class_to_count_dict['class_1'])
-    assert(1 == class_to_count_dict['class_2'])
+    assert ('class_1' in class_to_count_dict)
+    assert ('class_2' in class_to_count_dict)
+    assert (2 == class_to_count_dict['class_1'])
+    assert (1 == class_to_count_dict['class_2'])
 
     tokens_in_sentences = TaggedCorpus._get_tokens_per_sentence([train_sentence, dev_sentence, test_sentence])
 
-    assert(3 == len(tokens_in_sentences))
-    assert(4 == tokens_in_sentences[0])
-    assert(5 == tokens_in_sentences[1])
-    assert(4 == tokens_in_sentences[2])
+    assert (3 == len(tokens_in_sentences))
+    assert (4 == tokens_in_sentences[0])
+    assert (5 == tokens_in_sentences[1])
+    assert (4 == tokens_in_sentences[2])
 
 
 def test_tagged_corpus_downsample():
@@ -251,8 +270,8 @@ def test_tagged_corpus_downsample():
     corpus: TaggedCorpus = TaggedCorpus(
         [sentence, sentence, sentence, sentence, sentence, sentence, sentence, sentence, sentence, sentence], [], [])
 
-    assert(10 == len(corpus.train))
+    assert (10 == len(corpus.train))
 
     corpus.downsample(percentage=0.3, only_downsample_train=True)
 
-    assert(3 == len(corpus.train))
+    assert (3 == len(corpus.train))


### PR DESCRIPTION
- Added `whitespace_after` field to Token (see #54)
- Sentence tokenizer now records `whitespace_after`
- Added method to infer `whitespace_after` field for already tokenized data
- Distringuish between `to_plain_string()` and `to_tokenized_string()` of `Sentence` - the former produces original string, the latter whitespace-tokenized string