### PR TITLE
GH-367: sentence embeddings

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -588,7 +588,12 @@ class Sentence:
         return s
 
     def __str__(self) -> str:
-        return 'Sentence: "{}" - {} Tokens'.format(' '.join([t.text for t in self.tokens]), len(self))
+
+        if len(self.labels) == 0:
+            return f'Sentence: "{self.to_tokenized_string()}" - {len(self)} Tokens'
+        else:
+            return f'Sentence: "{self.to_tokenized_string()}" - {len(self)} Tokens - Labels: {self.labels} '
+
 
     def __len__(self) -> int:
         return len(self.tokens)
@@ -748,16 +753,20 @@ class TaggedCorpus(Corpus):
                 last_counter = int(counter)
         return downsampled
 
-    def obtain_statistics(self, tag_type: str = None) -> dict:
+    def obtain_statistics(self, tag_type: str = None, pretty_print: bool = True) -> dict:
         """
         Print statistics about the class distribution (only labels of sentences are taken into account) and sentence
         sizes.
         """
-        return {
+        json_string = {
             "TRAIN": self._obtain_statistics_for(self.train, "TRAIN", tag_type),
             "TEST": self._obtain_statistics_for(self.test, "TEST", tag_type),
             "DEV": self._obtain_statistics_for(self.dev, "DEV", tag_type),
         }
+        if pretty_print:
+            import json
+            json_string = json.dumps(json_string, indent=4)
+        return json_string
 
     @staticmethod
     def _obtain_statistics_for(sentences, name, tag_type) -> dict:

--- a/flair/data.py
+++ b/flair/data.py
@@ -589,11 +589,10 @@ class Sentence:
 
     def __str__(self) -> str:
 
-        if len(self.labels) == 0:
-            return f'Sentence: "{self.to_tokenized_string()}" - {len(self)} Tokens'
-        else:
+        if self.labels:
             return f'Sentence: "{self.to_tokenized_string()}" - {len(self)} Tokens - Labels: {self.labels} '
-
+        else:
+            return f'Sentence: "{self.to_tokenized_string()}" - {len(self)} Tokens'
 
     def __len__(self) -> int:
         return len(self.tokens)

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -56,7 +56,7 @@ class TextClassifier(flair.nn.Model):
     def forward(self, sentences) -> List[List[float]]:
         self.document_embeddings.embed(sentences)
 
-        text_embedding_list = [sentence.get_embedding() for sentence in sentences]
+        text_embedding_list = [sentence.get_embedding().unsqueeze(0) for sentence in sentences]
         text_embedding_tensor = torch.cat(text_embedding_list, 0)
 
         if torch.cuda.is_available():

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -96,7 +96,7 @@ def test_stacked_embeddings():
     embeddings.embed(sentence)
 
     for token in sentence.tokens:
-        assert(len(token.get_embedding()) != 0)
+        assert(len(token.get_embedding()) == 1124)
 
         token.clear_embeddings()
 
@@ -112,8 +112,8 @@ def test_document_lstm_embeddings():
 
     embeddings.embed(sentence)
 
-    assert (len(sentence.get_embedding()) != 0)
-    assert (sentence.get_embedding().shape[1] == embeddings.embedding_length)
+    assert (len(sentence.get_embedding()) == 128)
+    assert (len(sentence.get_embedding()) == embeddings.embedding_length)
 
     sentence.clear_embeddings()
 
@@ -129,44 +129,8 @@ def test_document_bidirectional_lstm_embeddings():
 
     embeddings.embed(sentence)
 
-    assert (len(sentence.get_embedding()) != 0)
-    assert (sentence.get_embedding().shape[1] == embeddings.embedding_length)
-
-    sentence.clear_embeddings()
-
-    assert (len(sentence.get_embedding()) == 0)
-
-
-@pytest.mark.integration
-def test_document_bidirectional_lstm_embeddings_using_first_representation():
-    sentence, glove, charlm = init_document_embeddings()
-
-    embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove, charlm], hidden_size=128,
-                                                                bidirectional=True)
-
-    embeddings.embed(sentence)
-
-    assert (len(sentence.get_embedding()) != 0)
-    assert (sentence.get_embedding().shape[1] == embeddings.embedding_length)
-
-    sentence.clear_embeddings()
-
-    assert (len(sentence.get_embedding()) == 0)
-
-
-@pytest.mark.slow
-def test_document_mean_embeddings():
-    text = 'I love Berlin. Berlin is a great place to live.'
-    sentence: Sentence = Sentence(text)
-
-    glove: TokenEmbeddings = WordEmbeddings('en-glove')
-    charlm: TokenEmbeddings = CharLMEmbeddings('mix-backward')
-
-    embeddings: DocumentMeanEmbeddings = DocumentMeanEmbeddings([glove, charlm])
-
-    embeddings.embed(sentence)
-
-    assert (len(sentence.get_embedding()) != 0)
+    assert (len(sentence.get_embedding()) == 512)
+    assert (len(sentence.get_embedding()) == embeddings.embedding_length)
 
     sentence.clear_embeddings()
 
@@ -182,7 +146,7 @@ def test_document_pool_embeddings():
 
         embeddings.embed(sentence)
 
-        assert (len(sentence.get_embedding()) != 0)
+        assert (len(sentence.get_embedding()) == 1124)
 
         sentence.clear_embeddings()
 


### PR DESCRIPTION
closes #367 

- `Sentence` embeddings are now vectors, same as `Token`. 
- Unit tests test for embedding length
- Make printing prettier for `Sentence` and `TaggedCorpus`