### PR TITLE
GH-605: add softmax to single label classification for confidence score

### DIFF
--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -252,7 +252,8 @@ class TextClassifier(flair.nn.Model):
         return labels
 
     def _get_single_label(self, label_scores) -> List[Label]:
-        conf, idx = torch.max(label_scores, 0)
+        softmax = torch.nn.functional.softmax(label_scores, dim=0)
+        conf, idx = torch.max(softmax, 0)
         label = self.label_dictionary.get_item_for_index(idx.item())
 
         return [Label(label, conf.item())]


### PR DESCRIPTION
closes #605 

Adds a softmax layer to get confidence scores for predictions in the `TextClassifier`.