### PR TITLE
GH-507: make cache_root a global variable

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -1,4 +1,15 @@
 import torch
+import os
+
+# global variable: cache_root
+cache_root = os.path.expanduser(os.path.join("~", ".flair"))
+
+# global variable: device
+device = None
+if torch.cuda.is_available():
+    device = torch.device("cuda:0")
+else:
+    device = torch.device("cpu")
 
 from . import data
 from . import models
@@ -30,10 +41,3 @@ logging.config.dictConfig(
 )
 
 logger = logging.getLogger("flair")
-
-
-device = None
-if torch.cuda.is_available():
-    device = torch.device("cuda:0")
-else:
-    device = torch.device("cpu")

--- a/flair/data_fetcher.py
+++ b/flair/data_fetcher.py
@@ -95,7 +95,7 @@ class NLPTask(Enum):
     TREC_50 = "trec-50"
 
     # text regression format
-    REGRESSION = 'regression'
+    REGRESSION = "regression"
 
 
 class NLPTaskDataFetcher:
@@ -127,7 +127,7 @@ class NLPTaskDataFetcher:
 
         # default dataset folder is the cache root
         if not base_path:
-            base_path = Path(flair.file_utils.CACHE_ROOT) / "datasets"
+            base_path = Path(flair.cache_root) / "datasets"
 
         if type(base_path) == str:
             base_path: Path = Path(base_path)
@@ -622,12 +622,7 @@ class NLPTaskDataFetcher:
         # conll 2000 chunking task
         if task == NLPTask.CONLL_2000:
             conll_2000_path = "https://www.clips.uantwerpen.be/conll2000/chunking/"
