### PR TITLE
GH-462: fix cuda unit tests

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1522,10 +1522,10 @@ class DocumentLSTMEmbeddings(DocumentEmbeddings):
             for add in range(longest_token_sequence_in_batch - len(sentence.tokens)):
                 word_embeddings.append(
                     torch.zeros(self.length_of_all_token_embeddings,
-                                dtype=torch.float, device=flair.device).unsqueeze(0)
+                                dtype=torch.float).unsqueeze(0)
                 )
 
-            word_embeddings_tensor = torch.cat(word_embeddings, 0)
+            word_embeddings_tensor = torch.cat(word_embeddings, 0).to(flair.device)
 
             sentence_states = word_embeddings_tensor
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -56,7 +56,7 @@ class TextClassifier(flair.nn.Model):
         self.document_embeddings.embed(sentences)
 
         text_embedding_list = [sentence.get_embedding().unsqueeze(0) for sentence in sentences]
-        text_embedding_tensor = torch.cat(text_embedding_list, 0)
+        text_embedding_tensor = torch.cat(text_embedding_list, 0).to(flair.device)
 
         label_scores = self.decoder(text_embedding_tensor)
 

--- a/flair/visual/activations.py
+++ b/flair/visual/activations.py
@@ -33,8 +33,7 @@ class Highlighter(object):
         ]
 
     def highlight(self, activation, text):
-
-        activation = activation.detach().numpy()
+        activation = activation.detach().cpu().numpy()
 
         step_size = (max(activation) - min(activation)) / len(self.color_map)
 

--- a/tests/test_data_fetchers.py
+++ b/tests/test_data_fetchers.py
@@ -7,7 +7,7 @@ from flair.data_fetcher import NLPTask, NLPTaskDataFetcher
 
 def test_load_imdb_data(tasks_base_path):
     # get training, test and dev data
-    corpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB, tasks_base_path)
+    corpus = NLPTaskDataFetcher.load_corpus('imdb', tasks_base_path)
 
     assert len(corpus.train) == 5
     assert len(corpus.dev) == 5

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -30,7 +30,7 @@ def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
     search_space.add(Parameter.RNN_LAYERS, hp.choice, options=[1, 2])
 
     # model trainer parameter
-    search_space.add(Parameter.OPTIMIZER, hp.choice, options=[SGD, AdamW])
+    search_space.add(Parameter.OPTIMIZER, hp.choice, options=[SGD])
 
     # training parameter
     search_space.add(Parameter.MINI_BATCH_SIZE, hp.choice, options=[4, 8, 32])

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -49,7 +49,7 @@ def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
 
 @pytest.mark.integration
 def test_text_classifier_param_selector(results_base_path, tasks_base_path):
-    corpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB, base_path=tasks_base_path)
+    corpus = NLPTaskDataFetcher.load_corpus('imdb', base_path=tasks_base_path)
 
     glove_embedding: WordEmbeddings = WordEmbeddings('en-glove')
 

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -26,7 +26,7 @@ def test_sequence_tagger_param_selector(results_base_path, tasks_base_path):
     search_space.add(Parameter.DROPOUT, hp.uniform, low=0.25, high=0.75)
     search_space.add(Parameter.WORD_DROPOUT, hp.uniform, low=0.0, high=0.25)
     search_space.add(Parameter.LOCKED_DROPOUT, hp.uniform, low=0.0, high=0.5)
-    search_space.add(Parameter.HIDDEN_SIZE, hp.choice, options=[64, 128, 256, 512])
+    search_space.add(Parameter.HIDDEN_SIZE, hp.choice, options=[64, 128])
     search_space.add(Parameter.RNN_LAYERS, hp.choice, options=[1, 2])
 
     # model trainer parameter
@@ -60,7 +60,7 @@ def test_text_classifier_param_selector(results_base_path, tasks_base_path):
     search_space.add(Parameter.HIDDEN_SIZE, hp.choice, options=[64, 128, 256, 512])
     search_space.add(Parameter.RNN_LAYERS, hp.choice, options=[1, 2])
     search_space.add(Parameter.REPROJECT_WORDS, hp.choice, options=[True, False])
-    search_space.add(Parameter.REPROJECT_WORD_DIMENSION, hp.choice, options=[64, 128, 256, 512])
+    search_space.add(Parameter.REPROJECT_WORD_DIMENSION, hp.choice, options=[64, 128])
     search_space.add(Parameter.BIDIRECTIONAL, hp.choice, options=[True, False])
     search_space.add(Parameter.DROPOUT, hp.uniform, low=0.25, high=0.75)
     search_space.add(Parameter.WORD_DROPOUT, hp.uniform, low=0.25, high=0.75)

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import pytest
+from torch.optim import SGD
 
 from torch.optim.optimizer import Optimizer
 from torch.optim.adam import Adam
@@ -272,7 +273,7 @@ def test_find_learning_rate(results_base_path, tasks_base_path):
                                             tag_type='ner',
                                             use_crf=False)
 
