### PR TITLE
A simple method to print the tag transition matrix learned by the CRF

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -18,6 +18,7 @@ from typing import List, Tuple, Union
 from flair.training_utils import clear_embeddings, Metric, Result
 
 from tqdm import tqdm
+from tabulate import tabulate
 
 log = logging.getLogger("flair")
 
@@ -818,3 +819,14 @@ class SequenceTagger(flair.nn.Model):
             model_name = cached_path(model_map[model_name], cache_dir=cache_dir)
 
         return model_name
+
+    def get_transition_matrix(self):
+        data = []
+        for to_idx, row in enumerate(self.transitions):
+            for from_idx, column in enumerate(row):
+                row = [self.tag_dictionary.get_item_for_index(from_idx),
+                       self.tag_dictionary.get_item_for_index(to_idx),
+                       column.item()]
+                data.append(row)
+            data.append(["----"])
+        print(tabulate(data, headers=['FROM', 'TO', 'SCORE']))

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ hyperopt>=0.1.1
 pytorch-pretrained-bert>=0.6.1
 bpemb>=0.2.9
 regex
+tabulate

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "pytorch-pretrained-bert>=0.6.1",
         "bpemb>=0.2.9",
         "regex",
+        "tabulate"
     ],
     include_package_data=True,
     python_requires=">=3.6",


### PR DESCRIPTION
- added `get_transition_matrix` to the `SequenceTagger` model
- added `tabulate` dependency to requirements.txt