### PR TITLE
Add method to find probability for each class in case of multi-class classification

### DIFF
--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -226,7 +226,7 @@ class TextClassifier(flair.nn.Model):
 
         return self._calculate_single_label_loss(scores, sentences)
 
-    def _obtain_labels(self, scores: List[List[float]]) -> List[List[Label]]:
+    def _obtain_labels(self, scores: List[List[float]], predict_prob: bool = False) -> List[List[Label]]:
         """
         Predicts the labels of sentences.
         :param scores: the prediction scores from the model
@@ -235,6 +235,9 @@ class TextClassifier(flair.nn.Model):
 
         if self.multi_label:
             return [self._get_multi_label(s) for s in scores]
+
+        elif predict_prob:
+            return [self._predict_label_probab(s) for s in scores]
 
         return [self._get_single_label(s) for s in scores]
 
@@ -257,6 +260,15 @@ class TextClassifier(flair.nn.Model):
         label = self.label_dictionary.get_item_for_index(idx.item())
 
         return [Label(label, conf.item())]
+
+    def _predict_label_probab(self, label_scores) -> List[Label]:
+        softmax = torch.nn.functional.softmax(label_scores, dim=0)
+        label_probabs = []
+        index = 0
+        for idx, conf in enumerate(softmax):
+            label = self.label_dictionary.get_item_for_index(idx)
+            label_probabs.append(Label(label, conf.item()))
+        return label_probabs
 
     def _calculate_multi_label_loss(
         self, label_scores, sentences: List[Sentence]

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -238,7 +238,7 @@ class TextClassifier(flair.nn.Model):
             return [self._get_multi_label(s) for s in scores]
 
         elif predict_prob:
-            return [self._predict_label_probab(s) for s in scores]
+            return [self._predict_label_prob(s) for s in scores]
 
         return [self._get_single_label(s) for s in scores]
 
@@ -262,13 +262,13 @@ class TextClassifier(flair.nn.Model):
 
         return [Label(label, conf.item())]
 
-    def _predict_label_probab(self, label_scores) -> List[Label]:
+    def _predict_label_prob(self, label_scores) -> List[Label]:
         softmax = torch.nn.functional.softmax(label_scores, dim=0)
-        label_probabs = []
+        label_probs = []
         for idx, conf in enumerate(softmax):
             label = self.label_dictionary.get_item_for_index(idx)
-            label_probabs.append(Label(label, conf.item()))
-        return label_probabs
+            label_probs.append(Label(label, conf.item()))
+        return label_probs
 
     def _calculate_multi_label_loss(
         self, label_scores, sentences: List[Sentence]

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -171,12 +171,13 @@ class TextClassifier(flair.nn.Model):
         return labels, loss
 
     def predict(
-        self, sentences: Union[Sentence, List[Sentence]], mini_batch_size: int = 32
+        self, sentences: Union[Sentence, List[Sentence]], mini_batch_size: int = 32, multi_class_prob: bool = False,
     ) -> List[Sentence]:
         """
         Predicts the class labels for the given sentences. The labels are directly added to the sentences.
         :param sentences: list of sentences
         :param mini_batch_size: mini batch size to use
