### PR TITLE
GH-678: Classification improvements

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -816,11 +816,17 @@ class Corpus:
             label_dictionary.add_item(label)
 
         max_labels = max([len(sent.labels) for sent in self.train])
-        log.info(max_labels)
         if max_labels > 1:
             label_dictionary.multi_label = True
 
         return label_dictionary
+
+    def get_label_distribution(self):
+        class_to_count = defaultdict(lambda: 0)
+        for sent in self.train:
+            for label in sent.labels:
+                class_to_count[label.value] += 1
+        return class_to_count
 
     def get_all_sentences(self) -> Dataset:
         return ConcatDataset([self.train, self.dev, self.test])

--- a/flair/data.py
+++ b/flair/data.py
@@ -25,6 +25,7 @@ class Dictionary:
         # init dictionaries
         self.item2idx: Dict[str, int] = {}
         self.idx2item: List[str] = []
+        self.multi_label: bool = False
 
         # in order to deal with unknown tokens, add <unk>
         if add_unk:
@@ -809,10 +810,15 @@ class Corpus:
         :return: dictionary of labels
         """
         labels = set([label.value for sent in self.train for label in sent.labels])
-
+        log.info(labels)
         label_dictionary: Dictionary = Dictionary(add_unk=False)
         for label in labels:
             label_dictionary.add_item(label)
+
+        max_labels = max([len(sent.labels) for sent in self.train])
+        log.info(max_labels)
+        if max_labels > 1:
+            label_dictionary.multi_label = True
 
         return label_dictionary
 

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -532,13 +532,11 @@ class ClassificationDataset(Dataset):
             line = f.readline()
             position = 0
             while line:
-                if "__label__" not in line:
+                if "__label__" not in line or " " not in line:
                     position = f.tell()
-                    # print(line)
                     line = f.readline()
                     continue
 
-                # print(self.in_memory)
                 if self.in_memory:
                     sentence = self._parse_line_to_sentence(
                         line, self.label_prefix, use_tokenizer
@@ -551,14 +549,10 @@ class ClassificationDataset(Dataset):
                         sentence.tokens = sentence.tokens[:max_tokens_per_doc]
                     if sentence is not None and len(sentence.tokens) > 0:
                         self.sentences.append(sentence)
+                        self.total_sentence_count += 1
                 else:
-                    # print('appending')
                     self.indices.append(position)
-
-                # print('counting')
-                self.total_sentence_count += 1
-                if self.total_sentence_count % 10000 == 0:
-                    print(self.total_sentence_count)
+                    self.total_sentence_count += 1
 
                 position = f.tell()
                 line = f.readline()

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -172,6 +172,7 @@ class WordEmbeddings(TokenEmbeddings):
         :param embeddings: one of: 'glove', 'extvec', 'crawl' or two-letter language code or custom
         If you want to use a custom embedding file, just pass the path to the embeddings as embeddings variable.
         """
