### PR TITLE
Actually exclude tests from packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author="Alan Akbik",
     author_email="alan.akbik@zalando.de",
     url="https://github.com/zalandoresearch/flair",
-    packages=find_packages(exclude="test"),  # same as name
+    packages=find_packages(exclude="tests"),  # same as name
     license="MIT",
     install_requires=required,
     include_package_data=True,


### PR DESCRIPTION
This mistake is causing issues in my own unit tests, when trying to import utils from my `tests` package Python gets confused and ends up trying to import from Flair's `tests`.