-    optimizer: Optimizer = AdamW
+    optimizer: Optimizer = SGD
 
     # initialize trainer
     trainer: ModelTrainer = ModelTrainer(tagger, corpus, optimizer=optimizer)

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -23,7 +23,7 @@ def test_train_load_use_tagger(results_base_path, tasks_base_path):
 
     embeddings = WordEmbeddings('glove')
 
-    tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+    tagger: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='ner',
@@ -56,7 +56,7 @@ def test_train_load_use_tagger_large(results_base_path, tasks_base_path):
 
     embeddings = WordEmbeddings('glove')
 
-    tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+    tagger: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='pos',
@@ -89,7 +89,7 @@ def test_train_charlm_load_use_tagger(results_base_path, tasks_base_path):
 
     embeddings = FlairEmbeddings('news-forward-fast')
 
-    tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+    tagger: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='ner',
@@ -125,7 +125,7 @@ def test_train_charlm_changed_chache_load_use_tagger(results_base_path, tasks_ba
     os.makedirs(cache_dir, exist_ok=True)
     embeddings = FlairEmbeddings('news-forward-fast', cache_directory=cache_dir)
 
-    tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+    tagger: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='ner',
@@ -161,7 +161,7 @@ def test_train_charlm_nochache_load_use_tagger(results_base_path, tasks_base_pat
 
     embeddings = FlairEmbeddings('news-forward-fast', use_cache=False)
 
-    tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+    tagger: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='ner',
@@ -194,7 +194,7 @@ def test_train_optimizer(results_base_path, tasks_base_path):
 
     embeddings = WordEmbeddings('glove')
 
-    tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+    tagger: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='ner',
@@ -230,7 +230,7 @@ def test_train_optimizer_arguments(results_base_path, tasks_base_path):
 
     embeddings = WordEmbeddings('glove')
 
-    tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+    tagger: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='ner',
@@ -266,7 +266,7 @@ def test_find_learning_rate(results_base_path, tasks_base_path):
 
     embeddings = WordEmbeddings('glove')
 
-    tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+    tagger: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='ner',
@@ -453,7 +453,7 @@ def test_train_load_use_tagger_multicorpus(results_base_path, tasks_base_path):
 
     embeddings = WordEmbeddings('glove')
 
-    tagger: SequenceTagger = SequenceTagger(hidden_size=256,
+    tagger: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='ner',
@@ -504,7 +504,7 @@ def test_train_resume_sequence_tagging_training(results_base_path, tasks_base_pa
 
     embeddings = WordEmbeddings('glove')
 
-    model: SequenceTagger = SequenceTagger(hidden_size=256,
+    model: SequenceTagger = SequenceTagger(hidden_size=64,
                                             embeddings=embeddings,
                                             tag_dictionary=tag_dictionary,
                                             tag_type='ner',

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -308,7 +308,7 @@ def test_load_use_serialized_tagger():
 @pytest.mark.integration
 def test_train_load_use_classifier(results_base_path, tasks_base_path):
 
-    corpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB, base_path=tasks_base_path)
+    corpus = NLPTaskDataFetcher.load_corpus('imdb', base_path=tasks_base_path)
     label_dict = corpus.make_label_dictionary()
 
     glove_embedding: WordEmbeddings = WordEmbeddings('en-glove')
@@ -344,7 +344,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
 @pytest.mark.integration
 def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
 
-    corpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB, base_path=tasks_base_path)
+    corpus = NLPTaskDataFetcher.load_corpus('imdb', base_path=tasks_base_path)
     label_dict = corpus.make_label_dictionary()
 
     glove_embedding: TokenEmbeddings = FlairEmbeddings('news-forward-fast')
@@ -380,7 +380,7 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
 @pytest.mark.integration
 def test_train_charlm_nocache_load_use_classifier(results_base_path, tasks_base_path):
 
-    corpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB, base_path=tasks_base_path)
+    corpus = NLPTaskDataFetcher.load_corpus('imdb', base_path=tasks_base_path)
     label_dict = corpus.make_label_dictionary()
 
     glove_embedding: TokenEmbeddings = FlairEmbeddings('news-forward-fast', use_cache=False)
@@ -479,7 +479,7 @@ def test_train_load_use_tagger_multicorpus(results_base_path, tasks_base_path):
 
 @pytest.mark.integration
 def test_train_resume_text_classification_training(results_base_path, tasks_base_path):
-    corpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB, base_path=tasks_base_path)
+    corpus = NLPTaskDataFetcher.load_corpus('imdb', base_path=tasks_base_path)
     label_dict = corpus.make_label_dictionary()
 
     embeddings: TokenEmbeddings = FlairEmbeddings('news-forward-fast', use_cache=False)


### PR DESCRIPTION
closes #462 

A number of smallish bug fixes. Fixes some CUDA operations and makes sure that the test IMDB dataset is used in unit tests instead of the full dataset (this was leading to timeouts).