### PR TITLE
GH-642: Added return probability distribution over all classes

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -119,7 +119,7 @@ class Label:
         if not value and value != "":
             raise ValueError(
                 "Incorrect label value provided. Label value needs to be set."
-            )
+                )
         else:
             self._value = value
 
@@ -171,10 +171,14 @@ class Token:
         self.sentence: Sentence = None
         self._embeddings: Dict = {}
         self.tags: Dict[str, Label] = {}
+        self.tags_proba_dist: Dict[str, List[Label]] = {}
 
     def add_tag_label(self, tag_type: str, tag: Label):
         self.tags[tag_type] = tag
-
+    
+    def add_tags_proba_dist(self, tag_type: str, tags: List[Label]):
+        self.tags_proba_dist[tag_type] = tags
+    
     def add_tag(self, tag_type: str, tag_value: str, confidence=1.0):
         tag = Label(tag_value, confidence)
         self.tags[tag_type] = tag
@@ -183,6 +187,11 @@ class Token:
         if tag_type in self.tags:
             return self.tags[tag_type]
         return Label("")
+
+    def get_tags_proba_dist(self, tag_type: str) -> List[Label]:
+        if tag_type in self.tags_proba_dist:
+            return self.tags_proba_dist[tag_type]
+        return []
 
     def get_head(self):
         return self.sentence.get_token(self.head_id)

--- a/flair/data.py
+++ b/flair/data.py
@@ -119,7 +119,7 @@ class Label:
         if not value and value != "":
             raise ValueError(
                 "Incorrect label value provided. Label value needs to be set."
-                )
+            )
         else:
             self._value = value
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -516,6 +516,12 @@ class SequenceTagger(flair.nn.Model):
             return score
 
     def _obtain_labels(self, feature, sentences) -> (List[List[Label]], List[List[List[Label]]]):
+        """
+        Returns a tuple of two lists: 
+         - The first list corresponds to the most likely `Label` per token in each sentence.
+         - The second list contains a probability distribution over all `Labels` for each token 
+           in a sentence for all sentences.
+        """
 
         sentences.sort(key=lambda x: len(x), reverse=True)
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -529,13 +529,14 @@ class SequenceTagger(flair.nn.Model):
             else:
                 tag_seq = []
                 confidences = []
+                scores = []
                 for backscore in feats[:length]:
                     softmax = F.softmax(backscore, dim=0)
                     _, idx = torch.max(backscore, 0)
                     prediction = idx.item()
                     tag_seq.append(prediction)
                     confidences.append(softmax[prediction].item())
-                    scores = softmax.tolist()
+                    scores.append(softmax.tolist())
 
             tags.append(
                 [

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -523,7 +523,6 @@ class SequenceTagger(flair.nn.Model):
 
         tags = []
         all_tags = []
-
         for feats, length in zip(feature, lengths):
             if self.use_crf:
                 confidences, tag_seq, scores = self._viterbi_decode(feats[:length])
@@ -536,6 +535,7 @@ class SequenceTagger(flair.nn.Model):
                     prediction = idx.item()
                     tag_seq.append(prediction)
                     confidences.append(softmax[prediction].item())
+                    scores = softmax.tolist()
 
             tags.append(
                 [


### PR DESCRIPTION
Hi,

this PR is about issue https://github.com/zalandoresearch/flair/issues/745. It:

- adds the property `tags_proba_dist` to `Token`, which contains a list of `Label`. The list of labels represents the probability distribution over all possible labels for this token.
- modifies `SequenceTagger._obtain_labels` to not only return the most probable label, but in addition a complete list of all possible labels with their respective scores.

The required changes in `SequenceTagger._viterbi_decode` are taken from https://github.com/zalandoresearch/flair/pull/642.

**Disclaimer:**  This is my first PR to the flair project. I'm happy for any feedback or ideas on how to improve this.