### PR TITLE
GH-547: introduce OpenAI GPT embeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -591,6 +591,9 @@ class OpenAIGPTEmbeddings(TokenEmbeddings):
                     if self.pooling_operation == 'first':
                         # Use embedding of first subword
                         token.set_embedding(self.name, hidden_states[0][0])
+                    elif self.pooling_operation == 'last':
+                        last_embedding = hidden_states[0][len(hidden_states[0]) - 1]
+                        token.set_embedding(self.name, last_embedding)
                     elif self.pooling_operation == 'first_last':
                         # Use embedding of first and last subword
                         first_embedding = hidden_states[0][0]

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -11,10 +11,11 @@ import torch
 from bpemb import BPEmb
 from deprecated import deprecated
 
-from pytorch_pretrained_bert import BertTokenizer, BertModel, TransfoXLTokenizer, TransfoXLModel
+from pytorch_pretrained_bert import BertTokenizer, BertModel, TransfoXLTokenizer, TransfoXLModel,\
+    OpenAIGPTModel, OpenAIGPTTokenizer
 
-from pytorch_pretrained_bert.modeling import \
-    PRETRAINED_MODEL_ARCHIVE_MAP as BERT_PRETRAINED_MODEL_ARCHIVE_MAP
+from pytorch_pretrained_bert.modeling_openai import \
+    PRETRAINED_MODEL_ARCHIVE_MAP as OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_MAP
 
 from pytorch_pretrained_bert.modeling_transfo_xl import \
             PRETRAINED_MODEL_ARCHIVE_MAP as TRANSFORMER_XL_PRETRAINED_MODEL_ARCHIVE_MAP
@@ -535,6 +536,72 @@ class TransformerXLEmbeddings(TokenEmbeddings):
                 for token, token_idx in zip(sentence.tokens, range(len(sentence.tokens))):
                     token: Token = token
                     token.set_embedding(self.name, hidden_states[0][token_idx])
+
+        return sentences
+
+    def extra_repr(self):
+        return 'model={}'.format(self.name)
+
+    def __str__(self):
+        return self.name
+
+
+class OpenAIGPTEmbeddings(TokenEmbeddings):
+    def __init__(self, model: str = 'openai-gpt', pooling_operation: str = 'first_last'):
+        """OpenAI GPT embeddings, as proposed in Radford et al. 2018.
+        :param model: name of OpenAI GPT model
+        :param pooling_operation: defines pooling operation for subwords
+        """
+        super().__init__()
+
+        if model not in OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_MAP.keys():
+            raise ValueError('Provided OpenAI GPT model is not available.')
+
+        self.tokenizer = OpenAIGPTTokenizer.from_pretrained(model)
+        self.model = OpenAIGPTModel.from_pretrained(model)
+        self.name = model
+        self.static_embeddings = True
+        self.pooling_operation = pooling_operation
+
+        dummy_sentence: Sentence = Sentence()
+        dummy_sentence.add_token(Token('hello'))
+        embedded_dummy = self.embed(dummy_sentence)
+        self.__embedding_length: int = len(embedded_dummy[0].get_token(1).get_embedding())
+
+    @property
+    def embedding_length(self) -> int:
+        return self.__embedding_length
+
+    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+        self.model.to(flair.device)
+        self.model.eval()
+
+        with torch.no_grad():
+            for sentence in sentences:
+                for token in sentence.tokens:
+                    token_text = token.text
+
+                    subwords = self.tokenizer.tokenize(token_text)
+                    indexed_tokens = self.tokenizer.convert_tokens_to_ids(subwords)
+                    tokens_tensor = torch.tensor([indexed_tokens])
+                    tokens_tensor = tokens_tensor.to(flair.device)
+
+                    hidden_states = self.model(tokens_tensor)
+
+                    if self.pooling_operation == 'first':
+                        # Use embedding of first subword
+                        token.set_embedding(self.name, hidden_states[0][0])
+                    elif self.pooling_operation == 'first_last':
+                        # Use embedding of first and last subword
+                        first_embedding = hidden_states[0][0]
+                        last_embedding = hidden_states[0][len(hidden_states[0]) - 1]
+                        final_embedding = torch.cat([first_embedding, last_embedding])
+                        token.set_embedding(self.name, final_embedding)
+                    else:
+                        # Otherwise, use mean over all subwords in token
+                        all_embeddings = [embedding.unsqueeze(0) for embedding in hidden_states[0]]
+                        mean = torch.mean(torch.cat(all_embeddings, dim=0), dim=0)
+                        token.set_embedding(self.name, mean)
 
         return sentences
 


### PR DESCRIPTION
Hi,

this PR finally introduces embeddings from the OpenAI GPT model. It uses the excellent [pytorch-pretrained-BERT](https://github.com/huggingface/pytorch-pretrained-BERT) library to download the GPT model, tokenize the input and extract embeddings from the subtokens.

For example the input token `puppeteer` will be tokenized into three subwords: `pupp`, `ete` and `er</w>`. I implemented four approaches to get embeddings from a token:

* Use the first subword from a token
* Use the last subword from a token
* Use the first and last subword from a token
* Use mean of all subwords

Here's a short benchmark on CoNLL-2003 NER for English, using only GPT embeddings (and no other embeddings like word embeddings):

| Pooling strategy | F1-Score
| -------------------- | -------------
| `first`                  | 77.53%
| `last`                  | 81.38%
| `first_last`          | 81.67%
| `mean`              | 81.46%

# Example

Here is a code snippet to train a model on CoNLL-2003 dataset with GPT embeddings:

```python
from typing import List

from flair.data import TaggedCorpus
from flair.data_fetcher import NLPTaskDataFetcher, NLPTask
from flair.embeddings import OpenAIGPTEmbeddings, StackedEmbeddings, TokenEmbeddings

corpus: TaggedCorpus = NLPTaskDataFetcher.load_corpus(NLPTask.CONLL_03)

tag_type = 'ner'
tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)

print(corpus.obtain_statistics())

embedding_types: List[TokenEmbeddings] = [
    OpenAIGPTEmbeddings()
]

embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)

from flair.models import SequenceTagger

tagger: SequenceTagger = SequenceTagger(hidden_size=512,
                                        embeddings=embeddings,
                                        tag_dictionary=tag_dictionary,
                                        tag_type=tag_type,
                                        use_crf=True)

from flair.trainers import ModelTrainer
from flair.training_utils import EvaluationMetric

trainer: ModelTrainer = ModelTrainer(tagger, corpus)

trainer.train('resources/taggers/ner-english-gpt',
              EvaluationMetric.MICRO_F1_SCORE,
              learning_rate=0.1,
              mini_batch_size=8,
              max_epochs=500)
```

To use different pooling strategies, just use the `pooling_operation` argument:

```python
OpenAIGPTEmbeddings(pooling_operation: str = 'first_last') # Use first and last subword from token
OpenAIGPTEmbeddings(pooling_operation: str = 'last') # Use only last subword from token
OpenAIGPTEmbeddings(pooling_operation: str = 'first') # Use only first subword from token
OpenAIGPTEmbeddings(pooling_operation: str = 'mean') # Use mean of all subwords from token
```