### PR TITLE
BugFix DocumentLMEmbeddings class

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2248,11 +2248,11 @@ class DocumentLMEmbeddings(DocumentEmbeddings):
                 if embedding.is_forward_lm:
                     sentence.set_embedding(
                         embedding.name,
-                        sentence[len(sentence)]._embeddings[embedding.name],
+                        sentence[len(sentence)-1]._embeddings[embedding.name],
                     )
                 else:
                     sentence.set_embedding(
-                        embedding.name, sentence[1]._embeddings[embedding.name]
+                        embedding.name, sentence[0]._embeddings[embedding.name]
                     )
 
         return sentences


### PR DESCRIPTION
Changed the call "sentence[idx]._embeddings[embedding.name]" for forward [len(sentence)-1] and backward [0] to solve the index out of range error.