### PR TITLE
GH-817: trainer modifications

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -204,7 +204,6 @@ class ModelTrainer:
                 self.model.train()
 
                 train_loss: float = 0
-                estimated_train_loss: float = 0
 
                 seen_batches = 0
                 total_number_of_batches = len(batch_loader)
@@ -229,7 +228,6 @@ class ModelTrainer:
                     )
 
                     if batch_no % modulo == 0:
-                        estimated_train_loss = train_loss / seen_batches
                         log.info(
                             f"epoch {epoch + 1} - iter {batch_no}/{total_number_of_batches} - loss "
                             f"{train_loss / seen_batches:.8f}"
@@ -241,8 +239,6 @@ class ModelTrainer:
                             )
 
                 train_loss /= seen_batches
-
-                train_loss = estimated_train_loss
 
                 self.model.eval()
 

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -55,6 +55,7 @@ class ModelTrainer:
         patience: int = 3,
         train_with_dev: bool = False,
         monitor_train: bool = False,
+        monitor_test: bool = False,
         embeddings_in_memory: bool = True,
         checkpoint: bool = False,
         save_final_model: bool = True,
@@ -94,7 +95,11 @@ class ModelTrainer:
 
         # determine what splits (train, dev, test) to evaluate and log
         log_train = True if monitor_train else False
-        log_test = True if (not param_selection_mode and self.corpus.test) else False
+        log_test = (
+            True
+            if (not param_selection_mode and self.corpus.test and monitor_test)
+            else False
+        )
         log_dev = True if not train_with_dev else False
 
         # prepare loss logging file and set up header


### PR DESCRIPTION
closes #817 
closes #796 

This PR introduces small fixes to the ModelTrainer class. It introduces a new parameter `monitor_test` that by default is set to `False`, meaning that test set evaluation is no longer performed during training (#796). It also changes the logging behavior of the `bad_epochs` parameter to hopefully be more intuitive (#817).