### PR TITLE
GH-108: Add additional training parameters.

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -307,8 +307,6 @@ class CharLMEmbeddings(TokenEmbeddings):
     """Contextual string embeddings of words, as proposed in Akbik et al., 2018."""
 
     def __init__(self, model, detach: bool = True):
-        super().__init__()
-
         """
             Contextual string embeddings of words, as proposed in Akbik et al., 2018.
 
@@ -321,6 +319,7 @@ class CharLMEmbeddings(TokenEmbeddings):
                 if set to false, the gradient will propagate into the language model. this dramatically slows down
                 training and often leads to worse results, so not recommended.
         """
+        super().__init__()
 
         # news-english-forward
         if model.lower() == 'news-forward':

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -381,7 +381,6 @@ class CharLMEmbeddings(TokenEmbeddings):
         return self.__embedding_length
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
-
         # get text sentences
         text_sentences = [sentence.to_tokenized_string() for sentence in sentences]
 

--- a/flair/trainers/text_classification_trainer.py
+++ b/flair/trainers/text_classification_trainer.py
@@ -24,27 +24,31 @@ class TextClassifierTrainer:
         self.corpus: TaggedCorpus = corpus
         self.label_dict: Dictionary = label_dict
         self.test_mode: bool = test_mode
-        self.snapshot = None
 
     def train(self,
               base_path: str,
               learning_rate: float = 0.1,
               mini_batch_size: int = 32,
+              eval_mini_batch_size: int = 8,
               max_epochs: int = 100,
               anneal_factor: float = 0.5,
               patience: int = 2,
               save_model: bool = True,
               embeddings_in_memory: bool = True,
-              train_with_dev: bool = False):
+              train_with_dev: bool = False,
+              eval_on_train: bool = False):
         """
         Trains the model using the training data of the corpus.
         :param base_path: the directory to which any results should be written to
         :param learning_rate: the learning rate
         :param mini_batch_size: the mini batch size
+        :param eval_mini_batch_size: the mini batch size for evaluation
         :param max_epochs: the maximum number of epochs to train
         :param save_model: boolean value indicating, whether the model should be saved or not
         :param embeddings_in_memory: boolean value indicating, if embeddings should be kept in memory or not
         :param train_with_dev: boolean value indicating, if the dev data set should be used for training or not
+        :param eval_on_train: boolean value indicating, if evaluation metrics should be calculated on training data set
+        or not
         """
 
         loss_txt = init_output_file(base_path, 'loss.txt')
@@ -101,8 +105,11 @@ class TextClassifierTrainer:
                         clear_embeddings(batch)
 
                     if batch_no % modulo == 0:
-                        print("epoch {0} - iter {1}/{2} - loss {3:.8f}".format(epoch + 1, batch_no, len(batches),
-                                                                               current_loss / seen_sentences))
+                        for group in optimizer.param_groups:
+                            learning_rate = group['lr']
+
+                        print("epoch {0} - iter {1}/{2} - loss {3:.8f} - lr {4:.4f} - bad epochs {5}".format(
+                            epoch + 1, batch_no, len(batches), current_loss / seen_sentences, learning_rate, scheduler.num_bad_epochs))
                         iteration = epoch * len(batches) + batch_no
                         self._extract_weights(iteration, weights_index, weights_txt)
 
@@ -112,13 +119,15 @@ class TextClassifierTrainer:
 
                 print('-' * 100)
 
-                train_acc, train_f_score, train_loss = self._calculate_evaluation_results_for(
-                    'TRAIN', self.corpus.train, embeddings_in_memory, epoch, mini_batch_size)
+                train_f_score = train_acc = train_loss = 0
+                if eval_on_train:
+                    train_acc, train_f_score, train_loss = self._calculate_evaluation_results_for(
+                        'TRAIN', self.corpus.train, embeddings_in_memory, epoch, eval_mini_batch_size)
 
                 dev_f_score = dev_acc = dev_loss = 0
                 if not train_with_dev:
                     dev_acc, dev_f_score, dev_loss = self._calculate_evaluation_results_for(
-                        'DEV', self.corpus.dev, embeddings_in_memory, epoch, mini_batch_size)
+                        'DEV', self.corpus.dev, embeddings_in_memory, epoch, eval_mini_batch_size)
 
                 with open(loss_txt, 'a') as f:
                     f.write('{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n'.format(


### PR DESCRIPTION
closes #108 

We could not find any memory leak. However, training a text classifier on a large data set which contains large documents/sentences using contextual string embeddings is quite expensive and can lead to out of memory issues. To avoid this, you can now
(1) disable the evaluation on the training data set
(2) use a smaller batch size for evaluation