### PR TITLE
GH-387: modify FlairEmbeddings to handle large texts

### DIFF
--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -89,13 +89,13 @@ class LanguageModel(nn.Module):
         return (weight.new(self.nlayers, bsz, self.hidden_size).zero_().clone().detach(),
                 weight.new(self.nlayers, bsz, self.hidden_size).zero_().clone().detach())
 
-    def get_representation(self, strings: List[str], chunk_size: int = 512):
+    def get_representation(self, strings: List[str], chars_per_chunk: int = 512):
 
         # cut up the input into chunks of max charlength = chunk_size
         longest = len(strings[0])
         chunks = []
         splice_begin = 0
-        for splice_end in range(chunk_size, longest, chunk_size):
+        for splice_end in range(chars_per_chunk, longest, chars_per_chunk):
             chunks.append([text[splice_begin:splice_end] for text in strings])
             splice_begin = splice_end
 
@@ -120,7 +120,7 @@ class LanguageModel(nn.Module):
 
             output_parts.append(rnn_output)
 
-        # concatenage all chunks to make final output
+        # concatenate all chunks to make final output
         output = torch.cat(output_parts)
 
         return output

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -587,9 +587,9 @@ class SequenceTagger(flair.nn.Model):
             model_file = cached_path(base_path, cache_dir=cache_dir)
 
         if model.lower() == 'ner':
-            base_path = '/'.join([aws_resource_path,
-                                  'NER-conll03--h256-l1-b32-%2Bglove%2Bnews-forward%2Bnews-backward--v0.2',
-                                  'en-ner-conll03-v0.2.pt'])
+            base_path = '/'.join([aws_resource_path_v04,
+                                  'NER-conll03-english',
+                                  'en-ner-conll03-v0.4.pt'])
             model_file = cached_path(base_path, cache_dir=cache_dir)
 
         elif model.lower() == 'ner-fast':

--- a/flair/trainers/language_model_trainer.py
+++ b/flair/trainers/language_model_trainer.py
@@ -17,89 +17,100 @@ from flair.training_utils import add_file_handler
 
 log = logging.getLogger('flair')
 
+
 class TextDataset(Dataset):
-    def __init__(self,path : Path, dictionary: Dictionary, expand_vocab=False, forward=True, split_on_char=True, random_case_flip=True):
+    def __init__(self,
+                 path: Path,
+                 dictionary: Dictionary,
+                 expand_vocab: bool = False,
+                 forward: bool = True,
+                 split_on_char: bool = True,
+                 random_case_flip: bool = True,
+                 shuffle_lines: bool = True):
 
         assert path.exists()
-        
-        self.files            = None
-        self.path             = path
-        self.dictionary       = dictionary
-        self.split_on_char    = split_on_char
-        self.forward          = forward
-        self.random_case_flip = random_case_flip
-        self.expand_vocab     = expand_vocab
 
-        
+        self.files = None
+        self.path = path
+        self.dictionary = dictionary
+        self.split_on_char = split_on_char
+        self.forward = forward
+        self.random_case_flip = random_case_flip
+        self.expand_vocab = expand_vocab
+        self.shuffle_lines = shuffle_lines
+
         if path.is_dir():
             self.files = sorted([f for f in path.iterdir() if f.exists()])
         else:
             self.files = [path]
-        
+
     def __len__(self):
         return len(self.files)
 
-    def __getitem__(self,index=0) -> torch.LongTensor:
-        return self.charsplit(self.files[index], self.expand_vocab, self.forward,self.split_on_char, self.random_case_flip)
-    
-    def charsplit(self, path: Path, expand_vocab=False, forward=True, split_on_char=True, random_case_flip=True) -> torch.LongTensor:
-        start_time = time.time()
+    def __getitem__(self, index=0) -> torch.tensor:
+        return self.charsplit(self.files[index], self.expand_vocab, self.forward, self.split_on_char,
+                              self.random_case_flip)
+
+    def charsplit(self, path: Path, expand_vocab=False, forward=True, split_on_char=True,
+                  random_case_flip=True) -> torch.tensor:
+
         """Tokenizes a text file on character basis."""
         assert path.exists()
 
