### PR TITLE
GH-270: Use new cuda semantics

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -1,3 +1,5 @@
+import torch
+
 from . import data
 from . import models
 from . import visual
@@ -36,3 +38,10 @@ logging.config.dictConfig({
 })
 
 logger = logging.getLogger('flair')
+
+
+device = None
+if torch.cuda.is_available():
+    device = torch.device('cuda')
+else:
+    device = torch.device('cpu')

--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -42,6 +42,6 @@ logger = logging.getLogger('flair')
 
 device = None
 if torch.cuda.is_available():
-    device = torch.device('cuda')
+    device = torch.device('cuda:0')
 else:
     device = torch.device('cpu')

--- a/flair/data.py
+++ b/flair/data.py
@@ -188,14 +188,13 @@ class Token:
     def clear_embeddings(self):
         self._embeddings: Dict = {}
 
-    def get_embedding(self) -> torch.FloatTensor:
-
+    def get_embedding(self) -> torch.tensor:
         embeddings = [self._embeddings[embed] for embed in sorted(self._embeddings.keys())]
 
         if embeddings:
             return torch.cat(embeddings, dim=0)
 
-        return torch.FloatTensor()
+        return torch.Tensor()
 
     @property
     def start_position(self) -> int:
@@ -442,7 +441,7 @@ class Sentence:
     def set_embedding(self, name: str, vector):
         self._embeddings[name] = vector.cpu()
 
-    def get_embedding(self) -> torch.autograd.Variable:
+    def get_embedding(self) -> torch.tensor:
         embeddings = []
         for embed in sorted(self._embeddings.keys()):
             embedding = self._embeddings[embed]
@@ -451,7 +450,7 @@ class Sentence:
         if embeddings:
             return torch.cat(embeddings, dim=0)
 
-        return torch.FloatTensor()
+        return torch.Tensor()
 
     def clear_embeddings(self, also_clear_word_embeddings: bool = True):
         self._embeddings: Dict = {}

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -384,7 +384,8 @@ class CharacterEmbeddings(TokenEmbeddings):
                 tokens_mask[i, :chars2_length[i]] = c
 
             # chars for rnn processing
-            chars = torch.LongTensor(tokens_mask, device=flair.device)
+            chars = torch.LongTensor(tokens_mask)
+            chars = chars.to(flair.device)
 
             character_embeddings = self.char_embedding(chars).transpose(0, 1)
 
@@ -394,7 +395,8 @@ class CharacterEmbeddings(TokenEmbeddings):
 
             outputs, output_lengths = torch.nn.utils.rnn.pad_packed_sequence(lstm_out)
             outputs = outputs.transpose(0, 1)
-            chars_embeds_temp = torch.FloatTensor(torch.zeros((outputs.size(0), outputs.size(2))), device=flair.device)
+            chars_embeds_temp = torch.FloatTensor(torch.zeros((outputs.size(0), outputs.size(2))))
+            chars_embeds_temp = chars_embeds_temp.to(flair.device)
             for i, index in enumerate(output_lengths):
                 chars_embeds_temp[i] = outputs[i, index - 1]
             character_embeddings = chars_embeds_temp.clone()
@@ -901,8 +903,10 @@ class BertEmbeddings(TokenEmbeddings):
 
         # prepare id maps for BERT model
         features = self._convert_sentences_to_features(sentences, longest_sentence_in_batch)
-        all_input_ids = torch.LongTensor([f.input_ids for f in features], device=flair.device)
-        all_input_masks = torch.LongTensor([f.input_mask for f in features], device=flair.device)
+        all_input_ids = torch.LongTensor([f.input_ids for f in features])
+        all_input_ids = all_input_ids.to(flair.device)
+        all_input_masks = torch.LongTensor([f.input_mask for f in features])
+        all_input_masks = all_input_masks.to(flair.device)
 
         # put encoded batch through BERT model to get all hidden states of all encoder layers
         if torch.cuda.is_available():

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -383,10 +383,8 @@ class CharacterEmbeddings(TokenEmbeddings):
             for i, c in enumerate(tokens_sorted_by_length):
                 tokens_mask[i, :chars2_length[i]] = c
 
