### PR TITLE
make sure evaluation is not performed over self.corpus.test if this doesn't contain any Sentence

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -177,6 +177,7 @@ class ModelTrainer:
                 dev_loss = '_'
 
                 train_metric = None
+                test_metric = None
                 if monitor_train:
                     train_metric, train_loss = self._calculate_evaluation_results_for(
                         'TRAIN', self.corpus.train, evaluation_metric, embeddings_in_memory, eval_mini_batch_size)
@@ -185,7 +186,7 @@ class ModelTrainer:
                     dev_metric, dev_loss = self._calculate_evaluation_results_for(
                         'DEV', self.corpus.dev, evaluation_metric, embeddings_in_memory, eval_mini_batch_size)
 
-                if not param_selection_mode:
+                if not param_selection_mode and self.corpus.test:
                     test_metric, test_loss = self._calculate_evaluation_results_for(
                         'TEST', self.corpus.test, evaluation_metric, embeddings_in_memory, eval_mini_batch_size,
                         base_path / 'test.tsv')


### PR DESCRIPTION
@alanakbik regarding my latest PR there were two more small changes that needed to be made in order to make sure that the evaluation is not called on over `self.corpus.test` if this is an empty list.