### PR TITLE
GH-921: fine-tune FlairEmbeddings

### DIFF
--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -129,7 +129,6 @@ class LanguageModel(nn.Module):
             ).transpose(0, 1)
 
             prediction, rnn_output, hidden = self.forward(batch, hidden)
-            rnn_output = rnn_output.detach()
 
             output_parts.append(rnn_output)
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -4,16 +4,14 @@ from pathlib import Path
 
 import torch.nn
 from torch.nn.parameter import Parameter
-from torch.optim import Optimizer
 import torch.nn.functional as F
-from torch.utils.data.dataset import Dataset
 
 import flair.nn
 import torch
 
-import flair.embeddings
 from flair.data import Dictionary, Sentence, Token, Label
 from flair.datasets import DataLoader
+from flair.embeddings import TokenEmbeddings
 from flair.file_utils import cached_path
 
 from typing import List, Tuple, Union
@@ -71,7 +69,7 @@ class SequenceTagger(flair.nn.Model):
     def __init__(
         self,
         hidden_size: int,
-        embeddings: flair.embeddings.TokenEmbeddings,
+        embeddings: TokenEmbeddings,
         tag_dictionary: Dictionary,
         tag_type: str,
         use_crf: bool = True,
@@ -291,6 +289,8 @@ class SequenceTagger(flair.nn.Model):
                             metric.add_fn(tag)
                         else:
                             metric.add_tn(tag)
+
+                store_embeddings(batch, "gpu")
 
             eval_loss /= batch_no
 

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -149,100 +149,6 @@ def test_train_charlm_load_use_tagger(results_base_path, tasks_base_path):
 
 
 @pytest.mark.integration
-def test_train_charlm_changed_chache_load_use_tagger(
-    results_base_path, tasks_base_path
-):
-    corpus = flair.datasets.ColumnCorpus(
-        data_folder=tasks_base_path / "fashion", column_format={0: "text", 2: "ner"}
-    )
-    tag_dictionary = corpus.make_tag_dictionary("ner")
-
-    # make a temporary cache directory that we remove afterwards
-    cache_dir = results_base_path / "cache"
-    os.makedirs(cache_dir, exist_ok=True)
-    embeddings = FlairEmbeddings("news-forward-fast", cache_directory=cache_dir)
-
-    tagger: SequenceTagger = SequenceTagger(
-        hidden_size=64,
-        embeddings=embeddings,
-        tag_dictionary=tag_dictionary,
-        tag_type="ner",
-        use_crf=False,
-    )
-
-    # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus)
-
-    trainer.train(
-        results_base_path,
-        learning_rate=0.1,
-        mini_batch_size=2,
-        max_epochs=2,
-        shuffle=False,
-    )
-
-    # remove the cache directory
-    shutil.rmtree(cache_dir)
-
-    loaded_model: SequenceTagger = SequenceTagger.load(
-        results_base_path / "final-model.pt"
-    )
-
-    sentence = Sentence("I love Berlin")
-    sentence_empty = Sentence("       ")
-
-    loaded_model.predict(sentence)
-    loaded_model.predict([sentence, sentence_empty])
-    loaded_model.predict([sentence_empty])
-
-    # clean up results directory
-    shutil.rmtree(results_base_path)
-
-
-@pytest.mark.integration
-def test_train_charlm_nochache_load_use_tagger(results_base_path, tasks_base_path):
-    corpus = flair.datasets.ColumnCorpus(
-        data_folder=tasks_base_path / "fashion", column_format={0: "text", 2: "ner"}
-    )
-    tag_dictionary = corpus.make_tag_dictionary("ner")
-
-    embeddings = FlairEmbeddings("news-forward-fast", use_cache=False)
-
-    tagger: SequenceTagger = SequenceTagger(
-        hidden_size=64,
-        embeddings=embeddings,
-        tag_dictionary=tag_dictionary,
-        tag_type="ner",
-        use_crf=False,
-    )
-
-    # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus)
-
-    trainer.train(
-        results_base_path,
-        learning_rate=0.1,
-        mini_batch_size=2,
-        max_epochs=2,
-        shuffle=False,
-    )
-
-    loaded_model: SequenceTagger = SequenceTagger.load(
-        results_base_path / "final-model.pt"
-    )
-
-    sentence = Sentence("I love Berlin")
-    sentence_empty = Sentence("       ")
-
-    loaded_model.predict(sentence)
-    loaded_model.predict([sentence, sentence_empty])
-    loaded_model.predict([sentence_empty])
-
-    # clean up results directory
-    shutil.rmtree(results_base_path)
-
-
-@pytest.mark.integration
 def test_train_optimizer(results_base_path, tasks_base_path):
     corpus = flair.datasets.ColumnCorpus(
         data_folder=tasks_base_path / "fashion", column_format={0: "text", 2: "ner"}
@@ -584,42 +490,6 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
 
 
 @pytest.mark.integration
-def test_train_charlm_nocache_load_use_classifier(results_base_path, tasks_base_path):
-    corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
-    label_dict = corpus.make_label_dictionary()
-
-    embedding: TokenEmbeddings = FlairEmbeddings("news-forward-fast", use_cache=False)
-    document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
-        [embedding], 128, 1, False, 64, False, False
-    )
-
-    model = TextClassifier(document_embeddings, label_dict, False)
-
-    trainer = ModelTrainer(model, corpus)
-    trainer.train(results_base_path, max_epochs=2, shuffle=False)
-
-    sentence = Sentence("Berlin is a really nice city.")
-
-    for s in model.predict(sentence):
-        for l in s.labels:
-            assert l.value is not None
-            assert 0.0 <= l.score <= 1.0
-            assert type(l.score) is float
-
-    loaded_model = TextClassifier.load(results_base_path / "final-model.pt")
-
-    sentence = Sentence("I love Berlin")
-    sentence_empty = Sentence("       ")
-
-    loaded_model.predict(sentence)
-    loaded_model.predict([sentence, sentence_empty])
-    loaded_model.predict([sentence_empty])
-
-    # clean up results directory
-    shutil.rmtree(results_base_path)
-
-
-@pytest.mark.integration
 def test_train_language_model(results_base_path, resources_path):
     # get default dictionary
     dictionary: Dictionary = Dictionary.load("chars")
@@ -709,7 +579,7 @@ def test_train_resume_text_classification_training(results_base_path, tasks_base
     corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
     label_dict = corpus.make_label_dictionary()
 
-    embeddings: TokenEmbeddings = FlairEmbeddings("news-forward-fast", use_cache=False)
+    embeddings: TokenEmbeddings = FlairEmbeddings("news-forward-fast")
     document_embeddings: DocumentRNNEmbeddings = DocumentRNNEmbeddings(
         [embeddings], 128, 1, False
     )


### PR DESCRIPTION
Closes #921 

This PR makes FlairEmbeddings task-trainable. This allows users to (a) fine-tune an existing language model on task data and (b) train a new model only on task data.

- You can **fine-tune an existing LM** by simply passing the `fine_tune` parameter in the `FlairEmbeddings` constructor, like this: 

```python
embeddings = FlairEmbeddings('news-foward', fine_tune=True)
```

- You can **task-train a wholly new language model** by passing an empty `LanguageModel` to the `FlairEmbeddings` constructor and the `fine_tune` parameter, like this: 


```python
# make an empty language model
language_model = LanguageModel(
    Dictionary.load('chars'),
    is_forward_lm=True,
    hidden_size=256,
    nlayers=1)

# init FlairEmbeddings to task-train this model
embeddings = FlairEmbeddings(language_model, fine_tune=True)
```

- Also closes #880 by fixing the embedding printout.

- This PR also removes the `FlairEmbeddings`-specific disk-caching mechanism. In the future, a more general caching mechanism applicable to all embedding types should be added on a different level of logic, potentially as a feature in the `ModelTrainer`. 
