### PR TITLE
Relax `regex` version in dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ deprecated>=1.2.4
 hyperopt>=0.1.1
 pytorch-pretrained-bert>=0.6.1
 bpemb>=0.2.9
-regex==2018.1.10
+regex

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "hyperopt>=0.1.1",
         "pytorch-pretrained-bert>=0.6.1",
         "bpemb>=0.2.9",
-        "regex==2018.1.10",
+        "regex",
     ],
     include_package_data=True,
     python_requires=">=3.6",


### PR DESCRIPTION
I don't see any reason why `regex` is pinned to `2018.1.10`. This is causing some issues with our other dependencies so I removed the version pin.

All tests pass locally on python 3.6