### PR TITLE
capability to change threshold during multi label classification

### DIFF
--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -29,6 +29,7 @@ class TextClassifier(flair.nn.Model):
         document_embeddings: flair.embeddings.DocumentEmbeddings,
         label_dictionary: Dictionary,
         multi_label: bool,
+        multi_label_threshold: float = 0.5
     ):
 
         super(TextClassifier, self).__init__()
@@ -36,6 +37,7 @@ class TextClassifier(flair.nn.Model):
         self.document_embeddings: flair.embeddings.DocumentRNNEmbeddings = document_embeddings
         self.label_dictionary: Dictionary = label_dictionary
         self.multi_label = multi_label
+        self.multi_label_threshold = multi_label_threshold
 
         self.decoder = nn.Linear(
             self.document_embeddings.embedding_length, len(self.label_dictionary)
@@ -245,7 +247,7 @@ class TextClassifier(flair.nn.Model):
 
         results = list(map(lambda x: sigmoid(x), label_scores))
         for idx, conf in enumerate(results):
-            if conf > 0.5:
+            if conf > self.multi_label_threshold:
                 label = self.label_dictionary.get_item_for_index(idx)
                 labels.append(Label(label, conf.item()))
 


### PR DESCRIPTION
Ability to define custom threshold level for multi-label classification problems while initialising the `TextClassifier` class. Default value in `0.5`

Eg
```  
text_classifier = TextClassifier(doc_embeddings,label_dictionary=label_dictionary, multi_label=True, multi_label_threshold=0.7 )
```

Any changes can be made later on just by changing this variable. For Eg.
```
classifier = TextClassifier.load_from_file(<model_path>)
classifier.multi_label_threshold = 0.65
```