+        self.embeddings = embeddings
 
         old_base_path = (
             "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources/embeddings/"
@@ -339,6 +340,9 @@ class WordEmbeddings(TokenEmbeddings):
 
     def __str__(self):
         return self.name
+
+    def extra_repr(self):
+        return f"'{self.embeddings}'"
 
 
 class FineTuneWordEmbeddings(WordEmbeddings):
@@ -2056,6 +2060,9 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
 
     def _add_embeddings_internal(self, sentences: List[Sentence]):
         pass
+
+    def extra_repr(self):
+        return f"fine_tune_mode={self.fine_tune_mode}, pooling={self.pooling}"
 
 
 class DocumentRNNEmbeddings(DocumentEmbeddings):

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2,6 +2,7 @@ import os
 import re
 import logging
 from abc import abstractmethod
+from collections import Counter
 from pathlib import Path
 from typing import List, Union, Dict
 
@@ -29,6 +30,7 @@ from pytorch_pretrained_bert.modeling_transfo_xl import (
 )
 
 import flair
+from flair.data import Corpus
 from .nn import LockedDropout, WordDropout
 from .data import Dictionary, Token, Sentence
 from .file_utils import cached_path, open_inside_zip
@@ -337,6 +339,165 @@ class WordEmbeddings(TokenEmbeddings):
 
     def __str__(self):
         return self.name
+
+
+class FineTuneWordEmbeddings(WordEmbeddings):
+    def __init__(self, embeddings, fine_tune_mode="nonlinear"):
+
+        super().__init__(embeddings=embeddings)
+
+        self.name = f"{self.name}-{fine_tune_mode}"
+
+        self.fine_tune_mode = fine_tune_mode
+        if self.fine_tune_mode in ["nonlinear", "linear"]:
+            self.embedding_flex = torch.nn.Linear(
+                self.embedding_length, self.embedding_length, bias=False
+            )
+            self.embedding_flex.weight.data.copy_(torch.eye(self.embedding_length))
+
+        if self.fine_tune_mode in ["nonlinear"]:
+            self.embedding_flex_nonlinear = torch.nn.ReLU(self.embedding_length)
+            self.embedding_flex_nonlinear_map = torch.nn.Linear(
+                self.embedding_length, self.embedding_length
+            )
+            # torch.nn.init.xavier_uniform_(self.embedding_flex_nonlinear_map.weight)
+
+        self.static_embeddings = False
+
+    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+
+        for i, sentence in enumerate(sentences):
+
+            word_embeddings = []
+
+            for token, token_idx in zip(sentence.tokens, range(len(sentence.tokens))):
+
+                if "field" not in self.__dict__ or self.field is None:
+                    word = token.text
+                else:
+                    word = token.get_tag(self.field).value
+
+                if word in self.precomputed_word_embeddings:
+                    word_embedding = self.precomputed_word_embeddings[word]
+                elif word.lower() in self.precomputed_word_embeddings:
+                    word_embedding = self.precomputed_word_embeddings[word.lower()]
+                elif (
+                    re.sub(r"\d", "#", word.lower()) in self.precomputed_word_embeddings
+                ):
+                    word_embedding = self.precomputed_word_embeddings[
+                        re.sub(r"\d", "#", word.lower())
+                    ]
+                elif (
+                    re.sub(r"\d", "0", word.lower()) in self.precomputed_word_embeddings
+                ):
+                    word_embedding = self.precomputed_word_embeddings[
+                        re.sub(r"\d", "0", word.lower())
+                    ]
+                else:
+                    word_embedding = np.zeros(self.embedding_length, dtype="float")
+
+                word_embeddings.append(torch.FloatTensor(word_embedding).unsqueeze(0))
+
+            word_embeddings = torch.cat(word_embeddings, dim=0).to(flair.device)
+
+            if self.fine_tune_mode in ["nonlinear", "linear"]:
+                word_embeddings = self.embedding_flex(word_embeddings)
+
+            if self.fine_tune_mode in ["nonlinear"]:
+                word_embeddings = self.embedding_flex_nonlinear(word_embeddings)
+                word_embeddings = self.embedding_flex_nonlinear_map(word_embeddings)
+
+            if self.static_embeddings:
+                word_embeddings = word_embeddings.detach()
+
+            for token, token_idx in zip(sentence.tokens, range(len(sentence.tokens))):
+                token.set_embedding(self.name, word_embeddings[token_idx])
+
+        return sentences
+
+
+class OneHotEmbeddings(TokenEmbeddings):
+    """One-hot encoded embeddings."""
+
+    def __init__(
+        self,
+        corpus=Union[Corpus, List[Sentence]],
+        field: str = "text",
+        embedding_length: int = 300,
+        min_freq: int = 3,
+    ):
+
+        super().__init__()
+        self.name = "one-hot"
+        self.static_embeddings = False
+
+        tokens = list(map((lambda s: s.tokens), corpus.train))
+        tokens = [token for sublist in tokens for token in sublist]
+
+        if field == "text":
+            most_common = Counter(list(map((lambda t: t.text), tokens))).most_common()
+        else:
+            most_common = Counter(
+                list(map((lambda t: t.get_tag(field)), tokens))
+            ).most_common()
+
+        tokens = []
+        for token, freq in most_common:
+            if freq < min_freq:
+                break
+            tokens.append(token)
+
+        self.vocab_dictionary: Dictionary = Dictionary()
+        for token in tokens:
+            self.vocab_dictionary.add_item(token)
+
+        # max_tokens = 500
+        self.__embedding_length = embedding_length
+
+        print(self.vocab_dictionary.idx2item)
+        print(f"vocabulary size of {len(self.vocab_dictionary)}")
+
+        # model architecture
+        self.embedding_layer = torch.nn.Embedding(
+            len(self.vocab_dictionary), self.__embedding_length
+        )
+        torch.nn.init.xavier_uniform_(self.embedding_layer.weight)
+
+    @property
+    def embedding_length(self) -> int:
+        return self.__embedding_length
+
+    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+
+        one_hot_sentences = []
+        for i, sentence in enumerate(sentences):
+            context_idxs = [
+                self.vocab_dictionary.get_idx_for_item(t.text) for t in sentence.tokens
+            ]
+
+            one_hot_sentences.extend(context_idxs)
+
+        one_hot_sentences = torch.tensor(one_hot_sentences, dtype=torch.long).to(
+            flair.device
+        )
+
+        embedded = self.embedding_layer.forward(one_hot_sentences)
+
+        index = 0
+        for sentence in sentences:
+            for token in sentence:
+                embedding = embedded[index]
+                token.set_embedding(self.name, embedding)
+                index += 1
+
+        return sentences
+
+    def __str__(self):
+        return self.name
+
+    @property
+    def embedding_length(self) -> int:
+        return self.__embedding_length
 
 
 class BPEmbSerializable(BPEmb):
@@ -1814,29 +1975,49 @@ class DocumentMeanEmbeddings(DocumentEmbeddings):
 
 
 class DocumentPoolEmbeddings(DocumentEmbeddings):
-    def __init__(self, embeddings: List[TokenEmbeddings], mode: str = "mean"):
+    def __init__(
+        self,
+        embeddings: List[TokenEmbeddings],
+        fine_tune_mode="linear",
+        pooling: str = "mean",
+    ):
         """The constructor takes a list of embeddings to be combined.
         :param embeddings: a list of token embeddings
-        :param mode: a string which can any value from ['mean', 'max', 'min']
+        :param pooling: a string which can any value from ['mean', 'max', 'min']
         """
         super().__init__()
 
         self.embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embeddings)
