### PR TITLE
Small fix for training example script

### DIFF
--- a/train.py
+++ b/train.py
@@ -11,7 +11,7 @@ corpus: TaggedCorpus = NLPTaskDataFetcher.load_corpus(NLPTask.UD_ENGLISH)
 print(corpus)
 
 # 2. what tag do we want to predict?
-tag_type = 'pos'
+tag_type = 'upos'
 
 # 3. make the tag dictionary from the corpus
 tag_dictionary = corpus.make_tag_dictionary(tag_type=tag_type)


### PR DESCRIPTION
Hi,

this PR fixes the training example script. The current `train.py` example script trains a model on English Universal Dependencies using the `pos` tag type. But that tag type is not correct for Universal Dependencies, because `upos` (indicating universal part-of-speech tags) should be used instead.

See also [CoNLL-U](https://universaldependencies.org/format.html) format description.