### PR TITLE
GH-736: minor bug fixes

### DIFF
--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -681,6 +681,22 @@ class CSVClassificationDataset(FlairDataset):
 
             for row in csv_reader:
 
+                # test if format is OK
+                wrong_format = False
+                for text_column in self.text_columns:
+                    if text_column >= len(row):
+                        wrong_format = True
+
+                # test if at least one label given
+                has_label = False
+                for column in self.column_name_map:
+                    if self.column_name_map[column].startswith("label") and row[column]:
+                        has_label = True
+                        break
+
+                if wrong_format or not has_label:
+                    continue
+
                 if self.in_memory:
 
                     text = " || ".join(

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -130,7 +130,7 @@ class LanguageModel(nn.Module):
             prediction, rnn_output, hidden = self.forward(batch, hidden)
             rnn_output = rnn_output.detach()
 
-            output_parts.append(rnn_output)
+            output_parts.append(rnn_output.to("cpu"))
 
         # concatenate all chunks to make final output
         output = torch.cat(output_parts)


### PR DESCRIPTION
This PR fixes two bugs: 

- CUDA out of memory errors were happening with `FlairEmbeddings` on large sentences due to a cat operation being performed on CUDA. Moved cat to normal memory. This may address #736 

- Error when loading sentences without labels with CSV classification dataset. 