-        with open(path, 'r', encoding="utf-8") as f:
-            tokens = 0
-            for line in f:
+        lines = open(path, 'r', encoding="utf-8").readlines()
+        log.info(f'read text file with {len(lines)} lines')
+        if self.shuffle_lines:
+            random.shuffle(lines)
+            log.info(f'shuffled')
+
+        tokens = 0
+        for line in lines:
+
+            if split_on_char:
+                chars = list(line)
+            else:
+                chars = line.split()
+
+            tokens += len(chars)
+
+            # Add chars to the dictionary
+            if expand_vocab:
+                for char in chars:
+                    self.dictionary.add_item(char)
+
+        ids = torch.zeros(tokens, dtype=torch.long)
+        if forward:
+            # charsplit file content
+            token = 0
+            for line in lines:
+                if random_case_flip:
+                    line = self.random_casechange(line)
 
                 if split_on_char:
                     chars = list(line)
                 else:
                     chars = line.split()
 
-                tokens += len(chars)
-
-                # Add chars to the dictionary
-                if expand_vocab:
-                    for char in chars:
-                        self.dictionary.add_item(char)
-
-        if forward:
-            # charsplit file content
-            with open(path, 'r', encoding="utf-8") as f:
-                ids = torch.zeros(tokens, dtype=torch.long)
-                token = 0
-                for line in f:
-                    if random_case_flip:
-                        line = self.random_casechange(line)
-
-                    if split_on_char:
-                        chars = list(line)
-                    else:
-                        chars = line.split()
-                        
-                    for char in chars:
-                        if token >= tokens: break
-                        ids[token] = self.dictionary.get_idx_for_item(char)
-                        token += 1
+                for char in chars:
+                    if token >= tokens: break
+                    ids[token] = self.dictionary.get_idx_for_item(char)
+                    token += 1
         else:
             # charsplit file content
-            with open(path, 'r', encoding="utf-8") as f:
-                ids = torch.zeros(tokens, dtype=torch.long)
-                token = tokens - 1
-                for line in f:
-                    if random_case_flip:
-                        line = self.random_casechange(line)
+            token = tokens - 1
+            for line in lines:
+                if random_case_flip:
+                    line = self.random_casechange(line)
 
-                    if split_on_char:
-                        chars = list(line)
-                    else:
-                        chars = line.split()
+                if split_on_char:
+                    chars = list(line)
+                else:
+                    chars = line.split()
 
-                    for char in chars:
-                        if token >= tokens: break
-                        ids[token] = self.dictionary.get_idx_for_item(char)
-                        token -= 1
-        #log.info("Time to load %s:%d" % ( str(path),time.time() - start_time))
+                for char in chars:
+                    if token >= tokens: break
+                    ids[token] = self.dictionary.get_idx_for_item(char)
+                    token -= 1
         return ids
 
     @staticmethod
@@ -135,21 +146,33 @@ class TextDataset(Dataset):
                     token += 1
 
         return ids
-        
-    
-class TextCorpus(object):
-    def __init__(self, path: Path, dictionary: Dictionary, forward: bool = True, character_level: bool = True, random_case_flip : bool = True):
-        self.dictionary: Dictionary = dictionary
-        self.forward                = forward
-        self.split_on_char          = character_level
-        self.random_case_flip       = random_case_flip
-        
-        self.train = TextDataset(path / 'train',dictionary, False,self.forward,self.split_on_char,self.random_case_flip)
 
-        # TextDataset returns a list. valid and test are only one file, so return the first elemetn
-        self.valid = TextDataset(path / 'valid.txt',dictionary, False,self.forward,self.split_on_char,self.random_case_flip)[0]
-        self.test  = TextDataset(path / 'test.txt',dictionary,False,self.forward,self.split_on_char,self.random_case_flip)[0]
-    
+
+class TextCorpus(object):
+    def __init__(self,
+                 path: Path, dictionary: Dictionary,
+                 forward: bool = True,
+                 character_level: bool = True,
+                 random_case_flip: bool = True,
+                 shuffle_lines: bool = True):
+        self.dictionary: Dictionary = dictionary
+        self.forward = forward
+        self.split_on_char = character_level
+        self.random_case_flip = random_case_flip
+        self.shuffle_lines = shuffle_lines
+
+        self.train = TextDataset(path / 'train', dictionary, False, self.forward, self.split_on_char,
+                                 self.random_case_flip, shuffle_lines=self.shuffle_lines)
+
+        # TextDataset returns a list. valid and test are only one file, so return the first element
+        self.valid = \
+            TextDataset(path / 'valid.txt', dictionary, False, self.forward, self.split_on_char, self.random_case_flip,
+                        shuffle_lines=False)[0]
+        self.test = \
+            TextDataset(path / 'test.txt', dictionary, False, self.forward, self.split_on_char, self.random_case_flip,
+                        shuffle_lines=False)[0]
+
+
 class LanguageModelTrainer:
     def __init__(self,
                  model: LanguageModel,
@@ -184,6 +207,7 @@ class LanguageModelTrainer:
               clip=0.25,
               max_epochs: int = 1000,
               checkpoint: bool = False,
+              grow_to_sequence_length: int = 0,
               **kwargs):
 
         # cast string to Path
