### PR TITLE
GH-327: log warning when creating empty sentences

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -352,13 +352,9 @@ class Sentence:
 
             # otherwise assumes whitespace tokenized text
             else:
-                # catch the empty string case
-                if not text:
-                    raise ValueError(
-                        "Cannot convert empty string to a Sentence object."
-                    )
                 # add each word in tokenized string as Token object to Sentence
                 word = ""
+                index = -1
                 for index, char in enumerate(text):
                     if char == " ":
                         if len(word) > 0:
@@ -373,6 +369,12 @@ class Sentence:
                 if len(word) > 0:
                     token = Token(word, start_position=index - len(word))
                     self.add_token(token)
+
+        # log a warning if the dataset is empty
+        if not text:
+            log.warn(
+                "ACHTUNG: An empty Sentence was created! Are there empty strings in your dataset?"
+            )
 
     def get_token(self, token_id: int) -> Token:
         for token in self.tokens:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -25,8 +25,8 @@ def test_get_head():
 
 def test_create_sentence_on_empty_string():
 
-    with pytest.raises(ValueError) as e:
-        sentence: Sentence = Sentence("")
+    sentence: Sentence = Sentence("")
+    assert 0 == len(sentence.tokens)
 
 
 def test_create_sentence_without_tokenizer():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -28,9 +28,6 @@ def test_create_sentence_on_empty_string():
     with pytest.raises(ValueError) as e:
         sentence: Sentence = Sentence("")
 
-        assert e.type is ValueError
-        assert e.value.args[0] == "Cannot convert empty string to a Sentence object."
-
 
 def test_create_sentence_without_tokenizer():
     sentence: Sentence = Sentence("I love Berlin.")


### PR DESCRIPTION
Previously, we had different behavior for creating Sentences from empty strings depending on whether or not a tokanizer was used: 

```python
from flair.data import Sentence

# this creates an empty sentence with 0 tokens
sentence = Sentence('', use_tokenizer=True)
print(sentence)

# this throws an error
sentence = Sentence('')
print(sentence)
```

With this PR, both cases now return an empty sentence and log a warning. Addresses #327