### PR TITLE
GH-83: Don't create empty tokens when using whitespace tokenization.

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -236,8 +236,9 @@ class Sentence:
             else:
                 # add each word in tokenized string as Token object to Sentence
                 for word in text.split(' '):
-                    token = Token(word)
-                    self.add_token(token)
+                    if word:
+                        token = Token(word)
+                        self.add_token(token)
 
     def _infer_space_after(self):
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -81,6 +81,7 @@ def test_sentence_infer_tokenization():
     assert ('xyz " abc "' == sentence.to_tokenized_string())
     assert ('xyz "abc"' == sentence.to_plain_string())
 
+
 def test_sentence_get_item():
     sentence: Sentence = Sentence('I love Berlin.', use_tokenizer=True)
 
@@ -89,6 +90,16 @@ def test_sentence_get_item():
 
     with pytest.raises(IndexError):
         token = sentence[4]
+
+
+def test_sentence_whitespace_tokenization():
+    sentence: Sentence = Sentence('I  love Berlin .')
+
+    assert (4 == len(sentence.tokens))
+    assert ('I' == sentence.get_token(1).text)
+    assert ('love' == sentence.get_token(2).text)
+    assert ('Berlin' == sentence.get_token(3).text)
+    assert ('.' == sentence.get_token(4).text)
 
 
 def test_sentence_to_tagged_string():


### PR DESCRIPTION
closes #83 