@@ -220,17 +244,22 @@ class LanguageModelTrainer:
                                                                  factor=anneal_factor,
                                                                  patience=patience)
 
-            train_data = None
-            training_generator = DataLoader(self.corpus.train,shuffle=False,num_workers=self.num_workers)
-            
+            training_generator = DataLoader(self.corpus.train, shuffle=False, num_workers=self.num_workers)
+
             for epoch in range(self.epoch, max_epochs):
-                epoch_start_time = time.time()                
+                epoch_start_time = time.time()
                 # Shuffle training files randomly after serially iterating through corpus one
                 if epoch > 0:
-                    training_generator = DataLoader(self.corpus.train,shuffle=True,num_workers=self.num_workers)
+                    training_generator = DataLoader(self.corpus.train, shuffle=True, num_workers=self.num_workers)
+                    self.model.save_checkpoint(base_path / f'epoch_{epoch}.pt', optimizer, epoch, 0, best_val_loss)
 
                 # iterate through training data, starting at self.split (for checkpointing)
                 for curr_split, train_slice in enumerate(training_generator, self.split):
+
+                    if sequence_length < grow_to_sequence_length:
+                        sequence_length += 1
+                    log.info(f'Sequence length is {sequence_length}')
+
                     split_start_time = time.time()
                     # off by one for printing                    
                     curr_split += 1
@@ -251,7 +280,7 @@ class LanguageModelTrainer:
                     ntokens = len(self.corpus.dictionary)
 
                     total_loss = 0
-                    start_time = time.time()                    
+                    start_time = time.time()
 
                     for batch, i in enumerate(range(0, train_data.size(0) - 1, sequence_length)):
                         data, targets = self._get_batch(train_data, i, sequence_length)
@@ -259,7 +288,6 @@ class LanguageModelTrainer:
                         if not data.is_cuda and cuda.is_available():
                             log.info("Batch %d is not on CUDA, training will be very slow" % (batch))
                             raise Exception("data isnt on cuda")
-                        
 
                         # Starting each batch, we detach the hidden state from how it was previously produced.
                         # If we didn't, the model would try backpropagating all the way to start of the dataset.
@@ -271,11 +299,9 @@ class LanguageModelTrainer:
                         # do the forward pass in the model
                         output, rnn_output, hidden = self.model.forward(data, hidden)
 
-
                         # try to predict the targets
                         loss = self.loss_function(output.view(-1, ntokens), targets)
                         loss.backward()
-
 
                         # `clip_grad_norm` helps prevent the exploding gradient problem in RNNs / LSTMs.
                         torch.nn.utils.clip_grad_norm_(self.model.parameters(), clip)
@@ -289,14 +315,14 @@ class LanguageModelTrainer:
                             elapsed = time.time() - start_time
                             log.info('| split {:3d} /{:3d} | {:5d}/{:5d} batches | ms/batch {:5.2f} | '
                                      'loss {:5.2f} | ppl {:8.2f}'.format(
-                                    curr_split, number_of_splits, batch, len(train_data) // sequence_length,
-                                    elapsed * 1000 / self.log_interval, cur_loss,
-                                    math.exp(cur_loss)))
+                                curr_split, number_of_splits, batch, len(train_data) // sequence_length,
+                                                                     elapsed * 1000 / self.log_interval, cur_loss,
+                                math.exp(cur_loss)))
                             total_loss = 0
                             start_time = time.time()
 
                     log.info("%d seconds for train split %d" % (time.time() - split_start_time, curr_split))
-                    
+
                     ###############################################################################
                     self.model.eval()
 
@@ -308,7 +334,8 @@ class LanguageModelTrainer:
                     log.info(self.model.generate_text())
 
                     if checkpoint:
