### PR TITLE
Replace instances of DocumentLSTMEmbeddings with DocumentRNNEmbeddings

### DIFF
--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -19,7 +19,7 @@ log = logging.getLogger('flair')
 class TextClassifier(flair.nn.Model):
     """
     Text Classification Model
-    The model takes word embeddings, puts them into an LSTM to obtain a text representation, and puts the
+    The model takes word embeddings, puts them into an RNN to obtain a text representation, and puts the
     text representation in the end into a linear layer to get the actual class label.
     The model can handle single and multi class data sets.
     """
@@ -31,7 +31,7 @@ class TextClassifier(flair.nn.Model):
 
         super(TextClassifier, self).__init__()
 
-        self.document_embeddings: flair.embeddings.DocumentLSTMEmbeddings = document_embeddings
+        self.document_embeddings: flair.embeddings.DocumentRNNEmbeddings = document_embeddings
         self.label_dictionary: Dictionary = label_dictionary
         self.multi_label = multi_label
 

--- a/resources/docs/TUTORIAL_7_TRAINING_A_MODEL.md
+++ b/resources/docs/TUTORIAL_7_TRAINING_A_MODEL.md
@@ -105,7 +105,7 @@ embeddings and Flair embeddings. In this example, we downsample the data to 10% 
 ```python
 from flair.data import TaggedCorpus
 from flair.data_fetcher import NLPTaskDataFetcher, NLPTask
-from flair.embeddings import WordEmbeddings, FlairEmbeddings, DocumentLSTMEmbeddings
+from flair.embeddings import WordEmbeddings, FlairEmbeddings, DocumentRNNEmbeddings
 from flair.models import TextClassifier
 from flair.trainers import ModelTrainer
 
@@ -125,7 +125,8 @@ word_embeddings = [WordEmbeddings('glove'),
                    ]
 
 # 4. initialize document embedding by passing list of word embeddings
-document_embeddings: DocumentLSTMEmbeddings = DocumentLSTMEmbeddings(word_embeddings,
+# Can choose between many RNN types (GRU by default, to change use rnn_type parameter)
+document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(word_embeddings,
                                                                      hidden_size=512,
                                                                      reproject_words=True,
                                                                      reproject_words_dimension=256,


### PR DESCRIPTION
Replaced some instances of `DocumentLSTMEmbeddings` with `DocumentRNNEmbeddings` to update the [tutorial](https://github.com/zalandoresearch/flair/blob/master/resources/docs/TUTORIAL_7_TRAINING_A_MODEL.md#tutorial-7-training-a-model) with respect to the new release 0.4.1