-            tokens_mask = torch.LongTensor(tokens_mask, device=flair.device)
-
             # chars for rnn processing
-            chars = tokens_mask
+            chars = torch.LongTensor(tokens_mask, device=flair.device)
 
             character_embeddings = self.char_embedding(chars).transpose(0, 1)
 
@@ -649,7 +647,7 @@ class FlairEmbeddings(TokenEmbeddings):
                     break
                 else:
                     for token, embedding in zip(sentence, embeddings):
-                        token.set_embedding(self.name, torch.FloatTensor(embedding, device=flair.device))
+                        token.set_embedding(self.name, torch.FloatTensor(embedding))
 
             if all_embeddings_retrieved_from_cache:
                 return sentences

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -12,6 +12,7 @@ from deprecated import deprecated
 from pytorch_pretrained_bert.tokenization import BertTokenizer
 from pytorch_pretrained_bert.modeling import BertModel, PRETRAINED_MODEL_ARCHIVE_MAP
 
+import flair
 from .nn import LockedDropout, WordDropout
 from .data import Dictionary, Token, Sentence
 from .file_utils import cached_path
@@ -281,7 +282,8 @@ class ELMoEmbeddings(TokenEmbeddings):
             weight_file = 'https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pt/elmo_pt_weights.hdf5'
 
         # put on Cuda if available
-        cuda_device = 0 if torch.cuda.is_available() else -1
+        from flair import device
+        cuda_device = 0 if str(device) == 'cuda' else -1
         self.ee = allennlp.commands.elmo.ElmoEmbedder(options_file=options_file,
                                                       weight_file=weight_file,
                                                       cuda_device=cuda_device)
@@ -380,12 +382,10 @@ class CharacterEmbeddings(TokenEmbeddings):
             for i, c in enumerate(tokens_sorted_by_length):
                 tokens_mask[i, :chars2_length[i]] = c
 
-            tokens_mask = torch.LongTensor(tokens_mask)
+            tokens_mask = torch.LongTensor(tokens_mask, device=flair.device)
 
             # chars for rnn processing
             chars = tokens_mask
-            if torch.cuda.is_available():
-                chars = chars.cuda()
 
             character_embeddings = self.char_embedding(chars).transpose(0, 1)
 
@@ -395,9 +395,7 @@ class CharacterEmbeddings(TokenEmbeddings):
 
             outputs, output_lengths = torch.nn.utils.rnn.pad_packed_sequence(lstm_out)
             outputs = outputs.transpose(0, 1)
-            chars_embeds_temp = torch.FloatTensor(torch.zeros((outputs.size(0), outputs.size(2))))
-            if torch.cuda.is_available():
-                chars_embeds_temp = chars_embeds_temp.cuda()
+            chars_embeds_temp = torch.FloatTensor(torch.zeros((outputs.size(0), outputs.size(2))), device=flair.device)
             for i, index in enumerate(output_lengths):
                 chars_embeds_temp[i] = outputs[i, index - 1]
             character_embeddings = chars_embeds_temp.clone()
@@ -904,12 +902,8 @@ class BertEmbeddings(TokenEmbeddings):
 
         # prepare id maps for BERT model
         features = self._convert_sentences_to_features(sentences, longest_sentence_in_batch)
-        if torch.cuda.is_available():
-            all_input_ids = torch.tensor([f.input_ids for f in features], dtype=torch.long).cuda()
-            all_input_masks = torch.tensor([f.input_mask for f in features], dtype=torch.long).cuda()
-        else:
-            all_input_ids = torch.tensor([f.input_ids for f in features], dtype=torch.long)
-            all_input_masks = torch.tensor([f.input_mask for f in features], dtype=torch.long)
+        all_input_ids = torch.tensor([f.input_ids for f in features], dtype=torch.long, device=flair.device)
+        all_input_masks = torch.tensor([f.input_mask for f in features], dtype=torch.long, device=flair.device)
 
         # put encoded batch through BERT model to get all hidden states of all encoder layers
         if torch.cuda.is_available():