-                        self.model.save_checkpoint(base_path / 'checkpoint.pt', optimizer, epoch, curr_split, best_val_loss)
+                        self.model.save_checkpoint(base_path / 'checkpoint.pt', optimizer, epoch, curr_split,
+                                                   best_val_loss)
 
                     # Save the model if the validation loss is the best we've seen so far.
                     if val_loss < best_val_loss:
@@ -320,11 +347,11 @@ class LanguageModelTrainer:
                     # print info
                     ###############################################################################
                     log.info('-' * 89)
-                    
+
                     summary = '| end of split {:3d} /{:3d} | epoch {:3d} | time: {:5.2f}s | valid loss {:5.2f} | ' \
                               'valid ppl {:8.2f} | learning rate {:3.4f}'.format(curr_split,
                                                                                  number_of_splits,
-                                                                                 epoch+1,
+                                                                                 epoch + 1,
                                                                                  (time.time() - split_start_time),
                                                                                  val_loss,
                                                                                  math.exp(val_loss),
@@ -381,7 +408,6 @@ class LanguageModelTrainer:
         data = data.narrow(0, 0, nbatch * batch_size)
         # Evenly divide the data across the bsz batches.
         data = data.view(batch_size, -1).t().contiguous()
-        data = data.to(flair.device)
         return data
 
     @staticmethod
@@ -407,6 +433,3 @@ class LanguageModelTrainer:
         return LanguageModelTrainer(checkpoint['model'], corpus, optimizer, epoch=checkpoint['epoch'],
                                     split=checkpoint['split'], loss=checkpoint['loss'],
                                     optimizer_state=checkpoint['optimizer_state_dict'])
-    
-
-    

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'sqlitedict>=1.6.0',
         'deprecated>=1.2.4',
         'hyperopt>=0.1.1',
-        'pytorch-pretrained-bert>=0.3.0'
+        'pytorch-pretrained-bert>=0.4.0'
     ],
     include_package_data=True,
     python_requires='>=3.6',

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -6,71 +6,71 @@ from flair.embeddings import WordEmbeddings, TokenEmbeddings, StackedEmbeddings,
 from flair.data import Sentence
 
 
-@pytest.mark.slow
-def test_glove():
-    load_and_apply_word_embeddings('glove')
-
-
-@pytest.mark.slow
-def test_extvec():
-    load_and_apply_word_embeddings('extvec')
-
-
-@pytest.mark.slow
-def test_crawl():
-    load_and_apply_word_embeddings('crawl')
-
-
-@pytest.mark.slow
-def test_news():
-    load_and_apply_word_embeddings('news')
-
-
-@pytest.mark.slow
-def test_fr():
-    load_and_apply_word_embeddings('fr')
-
-
-@pytest.mark.slow
-def test_it():
-    load_and_apply_word_embeddings('it')
-
-@pytest.mark.slow
-def test_it():
-    load_and_apply_word_embeddings('it-wiki')
-
-@pytest.mark.slow
-def test_it():
-    load_and_apply_word_embeddings('it-crawl')
-
-@pytest.mark.slow
-def test_news_forward():
-    load_and_apply_char_lm_embeddings('news-forward')
-
-
-@pytest.mark.slow
-def test_news_backward():
-    load_and_apply_char_lm_embeddings('news-backward')
-
-
-@pytest.mark.slow
-def test_mix_forward():
-    load_and_apply_char_lm_embeddings('mix-forward')
-
-
-@pytest.mark.slow
-def test_mix_backward():
-    load_and_apply_char_lm_embeddings('mix-backward')
-
-
-@pytest.mark.slow
-def test_german_forward():
-    load_and_apply_char_lm_embeddings('german-forward')
-
-
-@pytest.mark.slow
-def test_german_backward():
-    load_and_apply_char_lm_embeddings('german-backward')
+# @pytest.mark.slow
+# def test_glove():
+#     load_and_apply_word_embeddings('glove')
+#
+#
+# @pytest.mark.slow
+# def test_extvec():
+#     load_and_apply_word_embeddings('extvec')
+#
+#
+# @pytest.mark.slow
+# def test_crawl():
+#     load_and_apply_word_embeddings('crawl')
+#
+#
+# @pytest.mark.slow
+# def test_news():
+#     load_and_apply_word_embeddings('news')
+#
+#
+# @pytest.mark.slow
+# def test_fr():
+#     load_and_apply_word_embeddings('fr')
+#
+#
+# @pytest.mark.slow
+# def test_it():
+#     load_and_apply_word_embeddings('it')
+#
+# @pytest.mark.slow
+# def test_it():
+#     load_and_apply_word_embeddings('it-wiki')
+#
+# @pytest.mark.slow
+# def test_it():
+#     load_and_apply_word_embeddings('it-crawl')
+#
+# @pytest.mark.slow
+# def test_news_forward():
+#     load_and_apply_char_lm_embeddings('news-forward')
+#
+#
+# @pytest.mark.slow
+# def test_news_backward():
+#     load_and_apply_char_lm_embeddings('news-backward')
+#
+#
+# @pytest.mark.slow
+# def test_mix_forward():
+#     load_and_apply_char_lm_embeddings('mix-forward')
+#
+#
+# @pytest.mark.slow
+# def test_mix_backward():
+#     load_and_apply_char_lm_embeddings('mix-backward')
+#
+#
+# @pytest.mark.slow
+# def test_german_forward():
+#     load_and_apply_char_lm_embeddings('german-forward')
+#
+#
+# @pytest.mark.slow
+# def test_german_backward():
+#     load_and_apply_char_lm_embeddings('german-backward')
 
 
 def test_loading_not_existing_embedding():

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -5,7 +5,7 @@ from hyperopt import hp
 from torch.optim import SGD
 
 from flair.data_fetcher import NLPTaskDataFetcher, NLPTask
