### PR TITLE
GH-852: Add crosslingual MUSE embeddings

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -318,6 +318,7 @@ class Sentence:
         text: str = None,
         use_tokenizer: bool = False,
         labels: Union[List[Label], List[str]] = None,
+        language_code: str = None,
     ):
 
         super(Sentence, self).__init__()
@@ -329,6 +330,8 @@ class Sentence:
             self.add_labels(labels)
 
         self._embeddings: Dict = {}
+
+        self.language_code: str = language_code
 
         # if text is passed, instantiate sentence with tokens (words)
         if text is not None:
@@ -673,6 +676,17 @@ class Sentence:
 
     def __len__(self) -> int:
         return len(self.tokens)
+
+    def get_language_code(self) -> str:
+        if self.language_code is None:
+            import langdetect
+
+            try:
+                self.language_code = langdetect.detect(self.to_plain_string())
+            except:
+                self.language_code = "en"
+
+        return self.language_code
 
 
 class Corpus:

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -460,6 +460,104 @@ class BPEmbSerializable(BPEmb):
         state["spm"] = sentencepiece_load(self.model_file)
 
 
+class MuseCrosslingualEmbeddings(TokenEmbeddings):
+    def __init__(self,):
+        self.name: str = f"muse-crosslingual"
+        self.static_embeddings = True
+        self.__embedding_length: int = 300
+        self.language_embeddings = {}
+        super().__init__()
+
+    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+
+        for i, sentence in enumerate(sentences):
+
+            language_code = sentence.get_language_code()
+            print(language_code)
+            supported = [
+                "en",
+                "de",
+                "bg",
+                "ca",
+                "hr",
+                "cs",
+                "da",
+                "nl",
+                "et",
+                "fi",
+                "fr",
+                "el",
+                "he",
+                "hu",
+                "id",
+                "it",
+                "mk",
+                "no",
+                "pl",
+                "pt",
+                "ro",
+                "ru",
+                "sk",
+            ]
+            if language_code not in supported:
+                language_code = "en"
+
+            if language_code not in self.language_embeddings:
+                log.info(f"Loading up MUSE embeddings for '{language_code}'!")
+                # download if necessary
+                webpath = "https://alan-nlp.s3.eu-central-1.amazonaws.com/resources/embeddings-muse"
+                cache_dir = Path("embeddings") / "MUSE"
+                cached_path(
+                    f"{webpath}/muse.{language_code}.vec.gensim.vectors.npy",
+                    cache_dir=cache_dir,
+                )
+                embeddings_file = cached_path(
+                    f"{webpath}/muse.{language_code}.vec.gensim", cache_dir=cache_dir
+                )
+
+                # load the model
+                self.language_embeddings[
+                    language_code
+                ] = gensim.models.KeyedVectors.load(str(embeddings_file))
+
+            current_embedding_model = self.language_embeddings[language_code]
+
+            for token, token_idx in zip(sentence.tokens, range(len(sentence.tokens))):
+
+                if "field" not in self.__dict__ or self.field is None:
+                    word = token.text
+                else:
+                    word = token.get_tag(self.field).value
+
+                if word in current_embedding_model:
+                    word_embedding = current_embedding_model[word]
+                elif word.lower() in current_embedding_model:
+                    word_embedding = current_embedding_model[word.lower()]
+                elif re.sub(r"\d", "#", word.lower()) in current_embedding_model:
+                    word_embedding = current_embedding_model[
+                        re.sub(r"\d", "#", word.lower())
+                    ]
+                elif re.sub(r"\d", "0", word.lower()) in current_embedding_model:
+                    word_embedding = current_embedding_model[
+                        re.sub(r"\d", "0", word.lower())
+                    ]
+                else:
+                    word_embedding = np.zeros(self.embedding_length, dtype="float")
+
+                word_embedding = torch.FloatTensor(word_embedding)
+
+                token.set_embedding(self.name, word_embedding)
+
+        return sentences
+
+    @property
+    def embedding_length(self) -> int:
+        return self.__embedding_length
+
+    def __str__(self):
+        return self.name
+
+
 class BytePairEmbeddings(TokenEmbeddings):
     def __init__(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ bpemb>=0.2.9
 regex
 tabulate
 urllib3<1.25,>=1.20
+langdetect


### PR DESCRIPTION
Closes #852 

Use the new `MuseCrosslingualEmbeddings()` class to embed any sentence in one of 30 languages into the same embedding space. Behind the scenes the class first does language detection of the sentence to be embedded, and then embeds it with the appropriate language embeddings. If you train a classifier or sequence labeler with (only) this class, it will automatically work across all 30 languages, though quality may widely vary. 

Here's how to embed: 
```python
# initialize embeddings
embeddings = MuseCrosslingualEmbeddings()

# two sentences in different languages
sentence_1 = Sentence("This red shoe is new .")
sentence_2 = Sentence("Dieser rote Schuh ist rot .")

# language code is auto-detected
print(sentence_1.get_language_code())
print(sentence_2.get_language_code())

# embed sentences
embeddings.embed([sentence_1, sentence_2])

# print similarities
cos = torch.nn.CosineSimilarity(dim=0, eps=1e-6)
for token_1, token_2 in zip (sentence_1, sentence_2):
    print(f"'{token_1.text}' and '{token_2.text}' similarity: {cos(token_1.embedding, token_2.embedding)}")

```

