### PR TITLE
GH-329: Basque language support

### DIFF
--- a/flair/data_fetcher.py
+++ b/flair/data_fetcher.py
@@ -74,6 +74,9 @@ class NLPTask(Enum):
     UD_CHINESE = 'ud_chinese'
     UD_KOREAN = 'ud_korean'
 
+    # Language isolates
+    UD_BASQUE = 'ud_basque'
+
     # other datasets
     ONTONER = 'ontoner'
     FASHION = 'fashion'
@@ -754,3 +757,8 @@ class NLPTaskDataFetcher:
             cached_path(f'{ud_path}UD_Korean-Kaist/master/ko_kaist-ud-dev.conllu', Path('datasets') / task.value)
             cached_path(f'{ud_path}UD_Korean-Kaist/master/ko_kaist-ud-test.conllu', Path('datasets') / task.value)
             cached_path(f'{ud_path}UD_Korean-Kaist/master/ko_kaist-ud-train.conllu', Path('datasets') / task.value)
+
+        if task == NLPTask.UD_BASQUE:
+            cached_path(f'{ud_path}UD_Basque-BDT/master/eu_bdt-ud-dev.conllu', Path('datasets') / task.value)
+            cached_path(f'{ud_path}UD_Basque-BDT/master/eu_bdt-ud-test.conllu', Path('datasets') / task.value)
+            cached_path(f'{ud_path}UD_Basque-BDT/master/eu_bdt-ud-train.conllu', Path('datasets') / task.value)

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -643,11 +643,6 @@ class FlairEmbeddings(TokenEmbeddings):
             append_padded_sentence = sentences_padded.append
 
             start_marker = '\n'
-            if 'en->de' in self.name or 'en-de' in self.name:
-                start_marker = '.<e>\n<s>'
-
-            if 'de->en' in self.name or 'de-en' in self.name:
-                start_marker = '>s<\n>e<'
 
             end_marker = ' '
             extra_offset = len(start_marker)

--- a/resources/docs/TUTORIAL_3_WORD_EMBEDDING.md
+++ b/resources/docs/TUTORIAL_3_WORD_EMBEDDING.md
@@ -95,6 +95,7 @@ The following embeddings are currently supported:
 | 'zh' | Chinese | Chinese FastText embeddings |
 | 'hi' | Hindi | Hindi FastText embeddings |
 | 'id' | Indonesian | Indonesian FastText embeddings |
+| 'eu' | Basque | Basque FastText embeddings |
 
 So, if you want to load German FastText embeddings, instantiate as follows:
 

--- a/resources/docs/TUTORIAL_4_ELMO_BERT_FLAIR_EMBEDDING.md
+++ b/resources/docs/TUTORIAL_4_ELMO_BERT_FLAIR_EMBEDDING.md
@@ -70,6 +70,8 @@ Currently, the following contextual string embeddings are provided (more coming)
 | 'czech-backward'    | Czech | Added by [@stefan-it](https://github.com/stefan-it/flair-lms): Backward LM embeddings over various sources (Europarl, Wikipedia or OpenSubtitles2018) |
 | 'portuguese-forward'    | Portuguese | Added by [@ericlief](https://github.com/ericlief/language_models): Forward LM embeddings |
 | 'portuguese-backward'    | Portuguese | Added by [@ericlief](https://github.com/ericlief/language_models): Backward LM embeddings |
+| 'basque-forward'    | Basque | Added by [@stefan-it](https://github.com/stefan-it/flair-lms): Forward LM embeddings |
+| 'basque-backward'    | Basque | Added by [@stefan-it](https://github.com/stefan-it/flair-lms): Backward LM embeddings |
 
 So, if you want to load embeddings from the English news backward LM model, instantiate the method as follows:
 

--- a/resources/docs/TUTORIAL_6_CORPUS.md
+++ b/resources/docs/TUTORIAL_6_CORPUS.md
@@ -132,7 +132,7 @@ The following datasets are supported:
 | [WIKINER_PORTUGUESE](https://github.com/dice-group/FOX/tree/master/input/Wikiner) | [UD_SWEDISH](https://github.com/UniversalDependencies/UD_Swedish-Talbanken) | [UD_JAPANESE](https://github.com/UniversalDependencies/UD_Japanese-GSD) |
 | [WIKINER_POLISH](https://github.com/dice-group/FOX/tree/master/input/Wikiner) | [UD_DANISH](https://github.com/UniversalDependencies/UD_Danish-DDT) | [UD_CHINESE](https://github.com/UniversalDependencies/UD_Chinese-GSD) |
 | [WIKINER_RUSSIAN](https://github.com/dice-group/FOX/tree/master/input/Wikiner) | [UD_NORWEGIAN](https://github.com/UniversalDependencies/UD_Norwegian-Bokmaal) | [UD_KOREAN](https://github.com/UniversalDependencies/UD_Korean-Kaist) |
-| [UD_ENGLISH](https://github.com/UniversalDependencies/UD_English-EWT) | [UD_FINNISH](https://github.com/UniversalDependencies/UD_Finnish-TDT) |
+| [UD_ENGLISH](https://github.com/UniversalDependencies/UD_English-EWT) | [UD_FINNISH](https://github.com/UniversalDependencies/UD_Finnish-TDT) |  [UD_BASQUE](https://github.com/UniversalDependencies/UD_Basque-BDT) |
 | [UD_GERMAN](https://github.com/UniversalDependencies/UD_German-GSD) | [UD_SLOVENIAN](https://github.com/UniversalDependencies/UD_Slovenian-SSJ) |
 
 


### PR DESCRIPTION
This PR adds support for the **Basque language** to Flair. Specifically: 

- @stefan-it trained Flair embeddings for Basque which we now include, load with: 
```python
forward_lm_embeddings = FlairEmbeddings('basque-forward')
backward_lm_embeddings = FlairEmbeddings('basque-backward')
```
- add a download routine for Basque Universal Dependencies, load with 
```python
corpus = NLPTaskDataFetcher.load_corpus(NLPTask.UD_BASQUE)
```
- add Basque FastText embeddings, load with: 
```python
wikipedia_embeddings = WordEmbeddings('eu-wiki')
crawl_embeddings = WordEmbeddings('eu-crawl')
```