### PR TITLE
Gh 798 add csv reader

### DIFF
--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -678,7 +678,7 @@ class TableDataset(FlairDataset):
                     if self.max_chars_per_doc > 0:
                         text = text[: self.max_chars_per_doc]
 
-                    sentence = Sentence(text)
+                    sentence = Sentence(text, use_tokenizer=self.use_tokenizer)
 
                     for column in self.column_name_map:
                         if self.column_name_map[column].startswith("label"):
@@ -709,7 +709,7 @@ class TableDataset(FlairDataset):
             if self.max_chars_per_doc > 0:
                 text = text[: self.max_chars_per_doc]
 
-            sentence = Sentence(text)
+            sentence = Sentence(text, use_tokenizer=self.use_tokenizer)
             for column in self.column_name_map:
                 if self.column_name_map[column].startswith("label"):
                     sentence.add_label(row[column])

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -1,4 +1,4 @@
-import os
+import os, csv
 from abc import abstractmethod
 
 from torch.utils.data import Dataset, random_split
@@ -171,7 +171,8 @@ class ClassificationCorpus(Corpus):
         test_file=None,
         dev_file=None,
         use_tokenizer: bool = True,
-        max_tokens_per_doc=-1,
+        max_tokens_per_doc: int = -1,
+        max_chars_per_doc: int = -1,
         in_memory: bool = False,
     ):
         """
@@ -218,12 +219,14 @@ class ClassificationCorpus(Corpus):
             train_file,
             use_tokenizer=use_tokenizer,
             max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
             in_memory=in_memory,
         )
         test: Dataset = ClassificationDataset(
             test_file,
             use_tokenizer=use_tokenizer,
             max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
             in_memory=in_memory,
         )
 
@@ -232,6 +235,7 @@ class ClassificationCorpus(Corpus):
                 dev_file,
                 use_tokenizer=use_tokenizer,
                 max_tokens_per_doc=max_tokens_per_doc,
+                max_chars_per_doc=max_chars_per_doc,
                 in_memory=in_memory,
             )
         else:
@@ -244,6 +248,103 @@ class ClassificationCorpus(Corpus):
         super(ClassificationCorpus, self).__init__(
             train, dev, test, name=data_folder.name
         )
+
+
+class TableCorpus(Corpus):
+    def __init__(
+        self,
+        data_folder: Union[str, Path],
+        column_name_map: Dict[int, str],
+        train_file=None,
+        test_file=None,
+        dev_file=None,
+        use_tokenizer: bool = True,
+        max_tokens_per_doc=-1,
+        max_chars_per_doc=-1,
+        in_memory: bool = False,
+    ):
+        """
+        Helper function to get a TaggedCorpus from text classification-formatted task data
+
+        :param data_folder: base folder with the task data
+        :param train_file: the name of the train file
+        :param test_file: the name of the test file
+        :param dev_file: the name of the dev file, if None, dev data is sampled from train
+        :return: a TaggedCorpus with annotated train, dev and test data
+        """
+
+        if type(data_folder) == str:
+            data_folder: Path = Path(data_folder)
+
+        if train_file is not None:
+            train_file = data_folder / train_file
+        if test_file is not None:
+            test_file = data_folder / test_file
+        if dev_file is not None:
+            dev_file = data_folder / dev_file
+
+        # automatically identify train / test / dev files
+        if train_file is None:
+            for file in data_folder.iterdir():
+                file_name = file.name
+                if "train" in file_name:
+                    train_file = file
+                if "test" in file_name:
+                    test_file = file
+                if "dev" in file_name:
+                    dev_file = file
+                if "testa" in file_name:
+                    dev_file = file
+                if "testb" in file_name:
+                    test_file = file
+
+        log.info("Reading data from {}".format(data_folder))
+        log.info("Train: {}".format(train_file))
+        log.info("Dev: {}".format(dev_file))
+        log.info("Test: {}".format(test_file))
+
+        train: Dataset = TableDataset(
+            train_file,
+            column_name_map,
+            use_tokenizer=use_tokenizer,
+            max_tokens_per_doc=max_tokens_per_doc,
+            max_chars_per_doc=max_chars_per_doc,
+            in_memory=in_memory,
+        )
+
+        if test_file is not None:
+            test: Dataset = TableDataset(
+                dev_file,
+                column_name_map,
+                use_tokenizer=use_tokenizer,
+                max_tokens_per_doc=max_tokens_per_doc,
+                max_chars_per_doc=max_chars_per_doc,
+                in_memory=in_memory,
+            )
+        else:
+            train_length = len(train)
+            test_size: int = round(train_length / 10)
+            splits = random_split(train, [train_length - test_size, test_size])
+            train = splits[0]
+            test = splits[1]
+
+        if dev_file is not None:
+            dev: Dataset = TableDataset(
+                dev_file,
+                column_name_map,
+                use_tokenizer=use_tokenizer,
+                max_tokens_per_doc=max_tokens_per_doc,
+                max_chars_per_doc=max_chars_per_doc,
+                in_memory=in_memory,
+            )
+        else:
+            train_length = len(train)
+            dev_size: int = round(train_length / 10)
+            splits = random_split(train, [train_length - dev_size, dev_size])
+            train = splits[0]
+            dev = splits[1]
+
+        super(TableCorpus, self).__init__(train, dev, test, name=data_folder.name)
 
 
 class FlairDataset(Dataset):
@@ -527,11 +628,104 @@ class UniversalDependenciesDataset(FlairDataset):
         return sentence
 
 
+class TableDataset(FlairDataset):
+    def __init__(
+        self,
+        path_to_file: Union[str, Path],
+        column_name_map: Dict[int, str],
+        max_tokens_per_doc: int = -1,
+        max_chars_per_doc: int = -1,
+        use_tokenizer=True,
+        in_memory: bool = True,
+    ):
+        if type(path_to_file) == str:
+            path_to_file: Path = Path(path_to_file)
+
+        assert path_to_file.exists()
+
+        # variables
+        self.path_to_file = path_to_file
+        self.in_memory = in_memory
+        self.use_tokenizer = use_tokenizer
+        self.column_name_map = column_name_map
+        self.max_tokens_per_doc = max_tokens_per_doc
+        self.max_chars_per_doc = max_chars_per_doc
+
+        # different handling of in_memory data than streaming data
+        if self.in_memory:
+            self.sentences = []
+        else:
+            self.raw_data = []
+
+        self.total_sentence_count: int = 0
+
+        # most data sets have the token text in the first column, if not, pass 'text' as column
+        self.text_column: int = 0
+        for column in column_name_map:
+            if column_name_map[column] == "text":
+                self.text_column = column
+
+        with open(self.path_to_file) as csv_file:
+
+            csv_reader = csv.reader(csv_file)
+            for row in csv_reader:
+
+                if self.in_memory:
+
+                    print(row)
+
+                    text = row[self.text_column]
+                    if self.max_chars_per_doc > 0:
+                        text = text[: self.max_chars_per_doc]
+
+                    sentence = Sentence(text)
+
+                    for column in self.column_name_map:
+                        if self.column_name_map[column].startswith("label"):
+                            sentence.add_label(row[column])
+
+                    if (
+                        len(sentence) > self.max_tokens_per_doc
+                        and self.max_tokens_per_doc > 0
+                    ):
+                        sentence.tokens = sentence.tokens[: self.max_tokens_per_doc]
+                    self.sentences.append(sentence)
+
+                else:
+                    self.raw_data.append(row)
+
+                self.total_sentence_count += 1
+
+    def __len__(self):
+        return self.total_sentence_count
+
+    def __getitem__(self, index: int = 0) -> Sentence:
+        if self.in_memory:
+            return self.sentences[index]
+        else:
+            row = self.raw_data[index]
+            text = row[self.text_column]
+
+            if self.max_chars_per_doc > 0:
+                text = text[: self.max_chars_per_doc]
+
+            sentence = Sentence(text)
+            for column in self.column_name_map:
+                if self.column_name_map[column].startswith("label"):
+                    sentence.add_label(row[column])
+
+            if len(sentence) > self.max_tokens_per_doc and self.max_tokens_per_doc > 0:
+                sentence.tokens = sentence.tokens[: self.max_tokens_per_doc]
+
+            return sentence
+
+
 class ClassificationDataset(FlairDataset):
     def __init__(
         self,
         path_to_file: Union[str, Path],
         max_tokens_per_doc=-1,
+        max_chars_per_doc=-1,
         use_tokenizer=True,
         in_memory: bool = True,
     ):
@@ -561,6 +755,7 @@ class ClassificationDataset(FlairDataset):
             self.indices = []
 
         self.total_sentence_count: int = 0
+        self.max_chars_per_doc = max_chars_per_doc
 
         self.path_to_file = path_to_file
 
@@ -610,6 +805,9 @@ class ClassificationDataset(FlairDataset):
                 break
 
         text = line[l_len:].strip()
+
+        if self.max_chars_per_doc > 0:
+            text = text[: self.max_chars_per_doc]
 
         if text and labels:
             sentence = Sentence(text, labels=labels, use_tokenizer=use_tokenizer)

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -29,7 +29,7 @@ class ColumnCorpus(Corpus):
         in_memory: bool = True,
     ):
         """