@@ -1242,8 +1236,7 @@ class DocumentMeanEmbeddings(DocumentEmbeddings):
 
         self.__embedding_length: int = self.embeddings.embedding_length
 
-        if torch.cuda.is_available():
-            self.cuda()
+        self.to(flair.device)
 
     @property
     def embedding_length(self) -> int:
@@ -1272,9 +1265,7 @@ class DocumentMeanEmbeddings(DocumentEmbeddings):
                     token: Token = token
                     word_embeddings.append(token.get_embedding().unsqueeze(0))
 
-                word_embeddings = torch.cat(word_embeddings, dim=0)
-                if torch.cuda.is_available():
-                    word_embeddings = word_embeddings.cuda()
+                word_embeddings = torch.cat(word_embeddings, dim=0, device=flair.device)
 
                 mean_embedding = torch.mean(word_embeddings, 0)
 
@@ -1297,8 +1288,7 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
 
         self.__embedding_length: int = self.embeddings.embedding_length
 
-        if torch.cuda.is_available():
-            self.cuda()
+        self.to(flair.device)
 
         self.mode = mode
         if self.mode == 'mean':
@@ -1338,9 +1328,7 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
                     token: Token = token
                     word_embeddings.append(token.get_embedding().unsqueeze(0))
 
-                word_embeddings = torch.cat(word_embeddings, dim=0)
-                if torch.cuda.is_available():
-                    word_embeddings = word_embeddings.cuda()
+                word_embeddings = torch.cat(word_embeddings, dim=0, device=flair.device)
 
                 if self.mode == 'mean':
                     pooled_embedding = self.pool_op(word_embeddings, 0)
@@ -1416,8 +1404,7 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
 
         torch.nn.init.xavier_uniform_(self.word_reprojection_map.weight)
 
-        if torch.cuda.is_available():
-            self.cuda()
+        self.to(flair.device)
 
     @property
     def embedding_length(self) -> int:
@@ -1468,9 +1455,7 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
         # --------------------------------------------------------------------
         # GET REPRESENTATION FOR ENTIRE BATCH
         # --------------------------------------------------------------------
-        sentence_tensor = torch.cat(all_sentence_tensors, 1)
-        if torch.cuda.is_available():
-            sentence_tensor = sentence_tensor.cuda()
+        sentence_tensor = torch.cat(all_sentence_tensors, 1, device=flair.device)
 
         # --------------------------------------------------------------------
         # FF PART

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -283,7 +283,7 @@ class ELMoEmbeddings(TokenEmbeddings):
 
         # put on Cuda if available
         from flair import device
-        cuda_device = 0 if str(device) == 'cuda' else -1
+        cuda_device = 0 if str(device) != 'cpu' else -1
         self.ee = allennlp.commands.elmo.ElmoEmbedder(options_file=options_file,
                                                       weight_file=weight_file,
                                                       cuda_device=cuda_device)

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -239,7 +239,7 @@ class WordEmbeddings(TokenEmbeddings):
                 else:
                     word_embedding = np.zeros(self.embedding_length, dtype='float')
 
-                word_embedding = torch.tensor(word_embedding, dtype=torch.float)
+                word_embedding = torch.FloatTensor(word_embedding)
 
                 token.set_embedding(self.name, word_embedding)
 
@@ -314,9 +314,9 @@ class ELMoEmbeddings(TokenEmbeddings):
                 token: Token = token
 
                 word_embedding = torch.cat([
-                    torch.tesnor(sentence_embeddings[0, token_idx, :], dtype=torch.float),
-                    torch.tensor(sentence_embeddings[1, token_idx, :], dtype=torch.float),
-                    torch.tensor(sentence_embeddings[2, token_idx, :], dtype=torch.float)
+                    torch.FloatTensor(sentence_embeddings[0, token_idx, :]),
+                    torch.FloatTensor(sentence_embeddings[1, token_idx, :]),
+                    torch.FloatTensor(sentence_embeddings[2, token_idx, :])
                 ], 0)
 
                 token.set_embedding(self.name, word_embedding)
