### PR TITLE
GH-564: regression datasets

### DIFF
--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -1876,6 +1876,60 @@ class WASSA_ANGER(ClassificationCorpus):
         )
 
 
+class WASSA_FEAR(ClassificationCorpus):
+    def __init__(self, base_path=None, in_memory: bool = False):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        _download_wassa_if_not_there("fear", data_folder, dataset_name)
+
+        super(WASSA_FEAR, self).__init__(
+            data_folder, use_tokenizer=False, in_memory=in_memory
+        )
+
+
+class WASSA_JOY(ClassificationCorpus):
+    def __init__(self, base_path=None, in_memory: bool = False):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        _download_wassa_if_not_there("joy", data_folder, dataset_name)
+
+        super(WASSA_JOY, self).__init__(
+            data_folder, use_tokenizer=False, in_memory=in_memory
+        )
+
+
+class WASSA_SADNESS(ClassificationCorpus):
+    def __init__(self, base_path=None, in_memory: bool = False):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        _download_wassa_if_not_there("sadness", data_folder, dataset_name)
+
+        super(WASSA_SADNESS, self).__init__(
+            data_folder, use_tokenizer=False, in_memory=in_memory
+        )
+
+
 def _download_wikiner(language_code: str, dataset_name: str):
     # download data if necessary
     wikiner_path = (

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -1,3 +1,5 @@
+import os
+
 from torch.utils.data import Dataset, random_split
 from typing import List, Dict, Union
 import re
@@ -1828,6 +1830,50 @@ class UD_BASQUE(UniversalDependenciesCorpus):
         )
 
         super(UD_BASQUE, self).__init__(data_folder, in_memory=in_memory)
+
+
+def _download_wassa_if_not_there(emotion, data_folder, dataset_name):
+    for split in ["train", "dev", "test"]:
+
+        data_file = data_folder / f"{emotion}-{split}.txt"
+
+        if not data_file.is_file():
+
+            if split == "train":
+                url = f"http://saifmohammad.com/WebDocs/EmoInt%20Train%20Data/{emotion}-ratings-0to1.train.txt"
+            if split == "dev":
+                url = f"http://saifmohammad.com/WebDocs/EmoInt%20Dev%20Data%20With%20Gold/{emotion}-ratings-0to1.dev.gold.txt"
+            if split == "test":
+                url = f"http://saifmohammad.com/WebDocs/EmoInt%20Test%20Gold%20Data/{emotion}-ratings-0to1.test.gold.txt"
+
+            path = cached_path(url, Path("datasets") / dataset_name)
+
+            with open(path, "r") as f:
+                with open(data_file, "w") as out:
+                    next(f)
+                    for line in f:
+                        fields = line.split("\t")
+                        out.write(f"__label__{fields[3].rstrip()} {fields[1]}\n")
+
+            os.remove(path)
+
+
+class WASSA_ANGER(ClassificationCorpus):
+    def __init__(self, base_path=None, in_memory: bool = False):
+        # this dataset name
+        dataset_name = self.__class__.__name__.lower()
+
+        # default dataset folder is the cache root
+        if not base_path:
+            base_path = Path(flair.cache_root) / "datasets"
+        data_folder = base_path / dataset_name
+
+        # download data if necessary
+        _download_wassa_if_not_there("anger", data_folder, dataset_name)
+
+        super(WASSA_ANGER, self).__init__(
+            data_folder, use_tokenizer=False, in_memory=in_memory
+        )
 
 
 def _download_wikiner(language_code: str, dataset_name: str):

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -160,7 +160,9 @@ def get_from_cache(url: str, cache_dir: Path = None) -> Path:
     # make HEAD request to check ETag
     response = requests.head(url)
     if response.status_code != 200:
-        raise IOError("HEAD request failed for url {}".format(url))
+        raise IOError(
+            f"HEAD request failed for url {url} with status code {response.status_code}."
+        )
 
     # add ETag to filename if it exists
     # etag = response.headers.get("ETag")

--- a/flair/file_utils.py
+++ b/flair/file_utils.py
@@ -158,7 +158,7 @@ def get_from_cache(url: str, cache_dir: Path = None) -> Path:
         return cache_path
 
     # make HEAD request to check ETag
-    response = requests.head(url)
+    response = requests.head(url, headers={"User-Agent": "Flair"})
     if response.status_code != 200:
         raise IOError(
             f"HEAD request failed for url {url} with status code {response.status_code}."
@@ -174,7 +174,7 @@ def get_from_cache(url: str, cache_dir: Path = None) -> Path:
         logger.info("%s not found in cache, downloading to %s", url, temp_filename)
 
         # GET file object
-        req = requests.get(url, stream=True)
+        req = requests.get(url, stream=True, headers={"User-Agent": "Flair"})
         content_length = req.headers.get("Content-Length")
         total = int(content_length) if content_length is not None else None
         progress = Tqdm.tqdm(unit="B", total=total)

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -62,6 +62,17 @@ class TextRegressor(flair.models.TextClassifier):
 
             return sentences
 
+    def _calculate_loss(
+        self, scores: torch.tensor, sentences: List[Sentence]
+    ) -> torch.tensor:
+        """
+        Calculates the loss.
+        :param scores: the prediction scores from the model
+        :param sentences: list of sentences
+        :return: loss value
+        """
+        return self.loss_function(scores.squeeze(1), self._labels_to_indices(sentences))
+
     def forward_labels_and_loss(
         self, sentences: Union[Sentence, List[Sentence]]
     ) -> (List[List[float]], torch.tensor):


### PR DESCRIPTION
This PR fixes a problem with the loss function in the (still beta) `TextRegressor` and adds 4 regression datasets.

You can now train a regression model like this: 

```python
# get the corpus
from flair.datasets import WASSA_SADNESS
corpus = WASSA_SADNESS()
print(corpus)

# choose some word embedding or stack of embeddings
embeddings = OneHotEmbeddings(corpus)

# choose some document embedding
document_embedding = DocumentPoolEmbeddings([embeddings], fine_tune_mode='none')

# init text regressor
classifier = TextRegressor(document_embedding)

# init model trainer
trainer = ModelTrainer(classifier, corpus)

trainer.train(
    f"resources/taggers/test-regression",
    mini_batch_size=4,
    max_epochs=20,
)
```
