### PR TITLE
Change default pooling operation for PooledFlairEmbeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1190,7 +1190,7 @@ class PooledFlairEmbeddings(TokenEmbeddings):
     def __init__(
         self,
         contextual_embeddings: Union[str, FlairEmbeddings],
-        pooling: str = "fade",
+        pooling: str = "min",
         only_capitalized: bool = False,
         **kwargs,
     ):


### PR DESCRIPTION
Hi,

as briefly discussed with @alanakbik, this PR changes the default pooling operation for the `PooledFlairEmbeddings` from `fade` to `min`.

`fade` was not even mentioned in the upcoming NAACL paper, and `min` leads to good results:

![image](https://user-images.githubusercontent.com/20651387/56737023-ca9ca000-6769-11e9-93c2-4c012a661048.png)