+        :param multi_class_prob : return probability for all class for multiclass
         :return: the list of sentences containing the labels
         """
         with torch.no_grad():
@@ -192,7 +193,7 @@ class TextClassifier(flair.nn.Model):
 
             for batch in batches:
                 scores = self.forward(batch)
-                predicted_labels = self._obtain_labels(scores)
+                predicted_labels = self._obtain_labels(scores, predict_prob=multi_class_prob)
 
                 for (sentence, labels) in zip(batch, predicted_labels):
                     sentence.labels = labels

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -264,7 +264,6 @@ class TextClassifier(flair.nn.Model):
     def _predict_label_probab(self, label_scores) -> List[Label]:
         softmax = torch.nn.functional.softmax(label_scores, dim=0)
         label_probabs = []
-        index = 0
         for idx, conf in enumerate(softmax):
             label = self.label_dictionary.get_item_for_index(idx)
             label_probabs.append(Label(label, conf.item()))

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -449,6 +449,7 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
     # clean up results directory
     shutil.rmtree(results_base_path)
 
+
 @pytest.mark.integration
 def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_path):
     # corpus = NLPTaskDataFetcher.load_corpus('multi_class', base_path=tasks_base_path)

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -386,11 +386,6 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
 
     model = TextClassifier(document_embeddings, label_dict, False)
 
-    trainer = ModelTrainer(model, corpus)
-    trainer.train(
-        results_base_path, EvaluationMetric.MICRO_F1_SCORE, max_epochs=2, test_mode=True
-    )
-
     sentence = Sentence("Berlin is a really nice city.")
 
     for s in model.predict(sentence):
@@ -399,14 +394,12 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
             assert 0.0 <= l.score <= 1.0
             assert type(l.score) is float
 
-    loaded_model = TextClassifier.load_from_file(results_base_path / "final-model.pt")
-
     sentence = Sentence("I love Berlin")
     sentence_empty = Sentence("       ")
 
-    loaded_model.predict(sentence)
-    loaded_model.predict([sentence, sentence_empty])
-    loaded_model.predict([sentence_empty])
+    model.predict(sentence)
+    model.predict([sentence, sentence_empty])
+    model.predict([sentence_empty])
 
     # clean up results directory
     shutil.rmtree(results_base_path)

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -386,6 +386,11 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
 
     model = TextClassifier(document_embeddings, label_dict, False)
 
+    trainer = ModelTrainer(model, corpus)
+    trainer.train(
+        results_base_path, EvaluationMetric.MICRO_F1_SCORE, max_epochs=2, test_mode=True
+    )
+
     sentence = Sentence("Berlin is a really nice city.")
 
     for s in model.predict(sentence):
@@ -394,12 +399,14 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
             assert 0.0 <= l.score <= 1.0
             assert type(l.score) is float
 
+    loaded_model = TextClassifier.load_from_file(results_base_path / "final-model.pt")
+
     sentence = Sentence("I love Berlin")
     sentence_empty = Sentence("       ")
 
-    model.predict(sentence)
-    model.predict([sentence, sentence_empty])
-    model.predict([sentence_empty])
+    loaded_model.predict(sentence)
+    loaded_model.predict([sentence, sentence_empty])
+    loaded_model.predict([sentence_empty])
 
     # clean up results directory
     shutil.rmtree(results_base_path)
@@ -430,7 +437,7 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
             assert 0.0 <= l.score <= 1.0
             assert type(l.score) is float
 
-    loaded_model = TextClassifier.load_from_file(results_base_path / "final-model.pt")
+    loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
 
     sentence = Sentence("I love Berlin")
     sentence_empty = Sentence("       ")


### PR DESCRIPTION
**Added feature to get the confidence score of each class in case of Multi-class text classification**
Added new param  `multi_class_prob` to function `predict` to return the confidence score of all classes instead of just returning class with the highest confidence.

*Example to use this method*

```pythnon
>>> from flair.models import TextClassifier
>>> from flair.data import Sentence

# Loading English pretrained sentiment classification model
>>> classifier = TextClassifier.load('en-sentiment')

>>> sentence = Sentence('I have added a new feature in flair')
>>> classifier.predict(sentence)
>>> print('Sentiment Score: ', sentence.labels)
Sentiment Score:  [POSITIVE (0.9674275517463684)]

# Now if you want confidence score for both the class, you need to pass `multi_class_prob` as `True` to predict method

>>> classifier.predict(sentence, multi_class_prob=True)
>>> print('Sentiment Score: ', sentence.labels)
Sentiment Score:  [POSITIVE (0.9674275517463684), NEGATIVE (0.032572414726018906)]
```

