### PR TITLE
readme: add references to new NAACL 2019 papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If you use the pooled version of the Flair embeddings (PooledFlairEmbeddings), p
   title={Pooled Contextualized Embeddings for Named Entity Recognition},
   author={Akbik, Alan and Bergmann, Tanja and Vollgraf, Roland},
   booktitle = {{NAACL} 2019, 2019 Annual Conference of the North American Chapter of the Association for Computational Linguistics},
-  pages     = {to appear},
+  pages     = {724–728},
   year      = {2019}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ Here's how to [reproduce these numbers](/resources/docs/EXPERIMENTS.md) using Fl
 Alan Akbik, Duncan Blythe and Roland Vollgraf. 
 27th International Conference on Computational Linguistics, **COLING 2018**.*
 
-* *Pooled Contextualized Embeddings for Named Entity Recognition (to appear).
+* *[Pooled Contextualized Embeddings for Named Entity Recognition](https://www.aclweb.org/anthology/papers/N/N19/N19-1078/).
 Alan Akbik, Tanja Bergmann and Roland Vollgraf.
 2019 Annual Conference of the North American Chapter of the Association for Computational Linguistics, **NAACL 2019**.*
+
+* *[FLAIR: An Easy-to-Use Framework for State-of-the-Art NLP](https://www.aclweb.org/anthology/papers/N/N19/N19-4010/).
+Alan Akbik, Tanja Bergmann, Duncan Blythe, Kashif Rasul, Stefan Schweter and Roland Vollgraf.
+2019 Annual Conference of the North American Chapter of the Association for Computational Linguistics (Demonstrations), **NAACL 2019**.*
 
 ## Quick Start
 


### PR DESCRIPTION
Hi,

this PR adds the following NAACL 2019 papers to the main readme:

* [Pooled Contextualized Embeddings for Named Entity Recognition](https://www.aclweb.org/anthology/papers/N/N19/N19-1078/)

* [FLAIR: An Easy-to-Use Framework for State-of-the-Art NLP](https://www.aclweb.org/anthology/papers/N/N19/N19-4010/)