### PR TITLE
allow loading custom word2vec models(including model saved as binary file)

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -164,10 +164,12 @@ class StackedEmbeddings(TokenEmbeddings):
 class WordEmbeddings(TokenEmbeddings):
     """Standard static word embeddings, such as GloVe or FastText."""
 
-    def __init__(self, embeddings: str, field: str = None):
+    def __init__(self, embeddings: str, field: str = None, path: str = None, load_binary: bool = False):
         """
         Initializes classic word embeddings. Constructor downloads required files if not there.
         :param embeddings: one of: 'glove', 'extvec', 'crawl' or two-letter language code.
+        :param path(defaults to None): path of custom word2vec model (can also be a binary file)
+        :param load_binary(defaults to False): True in case custom word2vec model is a binary file
         If you want to use a custom embedding file, just pass the path to the embeddings as embeddings variable.
         """
 
@@ -274,6 +276,13 @@ class WordEmbeddings(TokenEmbeddings):
             )
 
         elif not Path(embeddings).exists():
+            if path is not None:
+                if Path(path).exists:
+                    embeddings = path
+                else:
+                    raise ValueError(
+                        f'The given custom path "{path}" is not available or is not a valid path.'
+                    )
             raise ValueError(
                 f'The given embeddings "{embeddings}" is not available or is not a valid path.'
             )
@@ -281,9 +290,14 @@ class WordEmbeddings(TokenEmbeddings):
         self.name: str = str(embeddings)
         self.static_embeddings = True
 
-        self.precomputed_word_embeddings = gensim.models.KeyedVectors.load(
-            str(embeddings)
-        )
+        if load_binary:
+            self.precomputed_word_embeddings = gensim.models.KeyedVectors.load_word2vec_format(
+                str(embeddings), binary=True
+            )
+        else:
+            self.precomputed_word_embeddings = gensim.models.KeyedVectors.load(
+                str(embeddings)
+            )
 
         self.field = field
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -164,12 +164,10 @@ class StackedEmbeddings(TokenEmbeddings):
 class WordEmbeddings(TokenEmbeddings):
     """Standard static word embeddings, such as GloVe or FastText."""
 
-    def __init__(self, embeddings: str, field: str = None, path: str = None, load_binary: bool = False):
+    def __init__(self, embeddings: str, field: str = None):
         """
         Initializes classic word embeddings. Constructor downloads required files if not there.
-        :param embeddings: one of: 'glove', 'extvec', 'crawl' or two-letter language code.
-        :param path(defaults to None): path of custom word2vec model (can also be a binary file)
-        :param load_binary(defaults to False): True in case custom word2vec model is a binary file
+        :param embeddings: one of: 'glove', 'extvec', 'crawl' or two-letter language code or custom
         If you want to use a custom embedding file, just pass the path to the embeddings as embeddings variable.
         """
 
@@ -276,13 +274,6 @@ class WordEmbeddings(TokenEmbeddings):
             )
 
         elif not Path(embeddings).exists():
-            if path is not None:
-                if Path(path).exists:
-                    embeddings = path
-                else:
-                    raise ValueError(
-                        f'The given custom path "{path}" is not available or is not a valid path.'
-                    )
             raise ValueError(
                 f'The given embeddings "{embeddings}" is not available or is not a valid path.'
             )
@@ -290,7 +281,7 @@ class WordEmbeddings(TokenEmbeddings):
         self.name: str = str(embeddings)
         self.static_embeddings = True
 
-        if load_binary:
+        if str(embeddings).endswith(".bin"):
             self.precomputed_word_embeddings = gensim.models.KeyedVectors.load_word2vec_format(
                 str(embeddings), binary=True
             )


### PR DESCRIPTION
Take custom path to a word2vec model saved on disk and load it through gensim.

In case model has been saved as a binary file load it through gensim.models.KeyedVectors.load_word2vec_format with "binary"  argument set to True