### PR TITLE
GH-429: relax matplotlib requirement to make compatible with allennlp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gensim>=3.4.0
 pytest>=3.6.4
 tqdm>=4.26.0
 segtok>=1.5.7
-matplotlib>=3.0.0
+matplotlib>=2.2.3
 mpld3==0.3
 sklearn
 sqlitedict>=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'gensim>=3.4.0',
         'tqdm>=4.26.0',
         'segtok>=1.5.7',
-        'matplotlib>=3.0.0',
+        'matplotlib>=2.2.3',
         'mpld3>=0.3',
         'sklearn',
         'sqlitedict>=1.6.0',


### PR DESCRIPTION
closes #429 

AllenNLP uses a lower version of matplotlib than the one we used in our requirements.txt. To make both compatible, we lower our matplotlib verison as well.