### PR TITLE
GH-498: sentence perplexity

### DIFF
--- a/tests/test_language_model.py
+++ b/tests/test_language_model.py
@@ -29,3 +29,34 @@ def test_generate_text_with_small_temperatures():
     text, likelihood = language_model.generate_text(temperature=0.01, number_of_characters=100)
     assert (text is not None)
     assert (len(text) >= 100)
+
+
+def test_compute_perplexity():
+
+    from flair.embeddings import FlairEmbeddings
+
+    language_model = FlairEmbeddings('news-forward-fast').lm
+
+    grammatical = 'The company made a profit'
+    perplexity_gramamtical_sentence = language_model.calculate_perplexity(grammatical)
+
+    ungrammatical = 'Nook negh qapla!'
+    perplexity_ungramamtical_sentence = language_model.calculate_perplexity(ungrammatical)
+
+    print(f'"{grammatical}" - perplexity is {perplexity_gramamtical_sentence}')
+    print(f'"{ungrammatical}" - perplexity is {perplexity_ungramamtical_sentence}')
+
+    assert (perplexity_gramamtical_sentence < perplexity_ungramamtical_sentence)
+
+    language_model = FlairEmbeddings('news-backward-fast').lm
+
+    grammatical = 'The company made a profit'
+    perplexity_gramamtical_sentence = language_model.calculate_perplexity(grammatical)
+
+    ungrammatical = 'Nook negh qapla!'
+    perplexity_ungramamtical_sentence = language_model.calculate_perplexity(ungrammatical)
+
+    print(f'"{grammatical}" - perplexity is {perplexity_gramamtical_sentence}')
+    print(f'"{ungrammatical}" - perplexity is {perplexity_ungramamtical_sentence}')
+
+    assert (perplexity_gramamtical_sentence < perplexity_ungramamtical_sentence)


### PR DESCRIPTION
closes #498 

to calculate perplexity using a language model do this: 

```python
from flair.embeddings import FlairEmbeddings

# get language model
language_model = FlairEmbeddings('news-forward-fast').lm

# calculate perplexity for grammatical sentence
grammatical = 'The company made a profit'
perplexity_gramamtical_sentence = language_model.calculate_perplexity(grammatical)

# calculate perplexity for ungrammatical sentence
ungrammatical = 'Nook negh qapla!'
perplexity_ungramamtical_sentence = language_model.calculate_perplexity(ungrammatical)

# print both
print(f'"{grammatical}" - perplexity is {perplexity_gramamtical_sentence}')
print(f'"{ungrammatical}" - perplexity is {perplexity_ungramamtical_sentence}')
```