-            data_file = (
-                Path(flair.file_utils.CACHE_ROOT)
-                / "datasets"
-                / task.value
-                / "train.txt"
-            )
+            data_file = Path(flair.cache_root) / "datasets" / task.value / "train.txt"
             if not data_file.is_file():
                 cached_path(
                     f"{conll_2000_path}train.txt.gz", Path("datasets") / task.value
@@ -638,39 +633,27 @@ class NLPTaskDataFetcher:
                 import gzip, shutil
 
                 with gzip.open(
-                    Path(flair.file_utils.CACHE_ROOT)
-                    / "datasets"
-                    / task.value
-                    / "train.txt.gz",
+                    Path(flair.cache_root) / "datasets" / task.value / "train.txt.gz",
                     "rb",
                 ) as f_in:
                     with open(
-                        Path(flair.file_utils.CACHE_ROOT)
-                        / "datasets"
-                        / task.value
-                        / "train.txt",
+                        Path(flair.cache_root) / "datasets" / task.value / "train.txt",
                         "wb",
                     ) as f_out:
                         shutil.copyfileobj(f_in, f_out)
                 with gzip.open(
-                    Path(flair.file_utils.CACHE_ROOT)
-                    / "datasets"
-                    / task.value
-                    / "test.txt.gz",
+                    Path(flair.cache_root) / "datasets" / task.value / "test.txt.gz",
                     "rb",
                 ) as f_in:
                     with open(
-                        Path(flair.file_utils.CACHE_ROOT)
-                        / "datasets"
-                        / task.value
-                        / "test.txt",
+                        Path(flair.cache_root) / "datasets" / task.value / "test.txt",
                         "wb",
                     ) as f_out:
                         shutil.copyfileobj(f_in, f_out)
 
         if task == NLPTask.NER_BASQUE:
             ner_basque_path = "http://ixa2.si.ehu.eus/eiec/"
-            data_path = Path(flair.file_utils.CACHE_ROOT) / "datasets" / task.value
+            data_path = Path(flair.cache_root) / "datasets" / task.value
             data_file = data_path / "named_ent_eu.train"
             if not data_file.is_file():
                 cached_path(
@@ -679,10 +662,7 @@ class NLPTaskDataFetcher:
                 import tarfile, shutil
 
                 with tarfile.open(
-                    Path(flair.file_utils.CACHE_ROOT)
-                    / "datasets"
-                    / task.value
-                    / "eiec_v1.0.tgz",
+                    Path(flair.cache_root) / "datasets" / task.value / "eiec_v1.0.tgz",
                     "r:gz",
                 ) as f_in:
                     corpus_files = (
@@ -697,14 +677,14 @@ class NLPTaskDataFetcher:
             imdb_acl_path = (
                 "http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"
             )
-            data_path = Path(flair.file_utils.CACHE_ROOT) / "datasets" / task.value
+            data_path = Path(flair.cache_root) / "datasets" / task.value
             data_file = data_path / "train.txt"
             if not data_file.is_file():
                 cached_path(imdb_acl_path, Path("datasets") / task.value)
                 import tarfile
 
                 with tarfile.open(
-                    Path(flair.file_utils.CACHE_ROOT)
+                    Path(flair.cache_root)
                     / "datasets"
                     / task.value
                     / "aclImdb_v1.tar.gz",
@@ -749,7 +729,7 @@ class NLPTaskDataFetcher:
                     Path("datasets") / task.value / "original",
                 )
 
-            data_path = Path(flair.file_utils.CACHE_ROOT) / "datasets" / task.value
+            data_path = Path(flair.cache_root) / "datasets" / task.value
             data_file = data_path / new_filenames[0]
 
             if not data_file.is_file():
@@ -816,7 +796,7 @@ class NLPTaskDataFetcher:
                 lc = "ru"
 
             data_file = (
-                Path(flair.file_utils.CACHE_ROOT)
+                Path(flair.cache_root)
                 / "datasets"
                 / task.value
                 / f"aij-wikiner-{lc}-wp3.train"
@@ -831,14 +811,14 @@ class NLPTaskDataFetcher:
 
                 # unpack and write out in CoNLL column-like format
                 bz_file = bz2.BZ2File(
-                    Path(flair.file_utils.CACHE_ROOT)
+                    Path(flair.cache_root)
                     / "datasets"
                     / task.value
                     / f"aij-wikiner-{lc}-wp3.bz2",
                     "rb",
                 )
                 with bz_file as f, open(
-                    Path(flair.file_utils.CACHE_ROOT)
+                    Path(flair.cache_root)
                     / "datasets"
                     / task.value
                     / f"aij-wikiner-{lc}-wp3.train",

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -349,7 +349,7 @@ class BPEmbSerializable(BPEmb):
         self.__dict__ = state
 
         # write out the binary sentence piece model into the expected directory
-        self.cache_dir: Path = Path(flair.file_utils.CACHE_ROOT) / "embeddings"
+        self.cache_dir: Path = Path(flair.cache_root) / "embeddings"
         if "spm_model_binary" in self.__dict__:
             # if the model was saved as binary and it is not found on disk, write to appropriate path
             if not os.path.exists(self.cache_dir / state["lang"]):
@@ -371,7 +371,7 @@ class BytePairEmbeddings(TokenEmbeddings):
         language: str,
         dim: int = 50,
         syllables: int = 100000,
-        cache_dir=Path(flair.file_utils.CACHE_ROOT) / "embeddings",
+        cache_dir=Path(flair.cache_root) / "embeddings",
     ):
         """
         Initializes BP embeddings. Constructor downloads required files if not there.

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -17,12 +17,9 @@ import zipfile
 import io
 
 # from allennlp.common.tqdm import Tqdm
-
+import flair
 
 logger = logging.getLogger("flair")
-
-
-CACHE_ROOT = os.path.expanduser(os.path.join("~", ".flair"))
 
 
 def load_big_file(f):
@@ -82,7 +79,7 @@ def cached_path(url_or_filename: str, cache_dir: Path) -> Path:
     return the path to the cached file. If it's already a local path,
     make sure the file exists and then return the path.
     """
-    dataset_cache = Path(CACHE_ROOT) / cache_dir
+    dataset_cache = Path(flair.cache_root) / cache_dir
 
     parsed = urlparse(url_or_filename)
 

--- a/tests/test_data_fetchers.py
+++ b/tests/test_data_fetchers.py
@@ -95,4 +95,4 @@ def test_download_load_data(tasks_base_path):
     assert len(corpus.test) == 2077
 
     # clean up data directory
-    shutil.rmtree(Path(flair.file_utils.CACHE_ROOT) / "datasets" / "ud_english")
+    shutil.rmtree(Path(flair.cache_root) / "datasets" / "ud_english")


### PR DESCRIPTION
closes #507 
closes #653

You can now specify the base cache directory, i.e. the directory to where all models/embeddings/datasets get downloaded. It defaults to .flair in your home folder, but you can override this by calling 

```python
import flair
flair.cache_root = 'my/cache/directory'
```

before calling your code.