### PR TITLE
GH-276: annealing options

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -6,7 +6,6 @@ from typing import List, Union, Dict
 import gensim
 import numpy as np
 import torch
-from torch.utils.data import TensorDataset, DataLoader, SequentialSampler
 from deprecated import deprecated
 
 from pytorch_pretrained_bert.tokenization import BertTokenizer

--- a/flair/hyperparameter/param_selection.py
+++ b/flair/hyperparameter/param_selection.py
@@ -96,7 +96,7 @@ class ParamSelector(object):
 
             # take the average over the last three scores of training
             if self.optimization_value == OptimizationValue.DEV_LOSS:
-                curr_scores = result['loss_history'][-3:]
+                curr_scores = result['dev_loss_history'][-3:]
             else:
                 curr_scores = list(map(lambda s: 1 - s, result['score_history'][-3:]))
             score = sum(curr_scores) / float(len(curr_scores))

--- a/flair/hyperparameter/param_selection.py
+++ b/flair/hyperparameter/param_selection.py
@@ -98,7 +98,7 @@ class ParamSelector(object):
             if self.optimization_value == OptimizationValue.DEV_LOSS:
                 curr_scores = result['dev_loss_history'][-3:]
             else:
-                curr_scores = list(map(lambda s: 1 - s, result['score_history'][-3:]))
+                curr_scores = list(map(lambda s: 1 - s, result['dev_score_history'][-3:]))
             score = sum(curr_scores) / float(len(curr_scores))
             var = np.var(curr_scores)
             scores.append(score)

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -99,7 +99,7 @@ class ModelTrainer:
         if train_with_dev:
             train_data.extend(self.corpus.dev)
 
-        score_history = []
+        dev_score_history = []
         dev_loss_history = []
         train_loss_history = []
 
@@ -179,9 +179,10 @@ class ModelTrainer:
                     dev_metric, dev_loss = self._calculate_evaluation_results_for(
                         'DEV', self.corpus.dev, evaluation_metric, embeddings_in_memory, mini_batch_size)
 
-                test_metric, test_loss = self._calculate_evaluation_results_for(
-                    'TEST', self.corpus.test, evaluation_metric, embeddings_in_memory, mini_batch_size,
-                    base_path / 'test.tsv')
+                if not param_selection_mode:
+                    test_metric, test_loss = self._calculate_evaluation_results_for(
+                        'TEST', self.corpus.test, evaluation_metric, embeddings_in_memory, mini_batch_size,
+                        base_path / 'test.tsv')
 
                 if not param_selection_mode:
                     with open(loss_txt, 'a') as f:
@@ -205,7 +206,7 @@ class ModelTrainer:
                         dev_score = dev_metric.micro_avg_f_score()
 
                     # append dev score to score history
-                    score_history.append(dev_score)
+                    dev_score_history.append(dev_score)
                     dev_loss_history.append(dev_loss.item())
 
                 # anneal against train loss if training with dev, otherwise anneal against dev score
@@ -242,7 +243,7 @@ class ModelTrainer:
             final_score = self.final_test(base_path, embeddings_in_memory, evaluation_metric, mini_batch_size)
 
         return {'test_score': final_score,
-                'score_history': score_history,
+                'dev_score_history': dev_score_history,
                 'train_loss_history': train_loss_history,
                 'dev_loss_history': dev_loss_history}
 


### PR DESCRIPTION
closes #276 

- add option to `ModelTrainer` to anneal either against test loss or dev score
- during parameter selection, never test on test data
- renamed some variables in `ModelTrainer` for clarity