@@ -383,7 +383,7 @@ class CharacterEmbeddings(TokenEmbeddings):
             for i, c in enumerate(tokens_sorted_by_length):
                 tokens_mask[i, :chars2_length[i]] = c
 
-            tokens_mask = torch.tensor(tokens_mask, dtype=torch.long, device=flair.device)
+            tokens_mask = torch.LongTensor(tokens_mask, device=flair.device)
 
             # chars for rnn processing
             chars = tokens_mask
@@ -396,7 +396,7 @@ class CharacterEmbeddings(TokenEmbeddings):
 
             outputs, output_lengths = torch.nn.utils.rnn.pad_packed_sequence(lstm_out)
             outputs = outputs.transpose(0, 1)
-            chars_embeds_temp = torch.tensor(torch.zeros((outputs.size(0), outputs.size(2))), dtype=torch.float, device=flair.device)
+            chars_embeds_temp = torch.FloatTensor(torch.zeros((outputs.size(0), outputs.size(2))), device=flair.device)
             for i, index in enumerate(output_lengths):
                 chars_embeds_temp[i] = outputs[i, index - 1]
             character_embeddings = chars_embeds_temp.clone()
@@ -649,7 +649,7 @@ class FlairEmbeddings(TokenEmbeddings):
                     break
                 else:
                     for token, embedding in zip(sentence, embeddings):
-                        token.set_embedding(self.name, torch.tensor(embedding, dtype=torch.float, device=flair.device))
+                        token.set_embedding(self.name, torch.FloatTensor(embedding, device=flair.device))
 
             if all_embeddings_retrieved_from_cache:
                 return sentences
@@ -903,8 +903,8 @@ class BertEmbeddings(TokenEmbeddings):
 
         # prepare id maps for BERT model
         features = self._convert_sentences_to_features(sentences, longest_sentence_in_batch)
-        all_input_ids = torch.tensor([f.input_ids for f in features], dtype=torch.long, device=flair.device)
-        all_input_masks = torch.tensor([f.input_mask for f in features], dtype=torch.long, device=flair.device)
+        all_input_ids = torch.LongTensor([f.input_ids for f in features], device=flair.device)
+        all_input_masks = torch.LongTensor([f.input_mask for f in features], device=flair.device)
 
         # put encoded batch through BERT model to get all hidden states of all encoder layers
         if torch.cuda.is_available():
@@ -1446,7 +1446,7 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
             # PADDING: pad shorter sentences out
             for add in range(longest_token_sequence_in_batch - len(sentence.tokens)):
                 word_embeddings.append(
-                    torch.tensor(np.zeros(self.length_of_all_token_embeddings, dtype='float'), dtype=torch.float).unsqueeze(0))
+                    torch.FloatTensor(np.zeros(self.length_of_all_token_embeddings, dtype='float')).unsqueeze(0))
 
             word_embeddings_tensor = torch.cat(word_embeddings, 0)
 

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -5,6 +5,7 @@ import torch
 import math
 from torch.autograd import Variable
 from typing import List, Union, Tuple
+from typing import List
 
 from torch.optim import Optimizer
 
@@ -86,8 +87,8 @@ class LanguageModel(nn.Module):
 
     def init_hidden(self, bsz):
         weight = next(self.parameters()).detach()
-        return (Variable(weight.new(self.nlayers, bsz, self.hidden_size).zero_()),
-                Variable(weight.new(self.nlayers, bsz, self.hidden_size).zero_()))
+        return (weight.new(self.nlayers, bsz, self.hidden_size).zero_().clone().detach(),
+                weight.new(self.nlayers, bsz, self.hidden_size).zero_().clone().detach())
 
     def get_representation(self, strings: List[str], detach_from_lm=True):
 
