### PR TITLE
Bump version of pytorch-pretrained-bert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ sklearn
 sqlitedict==1.6.0
 deprecated==1.2.4
 hyperopt==0.1.1
-pytorch-pretrained-bert==0.3.0
+pytorch-pretrained-bert==0.4.0


### PR DESCRIPTION
Hi,

today version 0.4.0 of the `pytorch-pretrained-bert` was released (see [Changelog](pytorch-pretrained-bert)) so it would be great to have the latest version of that module in the upcoming `flair` release.