### PR TITLE
GH-857: Memory management and interfaces

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from typing import List, Dict, Union
 
-import torch
+import torch, flair
 import logging
 
 from collections import Counter
@@ -146,7 +146,22 @@ class Label:
         return "{} ({})".format(self._value, self._score)
 
 
-class Token:
+class DataPoint:
+    @property
+    @abstractmethod
+    def embedding(self):
+        pass
+
+    @abstractmethod
+    def to(self, device: str):
+        pass
+
+    @abstractmethod
+    def clear_embeddings(self, embedding_names: List[str] = None):
+        pass
+
+
+class Token(DataPoint):
     """
     This class represents one word in a tokenized sentence. Each token may have any number of tags. It may also point
     to its head in a dependency tree.
@@ -198,11 +213,23 @@ class Token:
     def get_head(self):
         return self.sentence.get_token(self.head_id)
 
-    def set_embedding(self, name: str, vector: torch.autograd.Variable):
-        self._embeddings[name] = vector.cpu()
+    def set_embedding(self, name: str, vector: torch.tensor):
+        device = flair.device
+        if len(self._embeddings.keys()) > 0:
+            device = next(iter(self._embeddings.values())).device
+        self._embeddings[name] = vector.to(device, non_blocking=True)
 
-    def clear_embeddings(self):
-        self._embeddings: Dict = {}
+    def to(self, device: str):
+        for name, vector in self._embeddings.items():
+            self._embeddings[name] = vector.to(device, non_blocking=True)
+
+    def clear_embeddings(self, embedding_names: List[str] = None):
+        if embedding_names is None:
+            self._embeddings: Dict = {}
+        else:
+            for name in embedding_names:
+                if name in self._embeddings.keys():
+                    del self._embeddings[name]
 
     def get_embedding(self) -> torch.tensor:
         embeddings = [
@@ -212,7 +239,7 @@ class Token:
         if embeddings:
             return torch.cat(embeddings, dim=0)
 
-        return torch.Tensor()
+        return torch.tensor([], device=flair.device)
 
     def get_subembedding(self, names: List[str]) -> torch.tensor:
         embeddings = [self._embeddings[embed] for embed in sorted(names)]
@@ -308,7 +335,7 @@ class Span:
         )
 
 
-class Sentence:
+class Sentence(DataPoint):
     """
     A Sentence is a list of Tokens and is used to represent a sentence or text fragment.
     """
@@ -397,6 +424,8 @@ class Sentence:
             log.warn(
                 "ACHTUNG: An empty Sentence was created! Are there empty strings in your dataset?"
             )
+
+        self.tokenized = None
 
     def get_token(self, token_id: int) -> Token:
         for token in self.tokens:
@@ -513,7 +542,10 @@ class Sentence:
         return self.get_embedding()
 
     def set_embedding(self, name: str, vector):
-        self._embeddings[name] = vector.cpu()
+        device = flair.device
+        if len(self._embeddings.keys()) > 0:
+            device = next(iter(self._embeddings.values())).device
+        self._embeddings[name] = vector.to(device, non_blocking=True)
 
     def get_embedding(self) -> torch.tensor:
         embeddings = []
@@ -526,16 +558,29 @@ class Sentence:
 
         return torch.Tensor()
 
-    def clear_embeddings(self, also_clear_word_embeddings: bool = True):
-        self._embeddings: Dict = {}
+    def to(self, device: str):
 
-        if also_clear_word_embeddings:
-            for token in self:
-                token.clear_embeddings()
-
-    def cpu_embeddings(self):
+        # move sentence embeddings to device
         for name, vector in self._embeddings.items():
-            self._embeddings[name] = vector.cpu()
+            self._embeddings[name] = vector.to(device, non_blocking=True)
+
+        # move token embeddings to device
+        for token in self:
+            token.to(device)
+
+    def clear_embeddings(self, embedding_names: List[str] = None):
+
+        # clear sentence embeddings
+        if embedding_names is None:
+            self._embeddings: Dict = {}
+        else:
+            for name in embedding_names:
+                if name in self._embeddings.keys():
+                    del self._embeddings[name]
+
+        # clear token embeddings
+        for token in self:
+            token.clear_embeddings(embedding_names)
 
     def to_tagged_string(self, main_tag=None) -> str:
         list = []
@@ -560,7 +605,11 @@ class Sentence:
         return " ".join(list)
 
     def to_tokenized_string(self) -> str:
-        return " ".join([t.text for t in self.tokens])
+
+        if self.tokenized is None:
+            self.tokenized = " ".join([t.text for t in self.tokens])
+
+        return self.tokenized
 
     def to_plain_string(self):
         plain = ""
@@ -689,25 +738,35 @@ class Sentence:
         return self.language_code
 
 
+class FlairDataset(Dataset):
+    @abstractmethod
+    def is_in_memory(self) -> bool:
+        pass
+
+
 class Corpus:
     def __init__(
-        self, train: Dataset, dev: Dataset, test: Dataset, name: str = "corpus"
+        self,
+        train: FlairDataset,
+        dev: FlairDataset,
+        test: FlairDataset,
+        name: str = "corpus",
     ):
-        self._train: Dataset = train
-        self._dev: Dataset = dev
-        self._test: Dataset = test
+        self._train: FlairDataset = train
+        self._dev: FlairDataset = dev
+        self._test: FlairDataset = test
         self.name: str = name
 
     @property
-    def train(self) -> Dataset:
+    def train(self) -> FlairDataset:
         return self._train
 
     @property
-    def dev(self) -> Dataset:
+    def dev(self) -> FlairDataset:
         return self._dev
 
     @property
-    def test(self) -> Dataset:
+    def test(self) -> FlairDataset:
         return self._test
 
     def downsample(self, percentage: float = 0.1, only_downsample_train=False):

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -682,6 +682,9 @@ class CSVClassificationDataset(FlairDataset):
                     if text_column >= len(row):
                         wrong_format = True
 
+                if wrong_format:
+                    continue
+
                 # test if at least one label given
                 has_label = False
                 for column in self.column_name_map:
@@ -689,7 +692,7 @@ class CSVClassificationDataset(FlairDataset):
                         has_label = True
                         break
 
-                if wrong_format or not has_label:
+                if not has_label:
                     continue
 
                 if self.in_memory:

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -11,7 +11,7 @@ import torch.utils.data.dataloader
 from torch.utils.data.dataset import Subset, ConcatDataset
 
 import flair
-from flair.data import Sentence, Corpus, Token
+from flair.data import Sentence, Corpus, Token, FlairDataset
 from flair.file_utils import cached_path
 
 log = logging.getLogger("flair")
@@ -353,12 +353,6 @@ class CSVClassificationCorpus(Corpus):
         )
 
 
-class FlairDataset(Dataset):
-    @abstractmethod
-    def is_in_memory(self) -> bool:
-        pass
-
-
 class SentenceDataset(FlairDataset):
     def __init__(self, sentences: Union[Sentence, List[Sentence]]):
         # cast to list if necessary
@@ -478,6 +472,7 @@ class ColumnDataset(FlairDataset):
 
         if self.in_memory:
             sentence = self.sentences[index]
+
         else:
             with open(str(self.path_to_column_file), encoding="utf-8") as file:
                 file.seek(self.indices[index])

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1304,7 +1304,7 @@ class FlairEmbeddings(TokenEmbeddings):
                     else:
                         offset = offset_backward
 
-                    embedding = all_hidden_states_in_lm[offset, i, :]
+                    embedding = all_hidden_states_in_lm[offset, i, :].detach()
 
                     # if self.tokenized_lm or token.whitespace_after:
                     offset_forward += 1
@@ -1312,7 +1312,7 @@ class FlairEmbeddings(TokenEmbeddings):
 
                     offset_backward -= len(token.text)
 
-                    token.set_embedding(self.name, embedding.clone().detach())
+                    token.set_embedding(self.name, embedding.clone())
 
             all_hidden_states_in_lm = None
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -28,6 +28,7 @@ from pytorch_pretrained_bert.modeling_openai import (
 from pytorch_pretrained_bert.modeling_transfo_xl import (
     PRETRAINED_MODEL_ARCHIVE_MAP as TRANSFORMER_XL_PRETRAINED_MODEL_ARCHIVE_MAP,
 )
+from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 
 import flair
 from flair.data import Corpus
@@ -1068,6 +1069,10 @@ class FlairEmbeddings(TokenEmbeddings):
             "multi-forward-fast": f"{aws_path}/embeddings-v0.4/lm-multi-forward-fast-v0.1.pt",
             "multi-backward-fast": f"{aws_path}/embeddings-v0.4/lm-multi-backward-fast-v0.1.pt",
             # English models
+            "en-forward": f"{aws_path}/embeddings-v0.4.1/big-news-forward--h2048-l1-d0.05-lr30-0.25-20/news-forward-0.4.1.pt",
+            "en-backward": f"{aws_path}/embeddings-v0.4.1/big-news-backward--h2048-l1-d0.05-lr30-0.25-20/news-backward-0.4.1.pt",
+            "en-forward-fast": f"{aws_path}/embeddings/lm-news-english-forward-1024-v0.2rc.pt",
+            "en-backward-fast": f"{aws_path}/embeddings/lm-news-english-backward-1024-v0.2rc.pt",
             "news-forward": f"{aws_path}/embeddings-v0.4.1/big-news-forward--h2048-l1-d0.05-lr30-0.25-20/news-forward-0.4.1.pt",
             "news-backward": f"{aws_path}/embeddings-v0.4.1/big-news-backward--h2048-l1-d0.05-lr30-0.25-20/news-backward-0.4.1.pt",
             "news-forward-fast": f"{aws_path}/embeddings/lm-news-english-forward-1024-v0.2rc.pt",
@@ -2150,38 +2155,31 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
 
         longest_token_sequence_in_batch: int = len(sentences[0])
 
-        all_sentence_tensors = []
+        # all_sentence_tensors = []
         lengths: List[int] = []
 
-        # go through each sentence in batch
-        for i, sentence in enumerate(sentences):
+        # initialize zero-padded word embeddings tensor
+        sentence_tensor = torch.zeros(
+            [
+                len(sentences),
+                longest_token_sequence_in_batch,
+                self.embeddings.embedding_length,
+            ],
+            dtype=torch.float,
+            device=flair.device,
+        )
+
+        # fill values with word embeddings
+        for s_id, sentence in enumerate(sentences):
 
             lengths.append(len(sentence.tokens))
 
-            word_embeddings = []
+            sentence_tensor[s_id][: len(sentence)] = torch.cat(
+                [token.get_embedding().unsqueeze(0) for token in sentence], 0
+            )
 
-            for token, token_idx in zip(sentence.tokens, range(len(sentence.tokens))):
-                word_embeddings.append(token.get_embedding().unsqueeze(0))
-
-            # PADDING: pad shorter sentences out
-            for add in range(longest_token_sequence_in_batch - len(sentence.tokens)):
-                word_embeddings.append(
-                    torch.zeros(
-                        self.length_of_all_token_embeddings, dtype=torch.float
-                    ).unsqueeze(0)
-                )
-
-            word_embeddings_tensor = torch.cat(word_embeddings, 0).to(flair.device)
-
-            sentence_states = word_embeddings_tensor
-
-            # ADD TO SENTENCE LIST: add the representation
-            all_sentence_tensors.append(sentence_states.unsqueeze(1))
-
-        # --------------------------------------------------------------------
-        # GET REPRESENTATION FOR ENTIRE BATCH
-        # --------------------------------------------------------------------
-        sentence_tensor = torch.cat(all_sentence_tensors, 1)
+        # TODO: this can only be removed once the implementations of word_dropout and locked_dropout have a batch_first mode
+        sentence_tensor = sentence_tensor.transpose_(0, 1)
 
         # --------------------------------------------------------------------
         # FF PART
@@ -2194,14 +2192,13 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
             sentence_tensor = self.word_reprojection_map(sentence_tensor)
 
         sentence_tensor = self.dropout(sentence_tensor)
-
-        packed = torch.nn.utils.rnn.pack_padded_sequence(sentence_tensor, lengths)
+        packed = pack_padded_sequence(sentence_tensor, lengths)
 
         self.rnn.flatten_parameters()
 
         rnn_out, hidden = self.rnn(packed)
 
-        outputs, output_lengths = torch.nn.utils.rnn.pad_packed_sequence(rnn_out)
+        outputs, output_lengths = pad_packed_sequence(rnn_out)
 
         outputs = self.dropout(outputs)
 

--- a/flair/hyperparameter/param_selection.py
+++ b/flair/hyperparameter/param_selection.py
@@ -107,7 +107,6 @@ class ParamSelector(object):
 
             result = trainer.train(
                 self.base_path,
-                evaluation_metric=self.evaluation_metric,
                 max_epochs=self.max_epochs,
                 param_selection_mode=True,
                 **training_params,

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -124,13 +124,14 @@ class LanguageModel(nn.Module):
                 ]
                 sequences_as_char_indices.append(char_indices)
 
-            batch = torch.LongTensor(sequences_as_char_indices).transpose(0, 1)
-            batch = batch.to(flair.device)
+            batch = torch.tensor(
+                sequences_as_char_indices, dtype=torch.long, device=flair.device
+            ).transpose(0, 1)
 
             prediction, rnn_output, hidden = self.forward(batch, hidden)
             rnn_output = rnn_output.detach()
 
-            output_parts.append(rnn_output.to("cpu"))
+            output_parts.append(rnn_output)
 
         # concatenate all chunks to make final output
         output = torch.cat(output_parts)

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -375,8 +375,8 @@ class SequenceTagger(flair.nn.Model):
 
         for s_id, sentence in enumerate(sentences):
             # fill values with word embeddings
-            sentence_tensor[s_id][: len(sentence)] = torch.stack(
-                [token.get_embedding() for token in sentence], 0
+            sentence_tensor[s_id][: len(sentence)] = torch.cat(
+                [token.get_embedding().unsqueeze(0) for token in sentence], 0
             )
 
             # get the tags in this sentence

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -209,12 +209,7 @@ class SequenceTagger(flair.nn.Model):
         return model
 
     def evaluate(
-        self,
-        sentences: Dataset,
-        eval_mini_batch_size: int = 32,
-        embeddings_in_memory: bool = True,
-        out_path: Path = None,
-        num_workers: int = 8,
+        self, data_loader: DataLoader, out_path: Path = None
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -222,17 +217,10 @@ class SequenceTagger(flair.nn.Model):
 
             batch_no: int = 0
 
-            batch_loader = DataLoader(
-                sentences,
-                batch_size=eval_mini_batch_size,
-                shuffle=False,
-                num_workers=num_workers,
-            )
-
             metric = Metric("Evaluation")
 
             lines: List[str] = []
-            for batch in batch_loader:
+            for batch in data_loader:
                 batch_no += 1
 
                 with torch.no_grad():
@@ -278,10 +266,6 @@ class SequenceTagger(flair.nn.Model):
                             metric.add_fn(tag)
                         else:
                             metric.add_tn(tag)
-
-                clear_embeddings(
-                    batch, also_clear_word_embeddings=not embeddings_in_memory
-                )
 
             eval_loss /= batch_no
 
@@ -393,8 +377,8 @@ class SequenceTagger(flair.nn.Model):
 
         for s_id, sentence in enumerate(sentences):
             # fill values with word embeddings
-            sentence_tensor[s_id][: len(sentence)] = torch.cat(
-                [token.get_embedding().unsqueeze(0) for token in sentence], 0
+            sentence_tensor[s_id][: len(sentence)] = torch.stack(
+                [token.get_embedding() for token in sentence], 0
             )
 
             # get the tags in this sentence
@@ -403,9 +387,10 @@ class SequenceTagger(flair.nn.Model):
                 for token in sentence
             ]
             # add tags as tensor
-            tag = torch.LongTensor(tag_idx).to(flair.device)
+            tag = torch.tensor(tag_idx, device=flair.device)
             tag_list.append(tag)
 
+        # TODO: this can only be removed once the implementations of word_dropout and locked_dropout have a batch_first mode
         sentence_tensor = sentence_tensor.transpose_(0, 1)
 
         # --------------------------------------------------------------------
@@ -427,7 +412,7 @@ class SequenceTagger(flair.nn.Model):
             rnn_output, hidden = self.rnn(packed)
 
             sentence_tensor, output_lengths = torch.nn.utils.rnn.pad_packed_sequence(
-                rnn_output
+                rnn_output, batch_first=True
             )
 
             if self.use_dropout > 0.0:
@@ -440,17 +425,17 @@ class SequenceTagger(flair.nn.Model):
 
         features = self.linear(sentence_tensor)
 
-        return features.transpose_(0, 1)
+        return features
 
     def _score_sentence(self, feats, tags, lens_):
 
-        start = torch.LongTensor([self.tag_dictionary.get_idx_for_item(START_TAG)]).to(
-            flair.device
+        start = torch.tensor(
+            [self.tag_dictionary.get_idx_for_item(START_TAG)], device=flair.device
         )
         start = start[None, :].repeat(tags.shape[0], 1)
 
-        stop = torch.LongTensor([self.tag_dictionary.get_idx_for_item(STOP_TAG)]).to(
-            flair.device
+        stop = torch.tensor(
+            [self.tag_dictionary.get_idx_for_item(STOP_TAG)], device=flair.device
         )
         stop = stop[None, :].repeat(tags.shape[0], 1)
 
@@ -491,7 +476,7 @@ class SequenceTagger(flair.nn.Model):
                 for token in sentence
             ]
             # add tags as tensor
-            tag = torch.LongTensor(tag_idx).to(flair.device)
+            tag = torch.tensor(tag_idx, device=flair.device)
             tag_list.append(tag)
 
         return self._calculate_loss_old(scores, lengths, tag_list)
@@ -525,9 +510,9 @@ class SequenceTagger(flair.nn.Model):
         self, feature, sentences
     ) -> (List[List[Label]], List[List[List[Label]]]):
         """