@@ -117,7 +118,7 @@ class LanguageModel(nn.Module):
     def repackage_hidden(self, h):
         """Wraps hidden states in new Variables, to detach them from their history."""
         if type(h) == torch.Tensor:
-            return Variable(h.detach())
+            return torch.tensor(h.detach())
         else:
             return tuple(self.repackage_hidden(v) for v in h)
 

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -96,7 +96,7 @@ class LanguageModel(nn.Module):
             char_indices = [self.dictionary.get_idx_for_item(char) for char in string]
             sequences_as_char_indices.append(char_indices)
 
-        batch = Variable(torch.LongTensor(sequences_as_char_indices, device=flair.device).transpose(0, 1))
+        batch = torch.tensor(sequences_as_char_indices, dtype=torch.long, device=flair.device).transpose(0, 1)
 
         hidden = self.init_hidden(len(strings))
         prediction, rnn_output, hidden = self.forward(batch, hidden)

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -97,7 +97,7 @@ class LanguageModel(nn.Module):
             char_indices = [self.dictionary.get_idx_for_item(char) for char in string]
             sequences_as_char_indices.append(char_indices)
 
-        batch = torch.tensor(sequences_as_char_indices, dtype=torch.long, device=flair.device).transpose(0, 1)
+        batch = torch.LongTensor(sequences_as_char_indices, device=flair.device).transpose(0, 1)
 
         hidden = self.init_hidden(len(strings))
         prediction, rnn_output, hidden = self.forward(batch, hidden)

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -97,7 +97,8 @@ class LanguageModel(nn.Module):
             char_indices = [self.dictionary.get_idx_for_item(char) for char in string]
             sequences_as_char_indices.append(char_indices)
 
-        batch = torch.LongTensor(sequences_as_char_indices, device=flair.device).transpose(0, 1)
+        batch = torch.LongTensor(sequences_as_char_indices).transpose(0, 1)
+        batch = batch.to(flair.device)
 
         hidden = self.init_hidden(len(strings))
         prediction, rnn_output, hidden = self.forward(batch, hidden)

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -119,7 +119,7 @@ class LanguageModel(nn.Module):
     def repackage_hidden(self, h):
         """Wraps hidden states in new Variables, to detach them from their history."""
         if type(h) == torch.Tensor:
-            return torch.tensor(h.detach())
+            return h.clone().detach()
         else:
             return tuple(self.repackage_hidden(v) for v in h)
 

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -3,8 +3,7 @@ from pathlib import Path
 import torch.nn as nn
 import torch
 import math
-from torch.autograd import Variable
-from typing import List, Union, Tuple
+from typing import Union, Tuple
 from typing import List
 
 from torch.optim import Optimizer

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -477,7 +477,7 @@ class SequenceTagger(flair.nn.Model):
 
     def _forward_alg(self, feats, lens_):
 
-        init_alphas = torch.Tensor(self.tagset_size).fill_(-10000.)
+        init_alphas = torch.tensor(self.tagset_size, dtype=torch.float).fill_(-10000.)
         init_alphas[self.tag_dictionary.get_idx_for_item(START_TAG)] = 0.
 
         forward_var = torch.tensor(

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -324,6 +324,7 @@ class SequenceTagger(flair.nn.Model):
             tag_list.append(torch.LongTensor(tag_idx, device=flair.device))
 
         sentence_tensor = sentence_tensor.transpose_(0, 1)
+        sentence_tensor = sentence_tensor.to(flair.device)
 
         # --------------------------------------------------------------------
         # FF PART

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -485,7 +485,6 @@ class SequenceTagger(flair.nn.Model):
             feats.shape[1] + 1,
             feats.shape[2],
             device=flair.device
-
         ).fill_(0)
 
         forward_var[:, 0, :] = init_alphas[None, :].repeat(feats.shape[0], 1)

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -237,15 +237,14 @@ class TextClassifier(flair.nn.Model):
     def _labels_to_one_hot(self, sentences: List[Sentence]):
         label_list = [sentence.get_label_names() for sentence in sentences]
         one_hot = convert_labels_to_one_hot(label_list, self.label_dictionary)
