### PR TITLE
GH-770 'PosixPath' object is not subscriptable

### DIFF
--- a/resources/docs/TUTORIAL_7_TRAINING_A_MODEL.md
+++ b/resources/docs/TUTORIAL_7_TRAINING_A_MODEL.md
@@ -307,7 +307,8 @@ trainer.train('resources/taggers/example-ner',
 # 9. continue trainer at later point
 from pathlib import Path
 
-trainer = ModelTrainer.load_from_checkpoint(Path('resources/taggers/example-ner/checkpoint.pt'), corpus)
+checkpoint = tagger.load_checkpoint(Path('resources/taggers/example-ner/checkpoint.pt'))
+trainer = ModelTrainer.load_from_checkpoint(checkpoint, corpus)
 trainer.train('resources/taggers/example-ner',
               EvaluationMetric.MICRO_F1_SCORE,
               learning_rate=0.1,


### PR DESCRIPTION
Issue #770 is probably caused by an error in Tutorial 7 in the part about resuming training. 

This pull request contains a fix to the tutorial.