### PR TITLE
GH-340: use Path object for specifying corpus folder

### DIFF
--- a/resources/docs/TUTORIAL_9_TRAINING_LM_EMBEDDINGS.md
+++ b/resources/docs/TUTORIAL_9_TRAINING_LM_EMBEDDINGS.md
@@ -40,6 +40,8 @@ corpus/valid.txt
 Once you have this folder structure, simply point the `LanguageModelTrainer` class to it to start learning a model.
 
 ```python
+from pathlib import Path
+
 from flair.data import Dictionary
 from flair.models import LanguageModel
 from flair.trainers.language_model_trainer import LanguageModelTrainer, TextCorpus
@@ -51,7 +53,7 @@ is_forward_lm = True
 dictionary: Dictionary = Dictionary.load('chars')
 
 # get your corpus, process forward and at the character level
-corpus = TextCorpus('/path/to/your/corpus',
+corpus = TextCorpus(Path('/path/to/your/corpus'),
                     dictionary,
                     is_forward_lm,
                     character_level=True)


### PR DESCRIPTION
Hi,

this PR corrects the tutorial for training an own language model. The corpus folder must be a `Path` object (which is passed to the `TextCorpus` instance).