-        one_hot = [torch.FloatTensor(l, device=flair.device).unsqueeze(0) for l in one_hot]
+        one_hot = [torch.FloatTensor(l).unsqueeze(0) for l in one_hot]
         one_hot = torch.cat(one_hot, 0)
         one_hot = one_hot.to(flair.device)
         return one_hot
 
     def _labels_to_indices(self, sentences: List[Sentence]):
         indices = [
-            torch.LongTensor([self.label_dictionary.get_idx_for_item(label.value) for label in sentence.labels],
-                             device=flair.device)
+            torch.LongTensor([self.label_dictionary.get_idx_for_item(label.value) for label in sentence.labels])
             for sentence in sentences
         ]
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -56,7 +56,8 @@ class TextClassifier(flair.nn.Model):
         self.document_embeddings.embed(sentences)
 
         text_embedding_list = [sentence.get_embedding().unsqueeze(0) for sentence in sentences]
-        text_embedding_tensor = torch.cat(text_embedding_list, 0, device=flair.device)
+        text_embedding_tensor = torch.cat(text_embedding_list, 0)
+        text_embedding_tensor = text_embedding_tensor.to(flair.device)
 
         label_scores = self.decoder(text_embedding_tensor)
 
@@ -237,7 +238,8 @@ class TextClassifier(flair.nn.Model):
         label_list = [sentence.get_label_names() for sentence in sentences]
         one_hot = convert_labels_to_one_hot(label_list, self.label_dictionary)
         one_hot = [torch.tensor(l, dtype=torch.float, device=flair.device).unsqueeze(0) for l in one_hot]
-        one_hot = torch.cat(one_hot, 0, device=flair.device)
+        one_hot = torch.cat(one_hot, 0)
+        one_hot = one_hot.to(flair.device)
         return one_hot
 
     def _labels_to_indices(self, sentences: List[Sentence]):
@@ -247,7 +249,8 @@ class TextClassifier(flair.nn.Model):
             for sentence in sentences
         ]
 
-        vec = torch.cat(indices, 0, device=flair.device)
+        vec = torch.cat(indices, 0)
+        vec = vec.to(flair.device)
 
         return vec
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -237,15 +237,15 @@ class TextClassifier(flair.nn.Model):
     def _labels_to_one_hot(self, sentences: List[Sentence]):
         label_list = [sentence.get_label_names() for sentence in sentences]
         one_hot = convert_labels_to_one_hot(label_list, self.label_dictionary)
-        one_hot = [torch.tensor(l, dtype=torch.float, device=flair.device).unsqueeze(0) for l in one_hot]
+        one_hot = [torch.FloatTensor(l, device=flair.device).unsqueeze(0) for l in one_hot]
         one_hot = torch.cat(one_hot, 0)
         one_hot = one_hot.to(flair.device)
         return one_hot
 
     def _labels_to_indices(self, sentences: List[Sentence]):
         indices = [
-            torch.tensor([self.label_dictionary.get_idx_for_item(label.value) for label in sentence.labels],
-                         dtype=torch.long, device=flair.device)
+            torch.LongTensor([self.label_dictionary.get_idx_for_item(label.value) for label in sentence.labels],
+                             device=flair.device)
             for sentence in sentences
         ]
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -47,8 +47,7 @@ class TextClassifier(flair.nn.Model):
             self.loss_function = nn.CrossEntropyLoss()
 
         # auto-spawn on GPU if available
-        if torch.cuda.is_available():
-            self.cuda()
+        self.to(flair.device)
 
     def _init_weights(self):
         nn.init.xavier_uniform_(self.decoder.weight)
