### PR TITLE
GH-482: fix CUDA error with CharacterEmbeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -508,8 +508,9 @@ class CharacterEmbeddings(TokenEmbeddings):
             longest_token_in_sentence = max(chars2_length)
             tokens_mask = torch.zeros((len(tokens_sorted_by_length), longest_token_in_sentence),
                                       dtype=torch.long, device=flair.device)
+            
             for i, c in enumerate(tokens_sorted_by_length):
-                tokens_mask[i, :chars2_length[i]] = c
+                tokens_mask[i, :chars2_length[i]] = torch.tensor(c, dtype=torch.long, device=flair.device)
 
             # chars for rnn processing
             chars = tokens_mask


### PR DESCRIPTION
the new CUDA semantics introduced an error with CharacterEmbeddings (see #482)

This PR fixes this error.