### PR TITLE
GH-8: tutorials

### DIFF
--- a/resources/docs/TUTORIAL_BASICS.md
+++ b/resources/docs/TUTORIAL_BASICS.md
@@ -33,7 +33,7 @@ You can access the tokens of a sentence via their token id or with their index:
 # using the token id
 print(sentence.get_token(4))
 # using the index itself
-print(sentence[3]
+print(sentence[3])
 ```
 
 which should print in both cases
@@ -145,30 +145,6 @@ Importantly, these sentences now contain a wealth of `Token` level annotations.
 In the case of CoNLL-U, they should contain information including a token lemma, its part-of-speech, morphological
 annotation, its dependency relation and its head token.
 You can access this information using the tag fields of the `Token`.
-
-## Reading Files for Text Classification Tasks
-
-We also provide a helper method to read files that contain data for text classification tasks. Such files should have the following format:
-```text
-__label__<label_1> <text>
-__label__<label_1> __label__<label_2> <text>
-```
-Each line contains a textual document. A document can have one or multiple labels that are defined at the beginning of the line starting with the prefix
-`__label__`.
-
-To read such data, simply use the `NLPTaskDataFetcher` which converts each line to a `Sentence` object and assigns the labels. It returns a list of `Sentence`.
-
-```python
-from flair.data_fetcher import NLPTaskDataFetcher
-
-# use your own data path
-data_folder = 'path/to/text-classification/formatted/data'
-
-# get training, test and dev data
-sentences: List[Sentence] = NLPTaskDataFetcher.read_text_classification_file(data_folder)
-```
-
-If your text classification data files have a different format, feel free to add new methods to the `NLPTaskDataFetcher`.
 
 ## Next
 

--- a/resources/docs/TUTORIAL_TRAINING_A_MODEL.md
+++ b/resources/docs/TUTORIAL_TRAINING_A_MODEL.md
@@ -143,15 +143,31 @@ check [here](/resources/docs/EXPERIMENTS.md).
 
 Here is example code for training a text classifier over the AGNews corpus, using  a combination of simple GloVe
 embeddings and contextual string embeddings. In this example, we downsample the data to 10% of the original data.
+The AGNews corpus can be downloaded [here](https://www.di.unipi.it/~gulli/AG_corpus_of_news_articles.html).
 
-The AGNews corpus can be downloaded [here](https://www.di.unipi.it/~gulli/AG_corpus_of_news_articles.html). As
-described in the [basics](/resources/docs/TUTORIAL_BASICS.md) the `NLPTaskDataFetcher` expects the data in the
-following format:
+You need to convert the data into the following format so that the `NLPTaskDataFetcher` can read it:
+
 ```bash
 __label__<label_1> <text>
 __label__<label_1> __label__<label_2> <text>
 ```
-Thus, you need to convert the data into the expected format. After you converted the data you can use the
+
+Here, each line in the file contains a textual document. A document can have one or multiple labels that are defined at the beginning of the line starting with the prefix
+`__label__`. (If your text classification data files have a different format, feel free to add new methods to the `NLPTaskDataFetcher`.)
+
+Point the `NLPTaskDataFetcher` to this file to convert each line to a `Sentence` object annotated with the labels. It returns a list of `Sentence`.
+
+```python
+from flair.data_fetcher import NLPTaskDataFetcher
+
+# use your own data path
+data_folder = 'path/to/text-classification/formatted/data'
+
+# get training, test and dev data
+sentences: List[Sentence] = NLPTaskDataFetcher.read_text_classification_file(data_folder)
+```
+
+To train a model, you need to create three files in this way: A train, dev and test file. After you converted the data you can use the
 `NLPTask.AG_NEWS` to read the data, if the data files are located in the following folder structure:
 ```
 /resources/tasks/ag_news/train.txt

--- a/resources/docs/TUTORIAL_TRAINING_A_MODEL.md
+++ b/resources/docs/TUTORIAL_TRAINING_A_MODEL.md
@@ -143,7 +143,10 @@ check [here](/resources/docs/EXPERIMENTS.md).
 
 Here is example code for training a text classifier over the AGNews corpus, using  a combination of simple GloVe
 embeddings and contextual string embeddings. In this example, we downsample the data to 10% of the original data.
+
 The AGNews corpus can be downloaded [here](https://www.di.unipi.it/~gulli/AG_corpus_of_news_articles.html).
+
+### Preparing the data
 
 You need to convert the data into the following format so that the `NLPTaskDataFetcher` can read it:
 
@@ -166,6 +169,9 @@ data_folder = 'path/to/text-classification/formatted/data'
 # get training, test and dev data
 sentences: List[Sentence] = NLPTaskDataFetcher.read_text_classification_file(data_folder)
 ```
+
+
+### Training the classifier
 
 To train a model, you need to create three files in this way: A train, dev and test file. After you converted the data you can use the
 `NLPTask.AG_NEWS` to read the data, if the data files are located in the following folder structure:


### PR DESCRIPTION
Small simplifications to tutorials:
- moved explanation on text classification data format from BASICS to TRAINING A MODEL, since the format is only used in context of training a classification model. This makes the basics section a bit lighter and the classification explanation more grouped. 
- corrected typo