@@ -57,10 +56,7 @@ class TextClassifier(flair.nn.Model):
         self.document_embeddings.embed(sentences)
 
         text_embedding_list = [sentence.get_embedding().unsqueeze(0) for sentence in sentences]
-        text_embedding_tensor = torch.cat(text_embedding_list, 0)
-
-        if torch.cuda.is_available():
-            text_embedding_tensor = text_embedding_tensor.cuda()
+        text_embedding_tensor = torch.cat(text_embedding_list, 0, device=flair.device)
 
         label_scores = self.decoder(text_embedding_tensor)
 
@@ -112,9 +108,7 @@ class TextClassifier(flair.nn.Model):
         )
         model.load_state_dict(state['state_dict'])
         model.eval()
-
-        if torch.cuda.is_available():
-            model = model.cuda()
+        model.to(flair.device)
 
         return model
 
@@ -142,13 +136,9 @@ class TextClassifier(flair.nn.Model):
             warnings.filterwarnings("ignore")
             # load_big_file is a workaround by https://github.com/highway11git to load models on some Mac/Windows setups
             # see https://github.com/zalandoresearch/flair/issues/351
-            if torch.cuda.is_available():
-                f = flair.file_utils.load_big_file(str(model_file))
-                state = torch.load(f)
-            else:
-                f = flair.file_utils.load_big_file(str(model_file))
-                state = torch.load(f, map_location={'cuda:0': 'cpu'})
-        return state
+            f = flair.file_utils.load_big_file(str(model_file))
+            state = torch.load(f, map_location=flair.device)
+            return state
 
     def forward_loss(self, sentences: Union[List[Sentence], Sentence]) -> torch.tensor:
         scores = self.forward(sentences)
@@ -246,21 +236,18 @@ class TextClassifier(flair.nn.Model):
     def _labels_to_one_hot(self, sentences: List[Sentence]):
         label_list = [sentence.get_label_names() for sentence in sentences]
         one_hot = convert_labels_to_one_hot(label_list, self.label_dictionary)
-        one_hot = [torch.FloatTensor(l).unsqueeze(0) for l in one_hot]
-        one_hot = torch.cat(one_hot, 0)
-        if torch.cuda.is_available():
-            one_hot = one_hot.cuda()
+        one_hot = [torch.tensor(l, dtype=torch.float, device=flair.device).unsqueeze(0) for l in one_hot]
+        one_hot = torch.cat(one_hot, 0, device=flair.device)
         return one_hot
 
     def _labels_to_indices(self, sentences: List[Sentence]):
         indices = [
-            torch.LongTensor([self.label_dictionary.get_idx_for_item(label.value) for label in sentence.labels])
+            torch.tensor([self.label_dictionary.get_idx_for_item(label.value) for label in sentence.labels],
+                         dtype=torch.long, device=flair.device)
             for sentence in sentences
         ]
 
-        vec = torch.cat(indices, 0)
-        if torch.cuda.is_available():
-            vec = vec.cuda()
+        vec = torch.cat(indices, 0, device=flair.device)
 
         return vec
 

--- a/flair/trainers/language_model_trainer.py
+++ b/flair/trainers/language_model_trainer.py
@@ -403,8 +403,8 @@ class LanguageModelTrainer:
 
     @staticmethod
     def _repackage_hidden(h):
-        """Wraps hidden states in new Variables, to detach them from their history."""
-        return tuple(v.clone().detach().requires_grad_(True) for v in h)
+        """Wraps hidden states in new tensors, to detach them from their history."""
+        return tuple(v.clone().detach() for v in h)
 
     @staticmethod
     def load_from_checkpoint(checkpoint_file: Path, corpus: TextCorpus, optimizer: Optimizer = SGD):

--- a/flair/trainers/language_model_trainer.py
+++ b/flair/trainers/language_model_trainer.py
@@ -7,6 +7,7 @@ from typing import Union
 from torch.autograd import Variable
 from torch.optim.sgd import SGD
 
+import flair
 from flair.data import Dictionary
 from flair.models import LanguageModel
 from flair.optim import *
