### PR TITLE
Fixing text classification evaluation

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -423,23 +423,37 @@ class ModelTrainer:
 
                 eval_loss += loss
 
-                for predictions, true_values in zip([[label.value for label in sent_labels] for sent_labels in labels],
-                                                    [sentence.get_label_names() for sentence in batch]):
-                    for prediction in predictions:
-                        if prediction in true_values:
-                            metric.add_tp(prediction)
-                        else:
-                            metric.add_fp(prediction)
+                predictions_for_batch = [[label.value for label in sent_labels] for sent_labels in labels]
+                true_values_for_batch = [sentence.get_label_names() for sentence in batch]
+                label_dictionary = model.label_dictionary.get_items()
 
-                    for true_value in true_values:
-                        if true_value not in predictions:
-                            metric.add_fn(true_value)
-                        else:
-                            metric.add_tn(true_value)
+                for predictions_for_sentence, true_values_for_sentence in zip(predictions_for_batch, true_values_for_batch):
+                    ModelTrainer._evaluate_sentence_for_text_classification(metric,
+                                                                            label_dictionary,
+                                                                            predictions_for_sentence,
+                                                                            true_values_for_sentence)
 
             eval_loss /= len(sentences)
 
             return metric, eval_loss
+
+
+    @staticmethod
+    def _evaluate_sentence_for_text_classification(metric: Metric,
+                                                   label_dict: List[str],
+                                                   predictions: List[str],
+                                                   true_values: List[str]):
+
+        for label in label_dict:
+            if label in predictions and label in true_values:
+                metric.add_tp(label)
+            elif label in predictions and label not in true_values:
+                metric.add_fp(label)
+            elif label not in predictions and label in true_values:
+                metric.add_fn(label)
+            elif label not in predictions and label not in true_values:
+                metric.add_tn(label)
+
 
     @staticmethod
     def load_from_checkpoint(checkpoint_file: Path, model_type: str, corpus: Corpus, optimizer: Optimizer = SGD):

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -425,11 +425,11 @@ class ModelTrainer:
 
                 predictions_for_batch = [[label.value for label in sent_labels] for sent_labels in labels]
                 true_values_for_batch = [sentence.get_label_names() for sentence in batch]
-                label_dictionary = model.label_dictionary.get_items()
+                available_labels = model.label_dictionary.get_items()
 
                 for predictions_for_sentence, true_values_for_sentence in zip(predictions_for_batch, true_values_for_batch):
                     ModelTrainer._evaluate_sentence_for_text_classification(metric,
-                                                                            label_dictionary,
+                                                                            available_labels,
                                                                             predictions_for_sentence,
                                                                             true_values_for_sentence)
 
@@ -440,11 +440,11 @@ class ModelTrainer:
 
     @staticmethod
     def _evaluate_sentence_for_text_classification(metric: Metric,
-                                                   label_dict: List[str],
+                                                   available_labels: List[str],
                                                    predictions: List[str],
                                                    true_values: List[str]):
 
-        for label in label_dict:
+        for label in available_labels:
             if label in predictions and label in true_values:
                 metric.add_tp(label)
             elif label in predictions and label not in true_values:


### PR DESCRIPTION
Previous evaluation for text classification is incorrect. In particular, TP + FP + TN + FN doesn't equal number of sentences and TP is always same as TN. For example:

1: tp: 936 - fp: 58 - fn: 0 - tn: 936 - precision: 0.9416 - recall: 1.0000 - accuracy: 0.9699 - f1-score: 0.9699
2: tp: 0 - fp: 0 - fn: 92 - tn: 0 - precision: 0.0000 - recall: 0.0000 - accuracy: 0.0000 - f1-score: 0.0000
3: tp: 509 - fp: 464 - fn: 5 - tn: 509 - precision: 0.5231 - recall: 0.9903 - accuracy: 0.6846 - f1-score: 0.6846

Counting FN and TN is incorrect:
```
                    for true_value in true_values:
                        if true_value not in predictions:
                            metric.add_fn(true_value)
                        else:
                            metric.add_tn(true_value)

```

This commit fixes evaluation for text classification. Same classifier outputs:
1: tp: 936 - fp: 58 - fn: 0 - tn: 0 - precision: 0.9416 - recall: 1.0000 - accuracy: 0.9416 - f1-score: 0.9699
2: tp: 0 - fp: 0 - fn: 92 - tn: 902 - precision: 0.0000 - recall: 0.0000 - accuracy: 0.9074 - f1-score: 0.0000
3: tp: 432 - fp: 362 - fn: 82 - tn: 118 - precision: 0.5441 - recall: 0.8405 - accuracy: 0.5533 - f1-score: 0.660

TP + FP + TN + FN is always the same and equals number of observations.