### PR TITLE
GH-325: Fix BERT embeddings when running using CUDA

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -895,6 +895,8 @@ class BertEmbeddings(TokenEmbeddings):
             all_input_masks = torch.tensor([f.input_mask for f in features], dtype=torch.long)
 
         # put encoded batch through BERT model to get all hidden states of all encoder layers
+        if torch.cuda.is_available():
+            self.model.cuda()
         self.model.eval()
         all_encoder_layers, _ = self.model(all_input_ids, token_type_ids=None, attention_mask=all_input_masks)
 


### PR DESCRIPTION
BertEmbeddings fails when running on cuda backend on mixing GPU/CPU tensors.
The fix is simple - copy the model onto the GPU.

Should fix issue #325 

Thanks