### PR TITLE
GH-137: memory optimizations

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -169,10 +169,10 @@ class Token:
         return self.sentence.get_token(self.head_id)
 
     def __str__(self) -> str:
-        return 'Token: %d %s' % (self.idx, self.text) if self.idx is not None else 'Token: %s' % (self.text)
+        return 'Token: {} {}'.format(self.idx, self.text) if self.idx is not None else 'Token: {}'.format(self.text)
 
     def __repr__(self) -> str:
-        return 'Token: %d %s' % (self.idx, self.text) if self.idx is not None else 'Token: %s' % (self.text)
+        return 'Token: {} {}'.format(self.idx, self.text) if self.idx is not None else 'Token: {}'.format(self.text)
 
     def set_embedding(self, name: str, vector: torch.autograd.Variable):
         self._embeddings[name] = vector.cpu()
@@ -480,20 +480,20 @@ class Sentence:
         return iter(self.tokens)
 
     def __repr__(self):
-        return 'Sentence: "' + ' '.join([t.text for t in self.tokens]) + '" - %d Tokens' % len(self)
+        return 'Sentence: "{}" - {} Tokens'.format(' '.join([t.text for t in self.tokens]), len(self))
 
     def __copy__(self):
         s = Sentence()
         for token in self.tokens:
             nt = Token(token.text)
             for tag_type in token.tags:
-                nt.add_tag(tag_type, token.get_tag(tag_type))
+                nt.add_tag(tag_type, token.get_tag(tag_type).value, token.get_tag(tag_type).score)
 
             s.add_token(nt)
         return s
 
     def __str__(self) -> str:
-        return 'Sentence: "' + ' '.join([t.text for t in self.tokens]) + '" - %d Tokens' % len(self)
+        return 'Sentence: "{}" - {} Tokens'.format(' '.join([t.text for t in self.tokens]), len(self))
 
     def __len__(self) -> int:
         return len(self.tokens)

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -111,7 +111,6 @@ class StackedEmbeddings(TokenEmbeddings):
         if type(sentences) is Sentence:
             sentences = [sentences]
 
-        # default case: do not use cache
         for embedding in self.embeddings:
             embedding.embed(sentences)
 
@@ -368,6 +367,9 @@ class CharLMEmbeddings(TokenEmbeddings):
             arg2 : detach
                 if set to false, the gradient will propagate into the language model. this dramatically slows down
                 training and often leads to worse results, so not recommended.
+            arg3 : use_cache
+                if set to false, will not write embeddings to file for later retrieval. this saves disk space but will
+                not allow re-use of once computed embeddings that do not fit into memory
         """
         super().__init__()
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -424,7 +424,6 @@ class CharLMEmbeddings(TokenEmbeddings):
 
         # caching variables
         self.use_cache: bool = use_cache
-        self.cache_added: int = 0
         self.cache = None
 
         dummy_sentence: Sentence = Sentence()
@@ -524,7 +523,6 @@ class CharLMEmbeddings(TokenEmbeddings):
         if self.use_cache:
             for sentence in sentences:
                 self.cache[sentence.to_tokenized_string()] = [token._embeddings[self.name].tolist() for token in sentence]
-                self.cache_added += 1
 
         return sentences
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -64,6 +64,8 @@ class TextClassifier(nn.Module):
         Saves the current model to the provided file.
         :param model_file: the model file
         """
