### PR TITLE
GH-620: cuda fix for PooledFlairEmbeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1021,6 +1021,7 @@ class PooledFlairEmbeddings(TokenEmbeddings):
 
                 # update embedding
                 local_embedding = token._embeddings[self.context_embeddings.name]
+                local_embedding = local_embedding.to(flair.device)
 
                 if token.text[0].isupper() or not self.only_capitalized:
 


### PR DESCRIPTION
Hi,

this PR fixes a `expected type torch.cuda.FloatTensor but got torch.FloatTensor` error when training and testing the recently introduced `PooledFlairEmbeddings` on GPU.

Fixes #620.