### PR TITLE
readme: introduce status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ![alt text](resources/docs/flair_logo.svg)
 
+[![PyPI version](https://badge.fury.io/py/flair.svg)](https://badge.fury.io/py/flair)
+[![GitHub Issues](https://img.shields.io/github/issues/zalandoresearch/flair.svg)](https://github.com/zalandoresearch/flair/issues)
+[![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](resources/docs/CONTRIBUTING.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
+[![Travis](https://img.shields.io/travis/zalandoresearch/flair.svg)](https://travis-ci.org/zalandoresearch/flair)
+
 A very simple framework for **state-of-the-art NLP**. Developed by [Zalando Research](https://research.zalando.com/).
 
 ---


### PR DESCRIPTION
Hi,

this PR adds some nice status badges to the main readme. The following badges were introduces:

* PyPI version
* GitHub issues
* Contributions are welcome
* License information
* Travis CI status

It looks like:

![grafik](https://user-images.githubusercontent.com/20651387/44474415-dd872f80-a632-11e8-9c00-354a652dadc0.png)
