### PR TITLE
GH-226: add safeguard for non-tokenized input

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -321,6 +321,10 @@ class Sentence:
             # otherwise assumes whitespace tokenized text
             else:
                 # add each word in tokenized string as Token object to Sentence
+
+                if '  ' in text:
+                    raise ValueError('Your input text is not whitespace-tokenized. Please set the `use_tokenizer` argument to True.')
+                
                 offset = 0
                 for word in text.split(' '):
                     if word:


### PR DESCRIPTION
raise a ValueError if the input text is not whitespace-tokenized and no tokenizer is used.

See #226.

There is [one failing test](https://github.com/zalandoresearch/flair/blob/master/tests/test_data.py#L96) but I think it should fail. You would as well run into an infinite loop further done. Should the test be adapted to fail?