@@ -65,7 +66,7 @@ class TextCorpus(object):
 
         return train_slice
 
-    def charsplit(self, path: Path, expand_vocab=False, forward=True, split_on_char=True, random_case_flip=True) -> torch.LongTensor:
+    def charsplit(self, path: Path, expand_vocab=False, forward=True, split_on_char=True, random_case_flip=True) -> torch.tensor:
 
         """Tokenizes a text file on character basis."""
         assert path.exists()
@@ -90,7 +91,9 @@ class TextCorpus(object):
         if forward:
             # charsplit file content
             with open(path, 'r', encoding="utf-8") as f:
-                ids = torch.LongTensor(tokens)
+                i = torch.LongTensor(tokens)
+                a = torch.LongTensor(tokens)
+                ids = torch.tensor(tokens, dtype=torch.long)
                 token = 0
                 for line in f:
                     if random_case_flip:
@@ -108,7 +111,7 @@ class TextCorpus(object):
         else:
             # charsplit file content
             with open(path, 'r', encoding="utf-8") as f:
-                ids = torch.LongTensor(tokens)
+                ids = torch.tensor(tokens, dtype=torch.long)
                 token = tokens - 1
                 for line in f:
                     if random_case_flip:
@@ -149,7 +152,7 @@ class TextCorpus(object):
 
         # Tokenize file content
         with open(path, 'r') as f:
-            ids = torch.LongTensor(tokens)
+            ids = torch.tensor(tokens, dtype=torch.long)
             token = 0
             for line in f:
                 words = line.split() + ['<eos>']
@@ -385,7 +388,7 @@ class LanguageModelTrainer:
         # Trim off any extra elements that wouldn't cleanly fit (remainders).
         data = data.narrow(0, 0, nbatch * batch_size)
         # Evenly divide the data across the bsz batches.
-        data = data.view(batch_size, -1).t().contiguous()
+        data = data.view(batch_size, -1, device=flair.device).t().contiguous()
         return data
 
     @staticmethod

--- a/flair/trainers/language_model_trainer.py
+++ b/flair/trainers/language_model_trainer.py
@@ -90,7 +90,8 @@ class TextCorpus(object):
         if forward:
             # charsplit file content
             with open(path, 'r', encoding="utf-8") as f:
-                ids = torch.zeros(tokens, dtype=torch.long, device=flair.device)
+                ids = torch.zeros(tokens, dtype=torch.long)
+                ids = ids.to(flair.device)
                 token = 0
                 for line in f:
                     if random_case_flip:
@@ -108,7 +109,8 @@ class TextCorpus(object):
         else:
             # charsplit file content
             with open(path, 'r', encoding="utf-8") as f:
-                ids = torch.zeros(tokens, dtype=torch.long, device=flair.device)
+                ids = torch.zeros(tokens, dtype=torch.long)
+                ids = ids.to(flair.device)
                 token = tokens - 1
                 for line in f:
                     if random_case_flip:
@@ -149,7 +151,8 @@ class TextCorpus(object):
 
         # Tokenize file content
         with open(path, 'r') as f:
-            ids = torch.zeros(tokens, dtype=torch.long, device=flair.device)
+            ids = torch.zeros(tokens, dtype=torch.long)
+            ids = ids.to(flair.device)
             token = 0
             for line in f:
                 words = line.split() + ['<eos>']
@@ -386,7 +389,7 @@ class LanguageModelTrainer:
         data = data.narrow(0, 0, nbatch * batch_size)
         # Evenly divide the data across the bsz batches.
         data = data.view(batch_size, -1).t().contiguous()
-        data = data.to(device=flair.device)
+        data = data.to(flair.device)
         return data
 
     @staticmethod


### PR DESCRIPTION
closes #270 

- Don't use `torch.autograd.Variable` anymore
- Use `tensor = tensor.to(flair.device)` instead of `if torch.cuda.is_available(): tensor = tensor.cuda()`