+        self.eval()
+
         model_state = {
             'state_dict': self.state_dict(),
             'document_embeddings': self.document_embeddings,

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -64,8 +64,6 @@ class TextClassifier(nn.Module):
         Saves the current model to the provided file.
         :param model_file: the model file
         """
-        self.eval()
-
         model_state = {
             'state_dict': self.state_dict(),
             'document_embeddings': self.document_embeddings,

--- a/flair/trainers/sequence_tagger_trainer.py
+++ b/flair/trainers/sequence_tagger_trainer.py
@@ -31,6 +31,7 @@ class SequenceTaggerTrainer:
               embeddings_in_memory: bool = True,
               checkpoint: bool = False,
               save_final_model: bool = True,
+              anneal_with_restarts: bool = False,
               ):
 
         evaluation_method = 'F1'
@@ -47,8 +48,7 @@ class SequenceTaggerTrainer:
         optimizer = torch.optim.SGD(self.model.parameters(), lr=learning_rate)
 
         anneal_mode = 'min' if train_with_dev else 'max'
-        scheduler: ReduceLROnPlateau = ReduceLROnPlateau(optimizer, factor=anneal_factor, patience=patience,
-                                                         mode=anneal_mode)
+        scheduler = ReduceLROnPlateau(optimizer, factor=anneal_factor, patience=patience, mode=anneal_mode, verbose=True)
 
         train_data = self.corpus.train
 
@@ -59,8 +59,25 @@ class SequenceTaggerTrainer:
         # At any point you can hit Ctrl + C to break out of training early.
         try:
 
-            for epoch in range(max_epochs):
-                log.info('-' * 100)
+            previous_learning_rate = learning_rate
+            for epoch in range(0, max_epochs):
+
+                bad_epochs = scheduler.num_bad_epochs
+                for group in optimizer.param_groups:
+                    learning_rate = group['lr']
+
+                if learning_rate != previous_learning_rate and anneal_with_restarts:
+                    print('resetting to best model')
+                    self.model.load_from_file(base_path + "/best-model.pt")
+                    # restart optimizer and scheduler
+                    optimizer = torch.optim.SGD(self.model.parameters(), lr=learning_rate)
+                    scheduler = ReduceLROnPlateau(optimizer, factor=anneal_factor, patience=patience, mode=anneal_mode)
+
+                previous_learning_rate = learning_rate
+
+                if learning_rate < 0.001:
+                    print('learning rate too small - quitting training!')
+                    break
 
                 if not self.test_mode: random.shuffle(train_data)
 
@@ -71,9 +88,6 @@ class SequenceTaggerTrainer:
                 current_loss: float = 0
                 seen_sentences = 0
                 modulo = max(1, int(len(batches) / 10))
-
-                for group in optimizer.param_groups:
-                    learning_rate = group['lr']
 
                 for batch_no, batch in enumerate(batches):
                     batch: List[Sentence] = batch
@@ -113,27 +127,30 @@ class SequenceTaggerTrainer:
                 dev_score = dev_metric = None
                 if not train_with_dev:
                     dev_score, dev_metric = self.evaluate(self.corpus.dev, base_path,
-                                                                  evaluation_method=evaluation_method,
-                                                                  embeddings_in_memory=embeddings_in_memory)
+                                                          evaluation_method=evaluation_method,
+                                                          embeddings_in_memory=embeddings_in_memory)
 
                 test_score, test_metric = self.evaluate(self.corpus.test, base_path,
-                                                                 evaluation_method=evaluation_method,
-                                                                 embeddings_in_memory=embeddings_in_memory)
+                                                        evaluation_method=evaluation_method,
+                                                        embeddings_in_memory=embeddings_in_memory)
 
                 # anneal against train loss if training with dev, otherwise anneal against dev score
                 scheduler.step(current_loss) if train_with_dev else scheduler.step(dev_score)
 
-                log.info("EPOCH {0}: lr {1:.4f} - bad epochs {2}".format(epoch + 1, learning_rate, scheduler.num_bad_epochs))
+                log.info("EPOCH {0}: lr {1:.4f} - bad epochs {2}".format(epoch + 1, learning_rate, bad_epochs))
                 if not train_with_dev:
                     log.info("{0:<4}: f-score {1:.4f} - acc {2:.4f} - tp {3} - fp {4} - fn {5} - tn {6}".format(
-                        'DEV', dev_metric.f_score(), dev_metric.accuracy(), dev_metric._tp, dev_metric._fp, dev_metric._fn, dev_metric._tn))
+                        'DEV', dev_metric.f_score(), dev_metric.accuracy(), dev_metric._tp, dev_metric._fp,
+                        dev_metric._fn, dev_metric._tn))
                 log.info("{0:<4}: f-score {1:.4f} - acc {2:.4f} - tp {3} - fp {4} - fn {5} - tn {6}".format(
-                    'TEST', test_metric.f_score(), test_metric.accuracy(), test_metric._tp, test_metric._fp, test_metric._fn, test_metric._tn))
+                    'TEST', test_metric.f_score(), test_metric.accuracy(), test_metric._tp, test_metric._fp,
+                    test_metric._fn, test_metric._tn))
 
                 with open(loss_txt, 'a') as f:
                     dev_metric_str = dev_metric.to_tsv() if dev_metric is not None else Metric.to_empty_tsv()
                     f.write('{}\t{:%H:%M:%S}\t{}\t{}\t{}\t{}\t{}\t{}\n'.format(
-                        epoch, datetime.datetime.now(), '_', Metric.to_empty_tsv(), '_', dev_metric_str, '_', test_metric.to_tsv()))
+                        epoch, datetime.datetime.now(), '_', Metric.to_empty_tsv(), '_', dev_metric_str, '_',
+                        test_metric.to_tsv()))
 
                 # if we use dev data, remember best model based on dev evaluation score
                 if not train_with_dev and dev_score == scheduler.best:

--- a/flair/trainers/text_classification_trainer.py
+++ b/flair/trainers/text_classification_trainer.py
@@ -142,8 +142,6 @@ class TextClassifierTrainer:
                     f.write('{}\t{:%H:%M:%S}\t{}\t{}\t{}\t{}\t{}\t{}\n'.format(
                         epoch, datetime.datetime.now(), train_loss, train_metric_str, dev_loss, dev_metric_str, '_', Metric.to_empty_tsv()))
 
-                self.model.train()
-
                 # anneal against train loss if training with dev, otherwise anneal against dev score
                 scheduler.step(current_loss) if train_with_dev else scheduler.step(dev_metric.f_score())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib==3.0.0
 mpld3==0.3
 jinja2==2.10
 sklearn==0.0
+sqlitedict

--- a/tests/test_language_model_trainer.py
+++ b/tests/test_language_model_trainer.py
@@ -30,6 +30,6 @@ def test_training():
     print(sentence[1].embedding.size())
 
     # clean up results directory
-    shutil.rmtree('./results')
+    shutil.rmtree('./results', ignore_errors=True)
 
 


### PR DESCRIPTION
This PR adds a method for writing embeddings computed with `CharLMEmbeddings` to disk for fast reuse in and across experiments, therefore: 
- If a model is trained using CharLMEmbeddings is run over the same dataset several times (i.e. for experimenting with parameters), embeddings are only computed on the first run and then reused, thus potentially saving a lot of time.
- If embeddings are too large to fit into memory, you can set `embeddings_in_memory=False` as parameter in the `.train()` function and still reuse computed embeddings, thus again potentially saving a lot of time.