### PR TITLE
Update the pytest command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,19 +143,19 @@ You need [Pipenv](https://pipenv.readthedocs.io/) for this:
 
 ```bash
 pipenv install --dev && pipenv shell
-pytest
+pytest tests/
 ```
 
 To run integration tests execute:
 ```bash
-pytest --runintegration
+pytest --runintegration tests/
 ```
 The integration tests will train small models.
 Afterwards, the trained model will be loaded for prediction.
 
 To also run slow tests, such as loading and using the embeddings provided by flair, you should execute:
 ```bash
-pytest --runslow
+pytest --runslow tests/
 ```
 
 ## [License](/LICENSE)


### PR DESCRIPTION
Otherwise pytest could run test in the `lib` folder on all dependencies of the package. That happened to me.
Update: I just realized that I only ran into the issue, because it did do the installation with pip in a toplevel venv. This was neccessary, because the pipenv installation did not work. So this PR might not useful.