### PR TITLE
GH-776: DataLoader for in-memory datasets

### DIFF
--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -2233,12 +2233,16 @@ class DataLoader(torch.utils.data.dataloader.DataLoader):
         shuffle=False,
         sampler=None,
         batch_sampler=None,
+        num_workers=8,
         drop_last=False,
         timeout=0,
         worker_init_fn=None,
     ):
 
-        num_workers = 8
+        # in certain cases, multi-CPU data loading makes no sense and slows
+        # everything down. For this reason, we detect if a dataset is in-memory:
+        # if so, num_workers is set to 0 for faster processing
+
         if type(dataset) is list:
             num_workers = 0
         elif type(dataset) is Subset and dataset.dataset.in_memory == True:

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -12,6 +12,7 @@ import torch
 
 import flair.embeddings
 from flair.data import Dictionary, Sentence, Token, Label
+from flair.datasets import DataLoader
 from flair.file_utils import cached_path
 
 from typing import List, Tuple, Union
@@ -220,12 +221,8 @@ class SequenceTagger(flair.nn.Model):
 
             batch_no: int = 0
 
-            batch_loader = torch.utils.data.DataLoader(
-                sentences,
-                batch_size=eval_mini_batch_size,
-                shuffle=False,
-                num_workers=4,
-                collate_fn=list,
+            batch_loader = DataLoader(
+                sentences, batch_size=eval_mini_batch_size, shuffle=False
             )
 
             metric = Metric("Evaluation")
@@ -354,7 +351,9 @@ class SequenceTagger(flair.nn.Model):
                     tags, all_tags = self._obtain_labels(feature, batch)
 
                 for (sentence, sent_tags, sent_all_tags) in zip(batch, tags, all_tags):
-                    for (token, tag, token_all_tags) in zip(sentence.tokens, sent_tags, sent_all_tags):
+                    for (token, tag, token_all_tags) in zip(
+                        sentence.tokens, sent_tags, sent_all_tags
+                    ):
                         token.add_tag_label(self.tag_type, tag)
                         token.add_tags_proba_dist(self.tag_type, token_all_tags)
 
@@ -515,7 +514,9 @@ class SequenceTagger(flair.nn.Model):
             score /= len(features)
             return score
 
-    def _obtain_labels(self, feature, sentences) -> (List[List[Label]], List[List[List[Label]]]):
+    def _obtain_labels(
+        self, feature, sentences
+    ) -> (List[List[Label]], List[List[List[Label]]]):
         """
         Returns a tuple of two lists: 
          - The first list corresponds to the most likely `Label` per token in each sentence.
@@ -554,7 +555,7 @@ class SequenceTagger(flair.nn.Model):
             all_tags.append(
                 [
                     [
-                        Label(self.tag_dictionary.get_item_for_index(score_id), score) 
+                        Label(self.tag_dictionary.get_item_for_index(score_id), score)
                         for score_id, score in enumerate(score_dist)
                     ]
                     for score_dist in scores

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -214,6 +214,7 @@ class SequenceTagger(flair.nn.Model):
         eval_mini_batch_size: int = 32,
         embeddings_in_memory: bool = True,
         out_path: Path = None,
+        num_workers: int = 8,
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -222,7 +223,10 @@ class SequenceTagger(flair.nn.Model):
             batch_no: int = 0
 
             batch_loader = DataLoader(
-                sentences, batch_size=eval_mini_batch_size, shuffle=False
+                sentences,
+                batch_size=eval_mini_batch_size,
+                shuffle=False,
+                num_workers=num_workers,
             )
 
             metric = Metric("Evaluation")

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 import flair.nn
 import flair.embeddings
 from flair.data import Dictionary, Sentence, Label
+from flair.datasets import DataLoader
 from flair.file_utils import cached_path
 from flair.training_utils import (
     convert_labels_to_one_hot,
@@ -158,12 +159,8 @@ class TextClassifier(flair.nn.Model):
         with torch.no_grad():
             eval_loss = 0
 
-            batch_loader = torch.utils.data.DataLoader(
-                sentences,
-                batch_size=eval_mini_batch_size,
-                shuffle=False,
-                num_workers=4,
-                collate_fn=list,
+            batch_loader = DataLoader(
+                sentences, batch_size=eval_mini_batch_size, shuffle=False
             )
 
             metric = Metric("Evaluation")

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -154,13 +154,17 @@ class TextClassifier(flair.nn.Model):
         eval_mini_batch_size: int = 32,
         embeddings_in_memory: bool = False,
         out_path: Path = None,
+        num_workers: int = 8,
     ) -> (Result, float):
 
         with torch.no_grad():
             eval_loss = 0
 
             batch_loader = DataLoader(
-                sentences, batch_size=eval_mini_batch_size, shuffle=False
+                sentences,
+                batch_size=eval_mini_batch_size,
+                shuffle=False,
+                num_workers=num_workers,
             )
 
             metric = Metric("Evaluation")

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -88,13 +88,17 @@ class TextRegressor(flair.models.TextClassifier):
         eval_mini_batch_size: int = 32,
         embeddings_in_memory: bool = False,
         out_path: Path = None,
+        num_workers: int = 8,
     ) -> (Result, float):
 
         with torch.no_grad():
             eval_loss = 0
 
             batch_loader = DataLoader(
-                sentences, batch_size=eval_mini_batch_size, shuffle=False
+                sentences,
+                batch_size=eval_mini_batch_size,
+                shuffle=False,
+                num_workers=num_workers,
             )
 
             metric = MetricRegression("Evaluation")

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -5,6 +5,8 @@ import flair.embeddings
 import torch
 import torch.nn as nn
 from typing import List, Union
+
+from flair.datasets import DataLoader
 from flair.training_utils import clear_embeddings, Metric, MetricRegression, Result
 from flair.data import Sentence, Label
 import logging
@@ -91,12 +93,8 @@ class TextRegressor(flair.models.TextClassifier):
         with torch.no_grad():
             eval_loss = 0
 
-            batch_loader = torch.utils.data.DataLoader(
-                sentences,
-                batch_size=eval_mini_batch_size,
-                shuffle=False,
-                num_workers=4,
-                collate_fn=list,
+            batch_loader = DataLoader(
+                sentences, batch_size=eval_mini_batch_size, shuffle=False
             )
 
             metric = MetricRegression("Evaluation")

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -36,6 +36,7 @@ class Model(torch.nn.Module):
         eval_mini_batch_size: int = 32,
         embeddings_in_memory: bool = False,
         out_path: Path = None,
+        num_workers: int = 8,
     ) -> (Result, float):
         """Evaluates the model on a list of gold-labeled Sentences. Returns a Result object containing evaluation
         results and a loss value. Implement this to enable evaluation."""

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -242,7 +242,7 @@ class ModelTrainer:
                             self.corpus.train,
                             eval_mini_batch_size,
                             embeddings_in_memory,
-                            num_workers,
+                            num_workers=num_workers,
                         )
                         f.write(f"\t{train_eval_result.log_line}")
 
@@ -251,7 +251,7 @@ class ModelTrainer:
                             self.corpus.dev,
                             eval_mini_batch_size,
                             embeddings_in_memory,
-                            num_workers,
+                            num_workers=num_workers,
                         )
                         f.write(f"\t{dev_loss}\t{dev_eval_result.log_line}")
                         log.info(
@@ -270,6 +270,7 @@ class ModelTrainer:
                             eval_mini_batch_size,
                             embeddings_in_memory,
                             base_path / "test.tsv",
+                            num_workers=num_workers,
                         )
                         f.write(f"\t{test_loss}\t{test_eval_result.log_line}")
                         log.info(

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -61,6 +61,7 @@ class ModelTrainer:
         anneal_with_restarts: bool = False,
         shuffle: bool = True,
         param_selection_mode: bool = False,
+        num_workers: int = 8,
         **kwargs,
     ) -> dict:
 
@@ -177,7 +178,10 @@ class ModelTrainer:
                     break
 
                 batch_loader = DataLoader(
-                    train_data, batch_size=mini_batch_size, shuffle=shuffle
+                    train_data,
+                    batch_size=mini_batch_size,
+                    shuffle=shuffle,
+                    num_workers=num_workers,
                 )
 
                 self.model.train()
@@ -238,12 +242,16 @@ class ModelTrainer:
                             self.corpus.train,
                             eval_mini_batch_size,
                             embeddings_in_memory,
+                            num_workers,
                         )
                         f.write(f"\t{train_eval_result.log_line}")
 
                     if log_dev:
                         dev_eval_result, dev_loss = self.model.evaluate(
-                            self.corpus.dev, eval_mini_batch_size, embeddings_in_memory
+                            self.corpus.dev,
+                            eval_mini_batch_size,
+                            embeddings_in_memory,
+                            num_workers,
                         )
                         f.write(f"\t{dev_loss}\t{dev_eval_result.log_line}")
                         log.info(
@@ -305,7 +313,11 @@ class ModelTrainer:
         # test best model if test data is present
         if self.corpus.test:
             final_score = self.final_test(
-                base_path, embeddings_in_memory, evaluation_metric, eval_mini_batch_size
+                base_path,
+                embeddings_in_memory,
+                evaluation_metric,
+                eval_mini_batch_size,
+                num_workers,
             )
         else:
             final_score = 0
@@ -324,6 +336,7 @@ class ModelTrainer:
         embeddings_in_memory: bool,
         evaluation_metric: EvaluationMetric,
         eval_mini_batch_size: int,
+        num_workers: int = 8,
     ):
 
         log_line(log)
@@ -339,6 +352,7 @@ class ModelTrainer:
             eval_mini_batch_size=eval_mini_batch_size,
             embeddings_in_memory=embeddings_in_memory,
             out_path=base_path / "test.tsv",
+            num_workers=num_workers,
         )
 
         test_results: Result = test_results


### PR DESCRIPTION
This PR introduces a new `DataLoader` class that inherits from PyTorch `DataLoader` and contains optimizations for Flair. Specifically, in cases in which a `Dataset` is in memory, it returns direct pointers to `Sentence` objects of a dataset, allowing us to retain embeddings between epochs in training. This may greatly speed up training for datasets that fit in memory. 

It also modifies the `make_label_dictionary()` method to make use of the DataLoader, to speed up computation (i.e. closes #776), and adds a tqdm progress bar. 