-from flair.embeddings import WordEmbeddings, StackedEmbeddings, CharLMEmbeddings
+from flair.embeddings import WordEmbeddings, StackedEmbeddings, FlairEmbeddings
 from flair.hyperparameter import SearchSpace, Parameter, SequenceTaggerParamSelector, TextClassifierParamSelector
 from flair.optim import AdamW
 
@@ -20,7 +20,7 @@ def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
     # sequence tagger parameter
     search_space.add(Parameter.EMBEDDINGS, hp.choice, options=[
         StackedEmbeddings([WordEmbeddings('glove')]),
-        StackedEmbeddings([WordEmbeddings('glove'), CharLMEmbeddings('news-forward'), CharLMEmbeddings('news-backward')])
+        StackedEmbeddings([WordEmbeddings('glove'), FlairEmbeddings('news-forward'), FlairEmbeddings('news-backward')])
     ])
     search_space.add(Parameter.USE_CRF, hp.choice, options=[True, False])
     search_space.add(Parameter.DROPOUT, hp.uniform, low=0.25, high=0.75)

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -7,7 +7,7 @@ from torch.optim.adam import Adam
 
 from flair.data import Dictionary, Sentence
 from flair.data_fetcher import NLPTaskDataFetcher, NLPTask
-from flair.embeddings import WordEmbeddings, CharLMEmbeddings, DocumentLSTMEmbeddings, TokenEmbeddings
+from flair.embeddings import WordEmbeddings, DocumentLSTMEmbeddings, TokenEmbeddings, FlairEmbeddings
 from flair.models import SequenceTagger, TextClassifier, LanguageModel
 from flair.trainers import ModelTrainer
 from flair.trainers.language_model_trainer import LanguageModelTrainer, TextCorpus
@@ -87,7 +87,7 @@ def test_train_charlm_load_use_tagger(results_base_path, tasks_base_path):
     corpus = NLPTaskDataFetcher.load_corpus(NLPTask.FASHION, base_path=tasks_base_path)
     tag_dictionary = corpus.make_tag_dictionary('ner')
 
