### PR TITLE
GH-778: update GermEval model

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -840,11 +840,7 @@ class SequenceTagger(flair.nn.Model):
         )
 
         model_map["de-ner-germeval"] = "/".join(
-            [
-                aws_resource_path,
-                "NER-germeval--h256-l1-b32-%2Bde-fasttext%2Bgerman-forward%2Bgerman-backward--v0.2",
-                "de-ner-germeval-v0.3.pt",
-            ]
+            [aws_resource_path_v04, "NER-germeval", "de-ner-germeval-0.4.1.pt"]
         )
 
         model_map["fr-ner"] = "/".join(


### PR DESCRIPTION
Closes #778 

The NER germeval model did not give good results when evaluated. This may be because it was trained a long time ago on an old Flair version and some changes since then caused the model to be less effective. We retrained the model with the standard param combination and added it to Flair. 

Results are similar to before (even slightly better at 84.85 F1), but we did not do any parameter sweep or try out any of the new embeddings, so better results are likely possible.