### PR TITLE
GH-146: Retain Token embeddings in memory by default 

### DIFF
--- a/flair/data_fetcher.py
+++ b/flair/data_fetcher.py
@@ -350,8 +350,9 @@ class NLPTaskDataFetcher:
 
                 if text and labels:
                     sentence = Sentence(text, labels=labels, use_tokenizer=True)
-                    if max_tokens_per_doc == -1 or len(sentence.tokens) <= max_tokens_per_doc:
-                        sentences.append(sentence)
+                    if(len(sentence) > max_tokens_per_doc):
+                        sentence.tokens = sentence.tokens[:max_tokens_per_doc]
+                    sentences.append(sentence)
 
         return sentences
 

--- a/flair/trainers/text_classification_trainer.py
+++ b/flair/trainers/text_classification_trainer.py
@@ -107,8 +107,7 @@ class TextClassifierTrainer:
                     seen_sentences += len(batch)
                     current_loss += loss.item()
 
-                    if not embeddings_in_memory:
-                        clear_embeddings(batch)
+                    clear_embeddings(batch, also_clear_word_embeddings=not embeddings_in_memory)
 
                     if batch_no % modulo == 0:
                         log.info("epoch {0} - iter {1}/{2} - loss {3:.8f}".format(
@@ -221,8 +220,7 @@ class TextClassifierTrainer:
                 labels = self.model.obtain_labels(scores)
                 loss = self.model.calculate_loss(scores, batch)
 
-                if not embeddings_in_memory:
-                    clear_embeddings(batch)
+                clear_embeddings(batch, also_clear_word_embeddings=not embeddings_in_memory)
 
                 eval_loss += loss
 

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -121,13 +121,13 @@ class WeightExtractor(object):
         self.weights_dict[key] = indices
 
 
-def clear_embeddings(sentences: List[Sentence]):
+def clear_embeddings(sentences: List[Sentence], also_clear_word_embeddings=False):
     """
     Clears the embeddings from all given sentences.
     :param sentences: list of sentences
     """
     for sentence in sentences:
-        sentence.clear_embeddings(also_clear_word_embeddings=True)
+        sentence.clear_embeddings(also_clear_word_embeddings=also_clear_word_embeddings)
 
 
 def init_output_file(base_path: str, file_name: str):


### PR DESCRIPTION
- Retain Token embeddings in memory by default in `TextClassificationTrainer`
- This allows faster training on larger datasets
- Modify length restriction in `NLPTaskDataFetcher.read_text_classification_file()` to crop documents to length instead of filtering them.