-    embeddings = CharLMEmbeddings('news-forward-fast')
+    embeddings = FlairEmbeddings('news-forward-fast')
 
     tagger: SequenceTagger = SequenceTagger(hidden_size=256,
                                             embeddings=embeddings,
@@ -123,7 +123,7 @@ def test_train_charlm_changed_chache_load_use_tagger(results_base_path, tasks_ba
     # make a temporary cache directory that we remove afterwards
     cache_dir = results_base_path / 'cache'
     os.makedirs(cache_dir, exist_ok=True)
-    embeddings = CharLMEmbeddings('news-forward-fast', cache_directory=cache_dir)
+    embeddings = FlairEmbeddings('news-forward-fast', cache_directory=cache_dir)
 
     tagger: SequenceTagger = SequenceTagger(hidden_size=256,
                                             embeddings=embeddings,
@@ -159,7 +159,7 @@ def test_train_charlm_nochache_load_use_tagger(results_base_path, tasks_base_pat
     corpus = NLPTaskDataFetcher.load_corpus(NLPTask.FASHION, base_path=tasks_base_path)
     tag_dictionary = corpus.make_tag_dictionary('ner')
 
-    embeddings = CharLMEmbeddings('news-forward-fast', use_cache=False)
+    embeddings = FlairEmbeddings('news-forward-fast', use_cache=False)
 
     tagger: SequenceTagger = SequenceTagger(hidden_size=256,
                                             embeddings=embeddings,
@@ -347,7 +347,7 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
     corpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB, base_path=tasks_base_path)
     label_dict = corpus.make_label_dictionary()
 
-    glove_embedding: TokenEmbeddings = CharLMEmbeddings('news-forward-fast')
+    glove_embedding: TokenEmbeddings = FlairEmbeddings('news-forward-fast')
     document_embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove_embedding], 128, 1, False, 64, False,
                                                                          False)
 
@@ -383,7 +383,7 @@ def test_train_charlm_nocache_load_use_classifier(results_base_path, tasks_base_
     corpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB, base_path=tasks_base_path)
     label_dict = corpus.make_label_dictionary()
 
-    glove_embedding: TokenEmbeddings = CharLMEmbeddings('news-forward-fast', use_cache=False)
+    glove_embedding: TokenEmbeddings = FlairEmbeddings('news-forward-fast', use_cache=False)
     document_embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([glove_embedding], 128, 1, False, 64,
                                                                          False,
                                                                          False)
@@ -433,7 +433,7 @@ def test_train_language_model(results_base_path, resources_path):
     trainer.train(results_base_path, sequence_length=10, mini_batch_size=10, max_epochs=2)
 
     # use the character LM as embeddings to embed the example sentence 'I love Berlin'
-    char_lm_embeddings = CharLMEmbeddings(str(results_base_path / 'best-lm.pt'))
+    char_lm_embeddings = FlairEmbeddings(str(results_base_path / 'best-lm.pt'))
     sentence = Sentence('I love Berlin')
     char_lm_embeddings.embed(sentence)
 
@@ -482,7 +482,7 @@ def test_train_resume_text_classification_training(results_base_path, tasks_base
     corpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB, base_path=tasks_base_path)
     label_dict = corpus.make_label_dictionary()
 
-    embeddings: TokenEmbeddings = CharLMEmbeddings('news-forward-fast', use_cache=False)
+    embeddings: TokenEmbeddings = FlairEmbeddings('news-forward-fast', use_cache=False)
     document_embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings([embeddings], 128, 1, False)
 
     model = TextClassifier(document_embeddings, label_dict, False)

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -11,72 +11,72 @@ from flair.visual.manifold import Visualizer, tSNE
 from flair.visual.training_curves import Plotter
 
 
-@pytest.mark.slow
-def test_visualize_word_emeddings(resources_path):
-
-    with open(resources_path / 'visual/snippet.txt') as f:
-        sentences = [x for x in f.read().split('\n') if x]
-
-    sentences = [Sentence(x) for x in sentences]
-
-    charlm_embedding_forward = FlairEmbeddings('news-forward')
-    charlm_embedding_backward = FlairEmbeddings('news-backward')
-
-    embeddings = StackedEmbeddings([charlm_embedding_backward, charlm_embedding_forward])
-
-    visualizer = Visualizer()
-    visualizer.visualize_word_emeddings(embeddings, sentences, str(resources_path / 'visual/sentence_embeddings.html'))
-
-    # clean up directory
-    (resources_path / 'visual/sentence_embeddings.html').unlink()
-
-
-@pytest.mark.slow
-def test_visualize_word_emeddings(resources_path):
-
-    with open(resources_path / 'visual/snippet.txt') as f:
-        sentences = [x for x in f.read().split('\n') if x]
-
-    sentences = [Sentence(x) for x in sentences]
-
-    charlm_embedding_forward = FlairEmbeddings('news-forward')
-
-    visualizer = Visualizer()
-    visualizer.visualize_char_emeddings(charlm_embedding_forward, sentences, str(resources_path / 'visual/sentence_embeddings.html'))
-
-    # clean up directory
-    (resources_path / 'visual/sentence_embeddings.html').unlink()
+# @pytest.mark.slow
+# def test_visualize_word_emeddings(resources_path):
+#
+#     with open(resources_path / 'visual/snippet.txt') as f:
+#         sentences = [x for x in f.read().split('\n') if x]
+#
+#     sentences = [Sentence(x) for x in sentences]
+#
+#     charlm_embedding_forward = FlairEmbeddings('news-forward')
+#     charlm_embedding_backward = FlairEmbeddings('news-backward')
+#
+#     embeddings = StackedEmbeddings([charlm_embedding_backward, charlm_embedding_forward])
+#
+#     visualizer = Visualizer()
+#     visualizer.visualize_word_emeddings(embeddings, sentences, str(resources_path / 'visual/sentence_embeddings.html'))
+#
+#     # clean up directory
+#     (resources_path / 'visual/sentence_embeddings.html').unlink()
 
 
-@pytest.mark.slow
-def test_visualize(resources_path):
-
-    with open(resources_path / 'visual/snippet.txt') as f:
-        sentences = [x for x in f.read().split('\n') if x]
-
-    sentences = [Sentence(x) for x in sentences]
-
-    embeddings = FlairEmbeddings('news-forward')
-
-    visualizer = Visualizer()
-
-    X_forward = visualizer.prepare_char_embeddings(embeddings, sentences)
-
-    embeddings = FlairEmbeddings('news-backward')
-
-    X_backward = visualizer.prepare_char_embeddings(embeddings, sentences)
-
-    X = numpy.concatenate([X_forward, X_backward], axis=1)
-
-    contexts = visualizer.char_contexts(sentences)
-
-    trans_ = tSNE()
-    reduced = trans_.fit(X)
-
-    visualizer.visualize(reduced, contexts, str(resources_path / 'visual/char_embeddings.html'))
-
-    # clean up directory
-    (resources_path / 'visual/char_embeddings.html').unlink()
+# @pytest.mark.slow
+# def test_visualize_word_emeddings(resources_path):
+#
+#     with open(resources_path / 'visual/snippet.txt') as f:
+#         sentences = [x for x in f.read().split('\n') if x]
+#
+#     sentences = [Sentence(x) for x in sentences]
+#
+#     charlm_embedding_forward = FlairEmbeddings('news-forward')
+#
+#     visualizer = Visualizer()
+#     visualizer.visualize_char_emeddings(charlm_embedding_forward, sentences, str(resources_path / 'visual/sentence_embeddings.html'))
+#
+#     # clean up directory
+#     (resources_path / 'visual/sentence_embeddings.html').unlink()
+#
+#
+# @pytest.mark.slow
+# def test_visualize(resources_path):
+#
+#     with open(resources_path / 'visual/snippet.txt') as f:
+#         sentences = [x for x in f.read().split('\n') if x]
+#
+#     sentences = [Sentence(x) for x in sentences]
+#
+#     embeddings = FlairEmbeddings('news-forward')
+#
+#     visualizer = Visualizer()
+#
+#     X_forward = visualizer.prepare_char_embeddings(embeddings, sentences)
+#
+#     embeddings = FlairEmbeddings('news-backward')
+#
+#     X_backward = visualizer.prepare_char_embeddings(embeddings, sentences)
+#
+#     X = numpy.concatenate([X_forward, X_backward], axis=1)
+#
+#     contexts = visualizer.char_contexts(sentences)
+#
+#     trans_ = tSNE()
+#     reduced = trans_.fit(X)
+#
+#     visualizer.visualize(reduced, contexts, str(resources_path / 'visual/char_embeddings.html'))
+#
+#     # clean up directory
+#     (resources_path / 'visual/char_embeddings.html').unlink()
 
 
 def test_highlighter(resources_path):


### PR DESCRIPTION
closes #387 

This PR adds a fix for retrieving embeddings from a character LM for long sequences. The idea is to chop long sequences into chunks and push each chunk through the LM, while always remembering the last hidden state as new initial hidden state. This lowers memory requirements (shorter sequences at once) but increases runtime (more calls to RNN).

In detail: 

- `LanugageModel.get_representation()` and `FlairEmbeddings` now have the `chars_per_chunk` parameter that defaults to 512. Lowering this parameter reduces memory but increases runtime. 

- `LanguageModelTrainer` can now shuffle sentences in each split

- Deprecated `DocumentMeanEmbeddings` removed, as well as most mentions of deprecated `CharLMEmbeddings`

- Removed slow unit tests