-        Helper function to get a TaggedCorpus from CoNLL column-formatted task data such as CoNLL03 or CoNLL2000.
+        Instantiates a Corpus from CoNLL column-formatted task data such as CoNLL03 or CoNLL2000.
 
         :param data_folder: base folder with the task data
         :param column_format: a map specifying the column format
@@ -37,7 +37,7 @@ class ColumnCorpus(Corpus):
         :param test_file: the name of the test file
         :param dev_file: the name of the dev file, if None, dev data is sampled from train
         :param tag_to_bioes: whether to convert to BIOES tagging scheme
-        :return: a TaggedCorpus with annotated train, dev and test data
+        :return: a Corpus with annotated train, dev and test data
         """
 
         if type(data_folder) == str:
@@ -121,13 +121,13 @@ class UniversalDependenciesCorpus(Corpus):
         in_memory: bool = True,
     ):
         """
-        Helper function to get a TaggedCorpus from CoNLL-U column-formatted task data such as the UD corpora
+        Instantiates a Corpus from CoNLL-U column-formatted task data such as the UD corpora
 
         :param data_folder: base folder with the task data
         :param train_file: the name of the train file
         :param test_file: the name of the test file
         :param dev_file: the name of the dev file, if None, dev data is sampled from train
-        :return: a TaggedCorpus with annotated train, dev and test data
+        :return: a Corpus with annotated train, dev and test data
         """
         # automatically identify train / test / dev files
         if train_file is None:
@@ -176,13 +176,13 @@ class ClassificationCorpus(Corpus):
         in_memory: bool = False,
     ):
         """
