### PR TITLE
Fix #565 by raising an Exception for an empty String

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -323,6 +323,9 @@ class Sentence:
 
             # otherwise assumes whitespace tokenized text
             else:
+                # catch the empty string case
+                if not text:
+                    raise ValueError("Cannot convert empty string to a Sentence object.")
                 # add each word in tokenized string as Token object to Sentence
                 word = ''
                 for index, char in enumerate(text):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -22,6 +22,13 @@ def test_get_head():
     assert (token1 == token2.get_head())
     assert (None == token1.get_head())
 
+def test_create_sentence_on_empty_string():
+
+    with pytest.raises(ValueError) as e:
+        sentence: Sentence = Sentence('')
+
+        assert (e.type is ValueError)
+        assert (e.value.args[0] == "Cannot convert empty string to a Sentence object.")
 
 def test_create_sentence_without_tokenizer():
     sentence: Sentence = Sentence('I love Berlin.')


### PR DESCRIPTION
Fix #565 by raising a `ValueError` for an empty string.