### PR TITLE
GH-461: mention IMDB data fetcher in documentation

### DIFF
--- a/resources/docs/TUTORIAL_6_CORPUS.md
+++ b/resources/docs/TUTORIAL_6_CORPUS.md
@@ -104,6 +104,12 @@ corpus: TaggedCorpus = NLPTaskDataFetcher.load_classification_corpus(data_folder
 If you just want to read a single file, you can use 
 `NLPTaskDataFetcher.read_text_classification_file('path/to/file.txt)`, which returns a list of `Sentence` objects.
 
+**Notice**: In order to download and preprocess the IMDB dataset automatically, you can use the `load_corpus()` method
+that will execute all necessary steps to get a `flair` compatible text classification format:
+
+```python
+corpus: TaggedCorpus = NLPTaskDataFetcher.load_corpus(NLPTask.IMDB)
+```
 
 ## Downloading A Dataset
 


### PR DESCRIPTION
Hi,

this PR extends the text classification dataset section for IMDB and adds the possibility to use the recently introduced data fetcher (#410) to download and preprocess the IMDB dataset automatically.

Closes #461 :)