### PR TITLE
GH-85: Set save_model to True as default

### DIFF
--- a/flair/trainers/sequence_tagger_trainer.py
+++ b/flair/trainers/sequence_tagger_trainer.py
@@ -28,7 +28,7 @@ class SequenceTaggerTrainer:
               max_epochs: int = 100,
               anneal_factor: float = 0.5,
               patience: int = 2,
-              save_model: bool = False,
+              save_model: bool = True,
               embeddings_in_memory: bool = True,
               train_with_dev: bool = False):
 


### PR DESCRIPTION
Hi,

as discussed in #85 this PR sets the `save_model` parameter in `sequence_tagger_trainer` to `True` as new default.