-        Returns a tuple of two lists: 
+        Returns a tuple of two lists:
          - The first list corresponds to the most likely `Label` per token in each sentence.
-         - The second list contains a probability distribution over all `Labels` for each token 
+         - The second list contains a probability distribution over all `Labels` for each token
            in a sentence for all sentences.
         """
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -17,7 +17,7 @@ from flair.file_utils import cached_path
 
 from typing import List, Tuple, Union
 
-from flair.training_utils import clear_embeddings, Metric, Result
+from flair.training_utils import Metric, Result, store_embeddings
 
 from tqdm import tqdm
 from tabulate import tabulate
@@ -305,8 +305,8 @@ class SequenceTagger(flair.nn.Model):
         self,
         sentences: Union[List[Sentence], Sentence],
         mini_batch_size=32,
+        embedding_storage_mode="none",
         verbose=False,
-        clear_word_embeddings=True,
     ) -> List[Sentence]:
         with torch.no_grad():
             if isinstance(sentences, Sentence):
@@ -315,7 +315,7 @@ class SequenceTagger(flair.nn.Model):
             filtered_sentences = self._filter_empty_sentences(sentences)
 
             # remove previous embeddings
-            clear_embeddings(filtered_sentences, also_clear_word_embeddings=True)
+            store_embeddings(filtered_sentences, "none")
 
             # revere sort all sequences by their length
             filtered_sentences.sort(key=lambda x: len(x), reverse=True)
@@ -347,9 +347,7 @@ class SequenceTagger(flair.nn.Model):
                         token.add_tags_proba_dist(self.tag_type, token_all_tags)
 
                 # clearing token embeddings to save memory
-                clear_embeddings(
-                    batch, also_clear_word_embeddings=clear_word_embeddings
-                )
+                store_embeddings(batch, storage_mode=embedding_storage_mode)
 
             return sentences
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -149,37 +149,21 @@ class TextClassifier(flair.nn.Model):
             return sentences
 
     def evaluate(
-        self,
-        sentences: List[Sentence],
-        eval_mini_batch_size: int = 32,
-        embeddings_in_memory: bool = False,
-        out_path: Path = None,
-        num_workers: int = 8,
+        self, data_loader: DataLoader, out_path: Path = None
     ) -> (Result, float):
 
         with torch.no_grad():
             eval_loss = 0
 
-            batch_loader = DataLoader(
-                sentences,
-                batch_size=eval_mini_batch_size,
-                shuffle=False,
-                num_workers=num_workers,
-            )
-
             metric = Metric("Evaluation")
 
             lines: List[str] = []
             batch_count: int = 0
-            for batch in batch_loader:
+            for batch in data_loader:
 
                 batch_count += 1
 
                 labels, loss = self.forward_labels_and_loss(batch)
-
-                clear_embeddings(
-                    batch, also_clear_word_embeddings=not embeddings_in_memory
-                )
 
                 eval_loss += loss
 

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 from typing import List, Union
 
 from flair.datasets import DataLoader
-from flair.training_utils import clear_embeddings, Metric, MetricRegression, Result
+from flair.training_utils import MetricRegression, Result, store_embeddings
 from flair.data import Sentence, Label
 import logging
 
@@ -40,7 +40,10 @@ class TextRegressor(flair.models.TextClassifier):
         return vec
 
     def predict(
-        self, sentences: Union[Sentence, List[Sentence]], mini_batch_size: int = 32
+        self,
+        sentences: Union[Sentence, List[Sentence]],
+        mini_batch_size: int = 32,
+        embedding_storage_mode="none",
     ) -> List[Sentence]:
 
         with torch.no_grad():
@@ -48,6 +51,9 @@ class TextRegressor(flair.models.TextClassifier):
                 sentences = [sentences]
 
             filtered_sentences = self._filter_empty_sentences(sentences)
+
+            # remove previous embeddings
+            store_embeddings(filtered_sentences, "none")
 
             batches = [
                 filtered_sentences[x : x + mini_batch_size]
@@ -60,7 +66,8 @@ class TextRegressor(flair.models.TextClassifier):
                 for (sentence, score) in zip(batch, scores.tolist()):
                     sentence.labels = [Label(value=str(score[0]))]
 
-                clear_embeddings(batch)
+                # clearing token embeddings to save memory
+                store_embeddings(batch, storage_mode=embedding_storage_mode)
 
             return sentences
 
@@ -78,6 +85,7 @@ class TextRegressor(flair.models.TextClassifier):
     def forward_labels_and_loss(
         self, sentences: Union[Sentence, List[Sentence]]
     ) -> (List[List[float]], torch.tensor):
+
         scores = self.forward(sentences)
         loss = self._calculate_loss(scores, sentences)
         return scores, loss
@@ -92,12 +100,17 @@ class TextRegressor(flair.models.TextClassifier):
             metric = MetricRegression("Evaluation")
 
             lines: List[str] = []
-            for batch in data_loader:
+            total_count = 0
+            for batch_nr, batch in enumerate(data_loader):
+
+                if isinstance(batch, Sentence):
+                    batch = [batch]
 
                 scores, loss = self.forward_labels_and_loss(batch)
 
                 true_values = []
                 for sentence in batch:
+                    total_count += 1
                     for label in sentence.labels:
                         true_values.append(float(label.value))
 
@@ -121,7 +134,7 @@ class TextRegressor(flair.models.TextClassifier):
                     )
                     lines.append(eval_line)
 
-            eval_loss /= len(sentences)
+            eval_loss /= total_count
 
             ##TODO: not saving lines yet
             if out_path is not None:

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -83,28 +83,16 @@ class TextRegressor(flair.models.TextClassifier):
         return scores, loss
 
     def evaluate(
-        self,
-        sentences: List[Sentence],
-        eval_mini_batch_size: int = 32,
-        embeddings_in_memory: bool = False,
-        out_path: Path = None,
-        num_workers: int = 8,
+        self, data_loader: DataLoader, out_path: Path = None
     ) -> (Result, float):
 
         with torch.no_grad():
             eval_loss = 0
 
-            batch_loader = DataLoader(
-                sentences,
-                batch_size=eval_mini_batch_size,
-                shuffle=False,
-                num_workers=num_workers,
-            )
-
             metric = MetricRegression("Evaluation")
 
             lines: List[str] = []
-            for batch in batch_loader:
+            for batch in data_loader:
 
                 scores, loss = self.forward_labels_and_loss(batch)
 
@@ -119,10 +107,6 @@ class TextRegressor(flair.models.TextClassifier):
                         results.append(float(score[0].score))
                     else:
                         results.append(float(score[0]))
-
-                clear_embeddings(
-                    batch, also_clear_word_embeddings=not embeddings_in_memory
-                )
 
                 eval_loss += loss
 

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -9,6 +9,7 @@ from typing import Union, List
 
 import flair
 from flair.data import Sentence
+from flair.datasets import FlairDataset, DataLoader
 from flair.training_utils import Result
 
 
@@ -31,14 +32,9 @@ class Model(torch.nn.Module):
 
     @abstractmethod
     def evaluate(
-        self,
-        sentences: List[Sentence],
-        eval_mini_batch_size: int = 32,
-        embeddings_in_memory: bool = False,
-        out_path: Path = None,
-        num_workers: int = 8,
+        self, data_loader: DataLoader, out_path: Path = None
     ) -> (Result, float):
-        """Evaluates the model on a list of gold-labeled Sentences. Returns a Result object containing evaluation
+        """Evaluates the model. Returns a Result object containing evaluation
         results and a loss value. Implement this to enable evaluation."""
         pass
 

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -11,13 +11,12 @@ from torch.utils.data.dataset import ConcatDataset
 
 import flair
 import flair.nn
