### PR TITLE
GH-504: workaround for serialization of BPEmb object

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1,3 +1,4 @@
+import os
 import re
 import logging
 from abc import abstractmethod
@@ -253,13 +254,31 @@ class BPEmbSerializable(BPEmb):
 
     def __getstate__(self):
         state = self.__dict__.copy()
+        # save the sentence piece model as binary file (not as path which may change)
+        state['spm_model_binary'] = open(self.model_file, mode='rb').read()
         state['spm'] = None
         return state
 
     def __setstate__(self, state):
         from bpemb.util import sentencepiece_load
-        state['spm'] = sentencepiece_load(state['model_file'])
+        model_file = self.model_tpl.format(lang=state['lang'], vs=state['vs'])
         self.__dict__ = state
+
+        # write out the binary sentence piece model into the expected directory
+        self.cache_dir: Path = Path(flair.file_utils.CACHE_ROOT) / 'embeddings'
+        if 'spm_model_binary' in self.__dict__:
+            # if the model was saved as binary and it is not found on disk, write to appropriate path
+            if not os.path.exists(self.cache_dir / state['lang']):
+                os.makedirs(self.cache_dir / state['lang'])
+            self.model_file = self.cache_dir / model_file
+            with open(self.model_file, 'wb') as out:
+                out.write(self.__dict__['spm_model_binary'])
+        else:
+            # otherwise, use normal process and potentially trigger another download
+            self.model_file = self._load_file(model_file)
+
+        # once the modes if there, load it with sentence piece
+        state['spm'] = sentencepiece_load(self.model_file)
 
 
 class BytePairEmbeddings(TokenEmbeddings):


### PR DESCRIPTION
closes #504 

Workaround in which the sentence piece model is serialized as a binary that is written to the appropriate folder if missing.