### PR TITLE
GH-446: introduce version number

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -7,6 +7,7 @@ from . import trainers
 
 import logging.config
 
+__version__ = "0.4.1"
 
 logging.config.dictConfig({
     'version': 1,


### PR DESCRIPTION
Hi,

this PR adds version number to `__init__.py`, so it can be retrieved by `flair.__version__`.

I set the version number to the upcoming *0.4.1* release.

Closes #446 :)