+        self.__embedding_length = self.embeddings.embedding_length
+
+        # optional fine-tuning on top of embedding layer
+        self.fine_tune_mode = fine_tune_mode
+        if self.fine_tune_mode in ["nonlinear", "linear"]:
+            self.embedding_flex = torch.nn.Linear(
+                self.embedding_length, self.embedding_length, bias=False
+            )
+            self.embedding_flex.weight.data.copy_(torch.eye(self.embedding_length))
+
+        if self.fine_tune_mode in ["nonlinear"]:
+            self.embedding_flex_nonlinear = torch.nn.ReLU(self.embedding_length)
+            self.embedding_flex_nonlinear_map = torch.nn.Linear(
+                self.embedding_length, self.embedding_length
+            )
 
         self.__embedding_length: int = self.embeddings.embedding_length
 
         self.to(flair.device)
 
-        self.mode = mode
-        if self.mode == "mean":
+        self.pooling = pooling
+        if self.pooling == "mean":
             self.pool_op = torch.mean
-        elif mode == "max":
+        elif pooling == "max":
             self.pool_op = torch.max
-        elif mode == "min":
+        elif pooling == "min":
             self.pool_op = torch.min
         else:
             raise ValueError(f"Pooling operation for {self.mode!r} is not defined")
-        self.name: str = f"document_{self.mode}"
+        self.name: str = f"document_{self.pooling}"
 
     @property
     def embedding_length(self) -> int:
@@ -1846,33 +2027,32 @@ class DocumentPoolEmbeddings(DocumentEmbeddings):
         """Add embeddings to every sentence in the given list of sentences. If embeddings are already added, updates
         only if embeddings are non-static."""
 
-        everything_embedded: bool = True
-
         # if only one sentence is passed, convert to list of sentence
         if isinstance(sentences, Sentence):
             sentences = [sentences]
 
+        self.embeddings.embed(sentences)
+
         for sentence in sentences:
-            if self.name not in sentence._embeddings.keys():
-                everything_embedded = False
+            word_embeddings = []
+            for token in sentence.tokens:
+                word_embeddings.append(token.get_embedding().unsqueeze(0))
 