-from flair.data import Sentence, MultiCorpus, Corpus
+from flair.data import MultiCorpus, Corpus
 from flair.datasets import DataLoader
 from flair.optim import ExpAnnealLR
 from flair.training_utils import (
     init_output_file,
     WeightExtractor,
-    EvaluationMetric,
     log_line,
     add_file_handler,
     Result,
@@ -49,7 +48,6 @@ class ModelTrainer:
     def train(
         self,
         base_path: Union[Path, str],
-        evaluation_metric: EvaluationMetric = EvaluationMetric.MICRO_F1_SCORE,
         learning_rate: float = 0.1,
         mini_batch_size: int = 32,
         eval_mini_batch_size: int = None,
@@ -70,6 +68,33 @@ class ModelTrainer:
         sampler=None,
         **kwargs,
     ) -> dict:
+        """
+        Trains any class that implements the flair.nn.Model interface.
+        :param base_path: Main path to which all output during training is logged and models are saved
+        :param learning_rate: Initial learning rate
+        :param mini_batch_size: Size of mini-batches during training
+        :param eval_mini_batch_size: Size of mini-batches during evaluation
+        :param max_epochs: Maximum number of epochs to train. Terminates training if this number is surpassed.
+        :param anneal_factor: The factor by which the learning rate is annealed
+        :param patience: Patience is the number of epochs with no improvement the Trainer waits
+         until annealing the learning rate
+        :param min_learning_rate: If the learning rate falls below this threshold, training terminates
+        :param train_with_dev: If True, training is performed using both train+dev data
+        :param monitor_train: If True, training data is evaluated at end of each epoch
+        :param monitor_test: If True, test data is evaluated at end of each epoch
+        :param embedding_storage_mode: One of 'none' (all embeddings are deleted and freshly recomputed),
+        'cpu' (embeddings are stored on CPU) or 'gpu' (embeddings are stored on GPU)
+        :param checkpoint: If True, a full checkpoint is saved at end of each epoch
+        :param save_final_model: If True, final model is saved
+        :param anneal_with_restarts: If True, the last best model is restored when annealing the learning rate
+        :param shuffle: If True, data is shuffled during training
+        :param param_selection_mode: If True, testing is performed against dev data. Use this mode when doing
+        parameter selection.
+        :param num_workers: Number of workers in your data loader.
+        :param sampler: You can pass a data sampler here for special sampling of data.
+        :param kwargs: Other arguments for the Optimizer
+        :return:
+        """
 
         if eval_mini_batch_size is None:
             eval_mini_batch_size = mini_batch_size
@@ -95,8 +120,6 @@ class ModelTrainer:
         log.info(f' - train_with_dev: "{train_with_dev}"')
         log_line(log)
         log.info(f'Model training base path: "{base_path}"')
-        log_line(log)
-        log.info(f"Evaluation method: {evaluation_metric.name}")
         log_line(log)
         log.info(f"Device: {flair.device}")
         log_line(log)

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -336,3 +336,28 @@ def add_file_handler(log, output_file):
     fh.setFormatter(formatter)
     log.addHandler(fh)
     return fh
+
+
+def store_embeddings(sentences: List[Sentence], storage_mode: str):
+
+    # if memory mode option 'none' delete everything
+    if storage_mode == "none":
+        for sentence in sentences:
+            sentence.clear_embeddings()
+
+    # else delete only dynamic embeddings (otherwise autograd will keep everything in memory)
+    else:
+        # find out which ones are dynamic embeddings
+        delete_keys = []
+        for name, vector in sentences[0][0]._embeddings.items():
+            if sentences[0][0]._embeddings[name].requires_grad:
+                delete_keys.append(name)
+
+        # find out which ones are dynamic embeddings
+        for sentence in sentences:
+            sentence.clear_embeddings(delete_keys)
+
+    # memory management - option 1: send everything to CPU
+    if storage_mode == "cpu":
+        for sentence in sentences:
+            sentence.to("cpu")

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -295,15 +295,6 @@ class WeightExtractor(object):
         self.weights_dict[key] = indices
 
 
-def clear_embeddings(sentences: List[Sentence], also_clear_word_embeddings=False):
-    """
-    Clears the embeddings from all given sentences.
-    :param sentences: list of sentences
-    """
-    for sentence in sentences:
-        sentence.clear_embeddings(also_clear_word_embeddings=also_clear_word_embeddings)
-
-
 def init_output_file(base_path: Path, file_name: str) -> Path:
     """
     Creates a local file.

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -790,6 +790,6 @@ def test_keep_word_embeddings():
     for token in sentence:
         assert len(token.embedding.numpy()) == 0
 
-    loaded_model.predict(sentence, clear_word_embeddings=False)
+    loaded_model.predict(sentence)
     for token in sentence:
         assert len(token.embedding.numpy()) > 0

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -790,6 +790,6 @@ def test_keep_word_embeddings():
     for token in sentence:
         assert len(token.embedding.numpy()) == 0
 
-    loaded_model.predict(sentence)
+    loaded_model.predict(sentence, embedding_storage_mode="cpu")
     for token in sentence:
         assert len(token.embedding.numpy()) > 0

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -43,7 +43,6 @@ def test_train_load_use_tagger(results_base_path, tasks_base_path):
 
     trainer.train(
         results_base_path,
-        EvaluationMetric.MICRO_F1_SCORE,
         learning_rate=0.1,
         mini_batch_size=2,
         max_epochs=2,
@@ -85,7 +84,6 @@ def test_train_load_use_tagger_large(results_base_path, tasks_base_path):
 
     trainer.train(
         results_base_path,
-        EvaluationMetric.MICRO_F1_SCORE,
         learning_rate=0.1,
         mini_batch_size=32,
         max_epochs=2,
@@ -129,7 +127,6 @@ def test_train_charlm_load_use_tagger(results_base_path, tasks_base_path):
 
     trainer.train(
         results_base_path,
-        EvaluationMetric.MICRO_F1_SCORE,
         learning_rate=0.1,
         mini_batch_size=2,
         max_epochs=2,
@@ -178,7 +175,6 @@ def test_train_charlm_changed_chache_load_use_tagger(
 
     trainer.train(
         results_base_path,
-        EvaluationMetric.MACRO_ACCURACY,
         learning_rate=0.1,
         mini_batch_size=2,
         max_epochs=2,
@@ -270,7 +266,6 @@ def test_train_optimizer(results_base_path, tasks_base_path):
 
     trainer.train(
         results_base_path,
-        EvaluationMetric.MICRO_F1_SCORE,
         learning_rate=0.1,
         mini_batch_size=2,
         max_epochs=2,
@@ -316,7 +311,6 @@ def test_train_optimizer_arguments(results_base_path, tasks_base_path):
 
     trainer.train(
         results_base_path,
-        EvaluationMetric.MICRO_F1_SCORE,
         learning_rate=0.1,
         mini_batch_size=2,
         max_epochs=2,
@@ -401,9 +395,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
     model = TextClassifier(document_embeddings, label_dict, False)
 
     trainer = ModelTrainer(model, corpus)
-    trainer.train(
-        results_base_path, EvaluationMetric.MICRO_F1_SCORE, max_epochs=2, shuffle=False
-    )
+    trainer.train(results_base_path, max_epochs=2, shuffle=False)
 
     sentence = Sentence("Berlin is a really nice city.")
 
@@ -439,9 +431,7 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
     model = TextClassifier(document_embeddings, label_dict, False)
 
     trainer = ModelTrainer(model, corpus)
-    trainer.train(
-        results_base_path, EvaluationMetric.MICRO_F1_SCORE, max_epochs=2, shuffle=False
-    )
+    trainer.train(results_base_path, max_epochs=2, shuffle=False)
 
     sentence = Sentence("Berlin is a really nice city.")
 
@@ -482,7 +472,6 @@ def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_pat
     trainer = ModelTrainer(model, corpus)
     trainer.train(
         results_base_path,
-        EvaluationMetric.MICRO_F1_SCORE,
         mini_batch_size=1,
         max_epochs=100,
         shuffle=False,
@@ -537,9 +526,7 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
     model = TextClassifier(document_embeddings, label_dict, False)
 
     trainer = ModelTrainer(model, corpus)
-    trainer.train(
-        results_base_path, EvaluationMetric.MACRO_F1_SCORE, max_epochs=2, shuffle=False
-    )
+    trainer.train(results_base_path, max_epochs=2, shuffle=False)
 
     sentence = Sentence("Berlin is a really nice city.")
 


### PR DESCRIPTION
This PR introduces a number of changes to address memory management and slim down some interfaces. 

For **memory management**, it introduces the `embedding_storage_mode` parameter to the `ModelTrainer` class and `predict()` methods. This parameter can be one of 'none', 'cpu' and 'gpu':
- If 'none' all embeddings are deleted after usage - this has lowest memory requirements but means that embeddings need to be recomputed at each epoch of training potentially causing a slowdown. 
- If 'cpu' all embeddings are moved to CPU memory after usage. During training, this means that they only need to be moved back to GPU for the forward pass, and not recomputed so in many cases this is faster, but requires memory. 
- If 'gpu' all embeddings stay on GPU memory after computation. This eliminates memory shuffling during training, causing a speedup. However this option requires enough GPU memory to be available for all embeddings of the dataset. 

To use this option during training, simply set the parameter: 

```python
        # initialize trainer
        trainer: ModelTrainer = ModelTrainer(tagger, corpus)
        trainer.train(
            "path/to/your/model",
            embedding_storage_mode='gpu',
        )
```

In terms of **interfaces**, this PR introduces the `DataPoint` interface that is currently implemented by the `Token` and `Sentence` classes. The interface currently only has a `embedding` property, meaning that each `DataPoint` in Flair needs to be able to get an embedding. We will utilize this interface in the near future to extend Flair to other data types besides words and sentences.

It also slims down the `evaluate()` method in the `flair.nn.Model` interface to take a `DataLoader` instead of a group of parameters.