-        Helper function to get a TaggedCorpus from text classification-formatted task data
+        Instantiates a Corpus from text classification-formatted task data
 
         :param data_folder: base folder with the task data
         :param train_file: the name of the train file
         :param test_file: the name of the test file
         :param dev_file: the name of the dev file, if None, dev data is sampled from train
-        :return: a TaggedCorpus with annotated train, dev and test data
+        :return: a Corpus with annotated train, dev and test data
         """
 
         if type(data_folder) == str:
@@ -250,7 +250,7 @@ class ClassificationCorpus(Corpus):
         )
 
 
-class TableCorpus(Corpus):
+class CSVClassificationCorpus(Corpus):
     def __init__(
         self,
         data_folder: Union[str, Path],
@@ -264,13 +264,13 @@ class TableCorpus(Corpus):
         in_memory: bool = False,
     ):
         """
-        Helper function to get a TaggedCorpus from text classification-formatted task data
+        Instantiates a Corpus for text classification from CSV column formatted data
 
         :param data_folder: base folder with the task data
         :param train_file: the name of the train file
         :param test_file: the name of the test file
         :param dev_file: the name of the dev file, if None, dev data is sampled from train
-        :return: a TaggedCorpus with annotated train, dev and test data
+        :return: a Corpus with annotated train, dev and test data
         """
 
         if type(data_folder) == str:
@@ -303,7 +303,7 @@ class TableCorpus(Corpus):
         log.info("Dev: {}".format(dev_file))
         log.info("Test: {}".format(test_file))
 
-        train: Dataset = TableDataset(
+        train: Dataset = CSVClassificationDataset(
             train_file,
             column_name_map,
             use_tokenizer=use_tokenizer,
@@ -313,7 +313,7 @@ class TableCorpus(Corpus):
         )
 
         if test_file is not None:
-            test: Dataset = TableDataset(
+            test: Dataset = CSVClassificationDataset(
                 dev_file,
                 column_name_map,
                 use_tokenizer=use_tokenizer,
@@ -329,7 +329,7 @@ class TableCorpus(Corpus):
             test = splits[1]
 
         if dev_file is not None:
-            dev: Dataset = TableDataset(
+            dev: Dataset = CSVClassificationDataset(
                 dev_file,
                 column_name_map,
                 use_tokenizer=use_tokenizer,
@@ -344,7 +344,9 @@ class TableCorpus(Corpus):
             train = splits[0]
             dev = splits[1]
 
-        super(TableCorpus, self).__init__(train, dev, test, name=data_folder.name)
+        super(CSVClassificationCorpus, self).__init__(
+            train, dev, test, name=data_folder.name
+        )
 
 
 class FlairDataset(Dataset):
@@ -628,7 +630,7 @@ class UniversalDependenciesDataset(FlairDataset):
         return sentence
 
 
-class TableDataset(FlairDataset):
+class CSVClassificationDataset(FlairDataset):
     def __init__(
         self,
         path_to_file: Union[str, Path],
@@ -695,6 +697,9 @@ class TableDataset(FlairDataset):
                     self.raw_data.append(row)
 
                 self.total_sentence_count += 1
+
+    def is_in_memory(self) -> bool:
+        return False
 
     def __len__(self):
         return self.total_sentence_count

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -1,3 +1,5 @@
+import math
+import warnings
 import logging
 from pathlib import Path
 from typing import List, Union
@@ -16,31 +18,8 @@ from flair.training_utils import (
     Metric,
     Result,
 )
-import torch.nn.functional as F
 
 log = logging.getLogger("flair")
-
-
-class FocalLoss(nn.Module):
-    def __init__(self, alpha=1, gamma=2, logits=False, reduce=True):
-        super(FocalLoss, self).__init__()
-        self.alpha = alpha
-        self.gamma = gamma
-        self.logits = logits
-        self.reduce = reduce
-
-    def forward(self, inputs, targets):
-        if self.logits:
-            BCE_loss = F.binary_cross_entropy_with_logits(inputs, targets, reduce=False)
-        else:
-            BCE_loss = F.binary_cross_entropy(inputs, targets, reduce=False)
-        pt = torch.exp(-BCE_loss)
-        F_loss = self.alpha * (1 - pt) ** self.gamma * BCE_loss
-
-        if self.reduce:
-            return torch.mean(F_loss)
-        else:
-            return F_loss
 
 
 class TextClassifier(flair.nn.Model):
@@ -81,7 +60,6 @@ class TextClassifier(flair.nn.Model):
             self.loss_function = nn.BCEWithLogitsLoss()
         else:
             self.loss_function = nn.CrossEntropyLoss()
-            # self.loss_function = FocalLoss()
 
         # auto-spawn on GPU if available
         self.to(flair.device)

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -1,5 +1,3 @@
-import math
-import warnings
 import logging
 from pathlib import Path
 from typing import List, Union
@@ -18,8 +16,31 @@ from flair.training_utils import (
     Metric,
     Result,
 )
+import torch.nn.functional as F
 
 log = logging.getLogger("flair")
+
+
+class FocalLoss(nn.Module):
+    def __init__(self, alpha=1, gamma=2, logits=False, reduce=True):
+        super(FocalLoss, self).__init__()
+        self.alpha = alpha
+        self.gamma = gamma
+        self.logits = logits
+        self.reduce = reduce
+
+    def forward(self, inputs, targets):
+        if self.logits:
+            BCE_loss = F.binary_cross_entropy_with_logits(inputs, targets, reduce=False)
+        else:
+            BCE_loss = F.binary_cross_entropy(inputs, targets, reduce=False)
+        pt = torch.exp(-BCE_loss)
+        F_loss = self.alpha * (1 - pt) ** self.gamma * BCE_loss
+
+        if self.reduce:
+            return torch.mean(F_loss)
+        else:
+            return F_loss
 
 
 class TextClassifier(flair.nn.Model):
@@ -60,6 +81,7 @@ class TextClassifier(flair.nn.Model):
             self.loss_function = nn.BCEWithLogitsLoss()
         else:
             self.loss_function = nn.CrossEntropyLoss()
+            # self.loss_function = FocalLoss()
 
         # auto-spawn on GPU if available
         self.to(flair.device)


### PR DESCRIPTION
This PR adds another way for loading classification datasets, namely datasets that are in CSV format. You need to pass a column format (like in ColumnCorpus), which indicates which column(s) in the CSV holds the text and which field(s) the label(s).

```python
corpus = CSVClassificationCorpus(
    # path to the data folder containing train / test / dev files
    data_folder='path/to/data',
    # indicates which columns are text and labels
    column_name_map={4: "text", 1: "label_topic", 2: "label_subtopic"},
    # if CSV has a header, you can skip it
    skip_header=True)
```

closes #798 