### PR TITLE
GH-464: fix text generation on cuda:1

### DIFF
--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -273,9 +273,7 @@ class LanguageModel(nn.Module):
                         .unsqueeze(0)
                     )
 
-                input = torch.cat(char_tensors)
-                if torch.cuda.is_available():
-                    input = input.cuda()
+                input = torch.cat(char_tensors).to(flair.device)
 
                 prediction, _, hidden = self.forward(input, hidden)
 
@@ -289,8 +287,7 @@ class LanguageModel(nn.Module):
 
             for i in range(number_of_characters):
 
-                if torch.cuda.is_available():
-                    input = input.cuda()
+                input = input.to(flair.device)
 
                 # get predicted weights
                 prediction, _, hidden = self.forward(input, hidden)


### PR DESCRIPTION
#closes 464 

The `generate_text` method still used the `.cuda()` method to put tensors on GPU instead of `.to(device)`, defaulting on cuda:0. This causes errors if run in a process on another GPU, such as cuda:1. This PR fixes this.