-        if not everything_embedded:
+            word_embeddings = torch.cat(word_embeddings, dim=0).to(flair.device)
 
-            self.embeddings.embed(sentences)
+            if self.fine_tune_mode in ["nonlinear", "linear"]:
+                word_embeddings = self.embedding_flex(word_embeddings)
 
-            for sentence in sentences:
-                word_embeddings = []
-                for token in sentence.tokens:
-                    word_embeddings.append(token.get_embedding().unsqueeze(0))
+            if self.fine_tune_mode in ["nonlinear"]:
+                word_embeddings = self.embedding_flex_nonlinear(word_embeddings)
+                word_embeddings = self.embedding_flex_nonlinear_map(word_embeddings)
 
-                word_embeddings = torch.cat(word_embeddings, dim=0).to(flair.device)
+            if self.pooling == "mean":
+                pooled_embedding = self.pool_op(word_embeddings, 0)
+            else:
+                pooled_embedding, _ = self.pool_op(word_embeddings, 0)
 
-                if self.mode == "mean":
-                    pooled_embedding = self.pool_op(word_embeddings, 0)
-                else:
-                    pooled_embedding, _ = self.pool_op(word_embeddings, 0)
-
-                sentence.set_embedding(self.name, pooled_embedding)
+            sentence.set_embedding(self.name, pooled_embedding)
 
     def _add_embeddings_internal(self, sentences: List[Sentence]):
         pass

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -282,7 +282,7 @@ class SequenceTagger(flair.nn.Model):
                     batch, also_clear_word_embeddings=not embeddings_in_memory
                 )
 
-            eval_loss /= len(sentences)
+            eval_loss /= batch_no
 
             if out_path is not None:
                 with open(out_path, "w", encoding="utf-8") as outfile:
@@ -499,7 +499,7 @@ class SequenceTagger(flair.nn.Model):
 
             score = forward_score - gold_score
 
-            return score.sum()
+            return score.mean()
 
         else:
             score = 0
@@ -511,7 +511,7 @@ class SequenceTagger(flair.nn.Model):
                 score += torch.nn.functional.cross_entropy(
                     sentence_feats, sentence_tags
                 )
-
+            score /= len(features)
             return score
 
     def _obtain_labels(self, feature, sentences) -> List[List[Label]]:
@@ -829,9 +829,11 @@ class SequenceTagger(flair.nn.Model):
         data = []
         for to_idx, row in enumerate(self.transitions):
             for from_idx, column in enumerate(row):
-                row = [self.tag_dictionary.get_item_for_index(from_idx),
-                       self.tag_dictionary.get_item_for_index(to_idx),
-                       column.item()]
+                row = [
+                    self.tag_dictionary.get_item_for_index(from_idx),
+                    self.tag_dictionary.get_item_for_index(to_idx),
+                    column.item(),
+                ]
                 data.append(row)
             data.append(["----"])
-        print(tabulate(data, headers=['FROM', 'TO', 'SCORE']))
+        print(tabulate(data, headers=["FROM", "TO", "SCORE"]))

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -66,15 +66,15 @@ class TextClassifier(flair.nn.Model):
 
             for item in distribution:
                 # proportion = distribution[item] / total_count
-                proportion = math.sqrt(
+                proportion = math.log(
                     (total_count - distribution[item]) / distribution[item]
                 )
 
                 pos_weight[self.label_dictionary.get_idx_for_item(item)] = proportion
 
-            # print(pos_weight)
+            print(pos_weight)
 
-            self.loss_function = nn.BCEWithLogitsLoss()
+            self.loss_function = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
         else:
             self.loss_function = nn.CrossEntropyLoss()
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -33,7 +33,6 @@ class TextClassifier(flair.nn.Model):
         self,
         document_embeddings: flair.embeddings.DocumentEmbeddings,
         label_dictionary: Dictionary,
-        corpus,
         multi_label: bool = None,
         multi_label_threshold: float = 0.5,
     ):
@@ -57,24 +56,7 @@ class TextClassifier(flair.nn.Model):
         self._init_weights()
 
         if self.multi_label:
-            pos_weight = torch.ones([len(self.label_dictionary)])
-
-            distribution = corpus.get_label_distribution()
-            total_count = 0
-            for item in distribution:
-                total_count += distribution[item]
-
-            for item in distribution:
-                # proportion = distribution[item] / total_count
-                proportion = math.log(
-                    (total_count - distribution[item]) / distribution[item]
-                )
-
-                pos_weight[self.label_dictionary.get_idx_for_item(item)] = proportion
-
-            print(pos_weight)
-
-            self.loss_function = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
+            self.loss_function = nn.BCEWithLogitsLoss()
         else:
             self.loss_function = nn.CrossEntropyLoss()
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -33,7 +33,7 @@ class TextClassifier(flair.nn.Model):
         self,
         document_embeddings: flair.embeddings.DocumentEmbeddings,
         label_dictionary: Dictionary,
-        # corpus,
+        corpus,
         multi_label: bool = None,
         multi_label_threshold: float = 0.5,
     ):

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -33,7 +33,7 @@ class TextClassifier(flair.nn.Model):
         self,
         document_embeddings: flair.embeddings.DocumentEmbeddings,
         label_dictionary: Dictionary,
-        corpus,
+        # corpus,
         multi_label: bool = None,
         multi_label_threshold: float = 0.5,
     ):

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -144,9 +144,10 @@ class LockedDropout(torch.nn.Module):
     Implementation of locked (or variational) dropout. Randomly drops out entire parameters in embedding space.
     """
 
-    def __init__(self, dropout_rate=0.5):
+    def __init__(self, dropout_rate=0.5, inplace=False):
         super(LockedDropout, self).__init__()
         self.dropout_rate = dropout_rate
+        self.inplace = inplace
 
     def forward(self, x):
         if not self.training or not self.dropout_rate:
@@ -157,15 +158,20 @@ class LockedDropout(torch.nn.Module):
         mask = mask.expand_as(x)
         return mask * x
 
+    def extra_repr(self):
+        inplace_str = ", inplace" if self.inplace else ""
+        return "p={}{}".format(self.dropout_rate, inplace_str)
+
 
 class WordDropout(torch.nn.Module):
     """
     Implementation of word dropout. Randomly drops out entire words (or characters) in embedding space.
     """
 
-    def __init__(self, dropout_rate=0.05):
+    def __init__(self, dropout_rate=0.05, inplace=False):
         super(WordDropout, self).__init__()
         self.dropout_rate = dropout_rate
+        self.inplace = inplace
 
     def forward(self, x):
         if not self.training or not self.dropout_rate:
@@ -175,3 +181,7 @@ class WordDropout(torch.nn.Module):
         mask = torch.autograd.Variable(m, requires_grad=False)
         mask = mask.expand_as(x)
         return mask * x
+
+    def extra_repr(self):
+        inplace_str = ", inplace" if self.inplace else ""
+        return "p={}{}".format(self.dropout_rate, inplace_str)

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -187,7 +187,7 @@ class ModelTrainer:
                 self.model.train()
 
                 train_loss: float = 0
-                seen_sentences = 0
+                seen_batches = 0
                 total_number_of_batches = len(batch_loader)
 
                 modulo = max(1, int(total_number_of_batches / 10))
@@ -201,7 +201,7 @@ class ModelTrainer:
                     torch.nn.utils.clip_grad_norm_(self.model.parameters(), 5.0)
                     optimizer.step()
 
-                    seen_sentences += len(batch)
+                    seen_batches += 1
                     train_loss += loss.item()
 
                     clear_embeddings(
@@ -211,7 +211,7 @@ class ModelTrainer:
                     if batch_no % modulo == 0:
                         log.info(
                             f"epoch {epoch + 1} - iter {batch_no}/{total_number_of_batches} - loss "
-                            f"{train_loss / seen_sentences:.8f}"
+                            f"{train_loss / seen_batches:.8f}"
                         )
                         iteration = epoch * total_number_of_batches + batch_no
                         if not param_selection_mode:
@@ -219,7 +219,7 @@ class ModelTrainer:
                                 self.model.state_dict(), iteration
                             )
 
-                train_loss /= len(train_data)
+                train_loss /= seen_batches
 
                 self.model.eval()
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -83,7 +83,25 @@ def test_document_pool_embeddings():
 
     for mode in ["mean", "max", "min"]:
         embeddings: DocumentPoolEmbeddings = DocumentPoolEmbeddings(
-            [glove, charlm], mode=mode
+            [glove, charlm], pooling=mode, fine_tune_mode="none"
+        )
+
+        embeddings.embed(sentence)
+
+        assert len(sentence.get_embedding()) == 1074
+
+        sentence.clear_embeddings()
+
+        assert len(sentence.get_embedding()) == 0
+
+
+@pytest.mark.integration
+def test_document_pool_embeddings_nonlinear():
+    sentence, glove, charlm = init_document_embeddings()
+
+    for mode in ["mean", "max", "min"]:
+        embeddings: DocumentPoolEmbeddings = DocumentPoolEmbeddings(
+            [glove, charlm], pooling=mode, fine_tune_mode="nonlinear"
         )
 
         embeddings.embed(sentence)

--- a/train.py
+++ b/train.py
@@ -6,7 +6,7 @@ from flair.embeddings import (
     TokenEmbeddings,
     WordEmbeddings,
     StackedEmbeddings,
-    CharLMEmbeddings,
+    FlairEmbeddings,
     CharacterEmbeddings,
 )
 from flair.training_utils import EvaluationMetric
@@ -30,9 +30,9 @@ embedding_types: List[TokenEmbeddings] = [
     # CharacterEmbeddings(),
     # comment in these lines to use contextual string embeddings
     #
-    # CharLMEmbeddings('news-forward'),
+    # FlairEmbeddings('news-forward'),
     #
-    # CharLMEmbeddings('news-backward'),
+    # FlairEmbeddings('news-backward'),
 ]
 
 embeddings: StackedEmbeddings = StackedEmbeddings(embeddings=embedding_types)


### PR DESCRIPTION
This PR adds a number of small improvements and new features that were implemented in the course of investigating (but not yet solving) #678. 

#### FastText-style classification

FastText is a popular baseline for classifying text, based on learnable word embeddings that are mean-pooled. To allow Flair users to use this approach, we implemented a new word embedding type and adapted a document embedding: 

- **`OneHotEmbeddings`** - we add one-hot embeddings that are trainable on a downstream task. Instantiate by passing a corpus: 

```python
from flair.embeddings import OneHotEmbeddings
from flair.datasets import UD_ENGLISH

# a corpus
corpus = UD_ENGLISH()

# instantiate one-hot encoded word embeddings
embeddings = OneHotEmbeddings(corpus)
```

These embeddings can also be used to embed other fields (#398 #618). 

- Fine tuning options for **`DocumentPoolEmbeddings`** - we now allow users to specify a fine-tuning option before the pooling operation is executed in document pool embeddings. Options are 'none' (no fine-tuning), 'linear' (linear remapping of word embeddings), 'nonlinear' (nonlinear remapping of word embeddings). Nonlinear should be used together with `WordEmbeddings`, while None should be used with `OneHotEmbeddings` (not necessary since they are already learnt on data). So, to replicate FastText classification you can either do: 

```python
# instantiate one-hot encoded word embeddings
embeddings = OneHotEmbeddings(corpus)

# document pool embeddings
document_embeddings = DocumentPoolEmbeddings([embeddings], fine_tune_mode='none')
```

or 


```python
# instantiate pre-trained word embeddings
embeddings = WordEmbeddings('glove')

# document pool embeddings
document_embeddings = DocumentPoolEmbeddings([embeddings], fine_tune_mode='nonlinear')
```

#### Simplifications

Previously, users always had to specify whether their text classification problem was multi_label or not. Now, this is detected automatically if users do not specify. So now you can init like this: 

```python
# corpus
corpus = TREC_6()

# make label_dictionary
label_dictionary = corpus.make_label_dictionary()

# init text classifier
classifier = TextClassifier(document_embeddings, label_dictionary)
```

#### Others

- We added better module descriptions to embeddings and dropout so that more parameters get printed by default for models for better logging.
- We normalized the training loss across modules so that train / test loss are consistent. Closes #670 
- Improved speed of data loading for classification corpus
- Added TREC_6 classification corpus to `flair.datasets`
 
