### PR TITLE
GH-33: remove empty sentences

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -713,7 +713,7 @@ class Corpus:
         log.info(self)
 
     @staticmethod
-    def _filter_empty_sentences(dataset):
+    def _filter_empty_sentences(dataset) -> Dataset:
 
         # find out empty sentence indices
         empty_sentence_indices = []


### PR DESCRIPTION
Users sometimes have problems with datasets that contain empty sentences (see #33). We currently issue a warning when an empty sentence gets constructed, but leave the users to filter empty sentences by themselves. 

This PR adds a new function to the `Corpus` object, namely `filter_empty_sentences()`. By calling it, all empty sentences get removed. 

Example: 

```python
# load dataset (IMDB dataset has no empty sentences)
corpus = IMDB().downsample(0.001)
print(corpus)

# add an empty sentence to the training split
corpus._train += SentenceDataset(Sentence(''))
print(corpus)

# call .filter_empty_sentences() to remove empty sentences
corpus.filter_empty_sentences()
print(corpus)
```

