### PR TITLE
GH-891: memory storage

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -115,7 +115,7 @@ class DocumentEmbeddings(Embeddings):
 class StackedEmbeddings(TokenEmbeddings):
     """A stack of embeddings, used if you need to combine several different embedding types."""
 
-    def __init__(self, embeddings: List[TokenEmbeddings], detach: bool = True):
+    def __init__(self, embeddings: List[TokenEmbeddings]):
         """The constructor takes a list of embeddings to be combined."""
         super().__init__()
 
@@ -125,7 +125,6 @@ class StackedEmbeddings(TokenEmbeddings):
         for i, embedding in enumerate(embeddings):
             self.add_module("list_embedding_{}".format(i), embedding)
 
-        self.detach: bool = detach
         self.name: str = "Stack"
         self.static_embeddings: bool = True
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -324,10 +324,10 @@ class SequenceTagger(flair.nn.Model):
             return result, eval_loss
 
     def forward_loss(
-        self, sentences: Union[List[Sentence], Sentence], sort=True
+        self, data_points: Union[List[Sentence], Sentence], sort=True
     ) -> torch.tensor:
-        features = self.forward(sentences)
-        return self._calculate_loss(features, sentences)
+        features = self.forward(data_points)
+        return self._calculate_loss(features, data_points)
 
     def predict(
         self,

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -235,7 +235,7 @@ class SequenceTagger(flair.nn.Model):
         self,
         data_loader: DataLoader,
         out_path: Path = None,
-        embedding_storage_mode: str = "cpu",
+        embeddings_storage_mode: str = "cpu",
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -293,7 +293,7 @@ class SequenceTagger(flair.nn.Model):
                         else:
                             metric.add_tn(tag)
 
-                store_embeddings(batch, embedding_storage_mode)
+                store_embeddings(batch, embeddings_storage_mode)
 
             eval_loss /= batch_no
 
@@ -331,16 +331,16 @@ class SequenceTagger(flair.nn.Model):
 
     def predict(
         self,
-        sentences: Union[List[Sentence], Sentence],
+        data_points: Union[List[Sentence], Sentence],
         mini_batch_size=32,
         embedding_storage_mode="none",
         verbose=False,
     ) -> List[Sentence]:
         with torch.no_grad():
-            if isinstance(sentences, Sentence):
-                sentences = [sentences]
+            if isinstance(data_points, Sentence):
+                data_points = [data_points]
 
-            filtered_sentences = self._filter_empty_sentences(sentences)
+            filtered_sentences = self._filter_empty_sentences(data_points)
 
             # remove previous embeddings
             store_embeddings(filtered_sentences, "none")
@@ -377,7 +377,7 @@ class SequenceTagger(flair.nn.Model):
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
-            return sentences
+            return data_points
 
     def forward(self, sentences: List[Sentence]):
         self.zero_grad()

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -331,16 +331,16 @@ class SequenceTagger(flair.nn.Model):
 
     def predict(
         self,
-        data_points: Union[List[Sentence], Sentence],
+        sentences: Union[List[Sentence], Sentence],
         mini_batch_size=32,
         embedding_storage_mode="none",
         verbose=False,
     ) -> List[Sentence]:
         with torch.no_grad():
-            if isinstance(data_points, Sentence):
-                data_points = [data_points]
+            if isinstance(sentences, Sentence):
+                sentences = [sentences]
 
-            filtered_sentences = self._filter_empty_sentences(data_points)
+            filtered_sentences = self._filter_empty_sentences(sentences)
 
             # remove previous embeddings
             store_embeddings(filtered_sentences, "none")
@@ -377,7 +377,7 @@ class SequenceTagger(flair.nn.Model):
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
-            return data_points
+            return sentences
 
     def forward(self, sentences: List[Sentence]):
         self.zero_grad()

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -232,7 +232,10 @@ class SequenceTagger(flair.nn.Model):
         return model
 
     def evaluate(
-        self, data_loader: DataLoader, out_path: Path = None
+        self,
+        data_loader: DataLoader,
+        out_path: Path = None,
+        embedding_storage_mode: str = "cpu",
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -290,7 +293,7 @@ class SequenceTagger(flair.nn.Model):
                         else:
                             metric.add_tn(tag)
 
-                store_embeddings(batch, "gpu")
+                store_embeddings(batch, embedding_storage_mode)
 
             eval_loss /= batch_no
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -156,7 +156,10 @@ class TextClassifier(flair.nn.Model):
             return sentences
 
     def evaluate(
-        self, data_loader: DataLoader, out_path: Path = None
+        self,
+        data_loader: DataLoader,
+        out_path: Path = None,
+        embeddings_storage_mode: str = "cpu",
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -222,6 +225,8 @@ class TextClassifier(flair.nn.Model):
                             and label not in true_values_for_sentence
                         ):
                             metric.add_tn(label)
+
+                store_embeddings(batch, embeddings_storage_mode)
 
             eval_loss /= batch_count
 

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -115,23 +115,23 @@ class TextClassifier(flair.nn.Model):
 
     def predict(
         self,
-        data_points: Union[Sentence, List[Sentence]],
+        sentences: Union[Sentence, List[Sentence]],
         mini_batch_size: int = 32,
         embedding_storage_mode="none",
         multi_class_prob: bool = False,
     ) -> List[Sentence]:
         """
         Predicts the class labels for the given sentences. The labels are directly added to the sentences.
-        :param data_points: list of sentences
+        :param sentences: list of sentences
         :param mini_batch_size: mini batch size to use
         :param multi_class_prob : return probability for all class for multiclass
         :return: the list of sentences containing the labels
         """
         with torch.no_grad():
-            if type(data_points) is Sentence:
-                data_points = [data_points]
+            if type(sentences) is Sentence:
+                sentences = [sentences]
 
-            filtered_sentences = self._filter_empty_sentences(data_points)
+            filtered_sentences = self._filter_empty_sentences(sentences)
 
             # remove previous embeddings
             store_embeddings(filtered_sentences, "none")
@@ -153,7 +153,7 @@ class TextClassifier(flair.nn.Model):
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
-            return data_points
+            return sentences
 
     def evaluate(
         self,

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -115,23 +115,23 @@ class TextClassifier(flair.nn.Model):
 
     def predict(
         self,
-        sentences: Union[Sentence, List[Sentence]],
+        data_points: Union[Sentence, List[Sentence]],
         mini_batch_size: int = 32,
         embedding_storage_mode="none",
         multi_class_prob: bool = False,
     ) -> List[Sentence]:
         """
         Predicts the class labels for the given sentences. The labels are directly added to the sentences.
-        :param sentences: list of sentences
+        :param data_points: list of sentences
         :param mini_batch_size: mini batch size to use
         :param multi_class_prob : return probability for all class for multiclass
         :return: the list of sentences containing the labels
         """
         with torch.no_grad():
-            if type(sentences) is Sentence:
-                sentences = [sentences]
+            if type(data_points) is Sentence:
+                data_points = [data_points]
 
-            filtered_sentences = self._filter_empty_sentences(sentences)
+            filtered_sentences = self._filter_empty_sentences(data_points)
 
             # remove previous embeddings
             store_embeddings(filtered_sentences, "none")
@@ -153,7 +153,7 @@ class TextClassifier(flair.nn.Model):
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
-            return sentences
+            return data_points
 
     def evaluate(
         self,

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -100,10 +100,12 @@ class TextClassifier(flair.nn.Model):
         model.load_state_dict(state["state_dict"])
         return model
 
-    def forward_loss(self, sentences: Union[List[Sentence], Sentence]) -> torch.tensor:
+    def forward_loss(
+        self, data_points: Union[List[Sentence], Sentence]
+    ) -> torch.tensor:
 
-        scores = self.forward(sentences)
-        return self._calculate_loss(scores, sentences)
+        scores = self.forward(data_points)
+        return self._calculate_loss(scores, data_points)
 
     def forward_labels_and_loss(
         self, sentences: Union[Sentence, List[Sentence]]

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -41,16 +41,16 @@ class TextRegressor(flair.models.TextClassifier):
 
     def predict(
         self,
-        data_points: Union[Sentence, List[Sentence]],
+        sentences: Union[Sentence, List[Sentence]],
         mini_batch_size: int = 32,
         embedding_storage_mode="none",
     ) -> List[Sentence]:
 
         with torch.no_grad():
-            if type(data_points) is Sentence:
-                data_points = [data_points]
+            if type(sentences) is Sentence:
+                sentences = [sentences]
 
-            filtered_sentences = self._filter_empty_sentences(data_points)
+            filtered_sentences = self._filter_empty_sentences(sentences)
 
             # remove previous embeddings
             store_embeddings(filtered_sentences, "none")
@@ -69,7 +69,7 @@ class TextRegressor(flair.models.TextClassifier):
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
-            return data_points
+            return sentences
 
     def _calculate_loss(
         self, scores: torch.tensor, sentences: List[Sentence]

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -91,7 +91,10 @@ class TextRegressor(flair.models.TextClassifier):
         return scores, loss
 
     def evaluate(
-        self, data_loader: DataLoader, out_path: Path = None
+        self,
+        data_loader: DataLoader,
+        out_path: Path = None,
+        embedding_storage_mode: str = "cpu",
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -133,6 +136,8 @@ class TextRegressor(flair.models.TextClassifier):
                         sentence.to_original_text(), true_value, prediction
                     )
                     lines.append(eval_line)
+
+                store_embeddings(batch, embedding_storage_mode)
 
             eval_loss /= total_count
 

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -41,16 +41,16 @@ class TextRegressor(flair.models.TextClassifier):
 
     def predict(
         self,
-        sentences: Union[Sentence, List[Sentence]],
+        data_points: Union[Sentence, List[Sentence]],
         mini_batch_size: int = 32,
         embedding_storage_mode="none",
     ) -> List[Sentence]:
 
         with torch.no_grad():
-            if type(sentences) is Sentence:
-                sentences = [sentences]
+            if type(data_points) is Sentence:
+                data_points = [data_points]
 
-            filtered_sentences = self._filter_empty_sentences(sentences)
+            filtered_sentences = self._filter_empty_sentences(data_points)
 
             # remove previous embeddings
             store_embeddings(filtered_sentences, "none")
@@ -69,7 +69,7 @@ class TextRegressor(flair.models.TextClassifier):
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
-            return sentences
+            return data_points
 
     def _calculate_loss(
         self, scores: torch.tensor, sentences: List[Sentence]
@@ -94,7 +94,7 @@ class TextRegressor(flair.models.TextClassifier):
         self,
         data_loader: DataLoader,
         out_path: Path = None,
-        embedding_storage_mode: str = "cpu",
+        embeddings_storage_mode: str = "cpu",
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -137,7 +137,7 @@ class TextRegressor(flair.models.TextClassifier):
                     )
                     lines.append(eval_line)
 
-                store_embeddings(batch, embedding_storage_mode)
+                store_embeddings(batch, embeddings_storage_mode)
 
             eval_loss /= total_count
 

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -19,7 +19,7 @@ class Model(torch.nn.Module):
 
     @abstractmethod
     def forward_loss(
-        self, sentences: Union[List[DataPoint], DataPoint]
+        self, data_points: Union[List[DataPoint], DataPoint]
     ) -> torch.tensor:
         """Performs a forward pass and returns a loss tensor for backpropagation. Implement this to enable training."""
         pass

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -25,24 +25,6 @@ class Model(torch.nn.Module):
         pass
 
     @abstractmethod
-    def predict(
-        self,
-        data_points: Union[List[DataPoint], DataPoint],
-        mini_batch_size=32,
-        embeddings_storage_mode: str = "none",
-    ) -> List[DataPoint]:
-        """
-        :param data_points: DataPoints for which to make a prediction
-        :param mini_batch_size: size of mini batches during prediction
-        :param embeddings_storage_mode: One of 'none', 'cpu' or 'gpu'. 'none' means all embeddings are deleted and
-        freshly recomputed, 'cpu' means all embeddings are stored on CPU, or 'gpu' means all embeddings are stored on GPU
-        :return: List of DataPoint with predictions
-        """
-        """Predicts the labels/tags for the given list of sentences. The labels/tags are added directly to the
-        sentences. Implement this to enable prediction."""
-        pass
-
-    @abstractmethod
     def evaluate(
         self,
         data_loader: DataLoader,

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -24,7 +24,10 @@ class Model(torch.nn.Module):
 
     @abstractmethod
     def predict(
-        self, sentences: Union[List[Sentence], Sentence], mini_batch_size=32
+        self,
+        sentences: Union[List[Sentence], Sentence],
+        mini_batch_size=32,
+        embeddings_storage_mode: str = "none",
     ) -> List[Sentence]:
         """Predicts the labels/tags for the given list of sentences. The labels/tags are added directly to the
         sentences. Implement this to enable prediction."""
@@ -32,7 +35,10 @@ class Model(torch.nn.Module):
 
     @abstractmethod
     def evaluate(
-        self, data_loader: DataLoader, out_path: Path = None
+        self,
+        data_loader: DataLoader,
+        out_path: Path = None,
+        embeddings_storage_mode: str = "cpu",
     ) -> (Result, float):
         """Evaluates the model. Returns a Result object containing evaluation
         results and a loss value. Implement this to enable evaluation."""

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -8,8 +8,8 @@ from abc import abstractmethod
 from typing import Union, List
 
 import flair
-from flair.data import Sentence
-from flair.datasets import FlairDataset, DataLoader
+from flair.data import DataPoint
+from flair.datasets import DataLoader
 from flair.training_utils import Result
 
 
@@ -18,17 +18,26 @@ class Model(torch.nn.Module):
     Every new type of model must implement these methods."""
 
     @abstractmethod
-    def forward_loss(self, sentences: Union[List[Sentence], Sentence]) -> torch.tensor:
+    def forward_loss(
+        self, sentences: Union[List[DataPoint], DataPoint]
+    ) -> torch.tensor:
         """Performs a forward pass and returns a loss tensor for backpropagation. Implement this to enable training."""
         pass
 
     @abstractmethod
     def predict(
         self,
-        sentences: Union[List[Sentence], Sentence],
+        data_points: Union[List[DataPoint], DataPoint],
         mini_batch_size=32,
         embeddings_storage_mode: str = "none",
-    ) -> List[Sentence]:
+    ) -> List[DataPoint]:
+        """
+        :param data_points: DataPoints for which to make a prediction
+        :param mini_batch_size: size of mini batches during prediction
+        :param embeddings_storage_mode: One of 'none', 'cpu' or 'gpu'. 'none' means all embeddings are deleted and
+        freshly recomputed, 'cpu' means all embeddings are stored on CPU, or 'gpu' means all embeddings are stored on GPU
+        :return: List of DataPoint with predictions
+        """
         """Predicts the labels/tags for the given list of sentences. The labels/tags are added directly to the
         sentences. Implement this to enable prediction."""
         pass
@@ -41,7 +50,13 @@ class Model(torch.nn.Module):
         embeddings_storage_mode: str = "cpu",
     ) -> (Result, float):
         """Evaluates the model. Returns a Result object containing evaluation
-        results and a loss value. Implement this to enable evaluation."""
+        results and a loss value. Implement this to enable evaluation.
+        :param data_loader: DataLoader that iterates over dataset to be evaluated
+        :param out_path: Optional output path to store predictions
+        :param embeddings_storage_mode: One of 'none', 'cpu' or 'gpu'. 'none' means all embeddings are deleted and
+        freshly recomputed, 'cpu' means all embeddings are stored on CPU, or 'gpu' means all embeddings are stored on GPU
+        :return: Returns a Tuple consisting of a Result object and a loss float value
+        """
         pass
 
     @abstractmethod

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -471,7 +471,7 @@ class ModelTrainer:
                 num_workers=num_workers,
             ),
             out_path=base_path / "test.tsv",
-            embedding_storage_mode="none",
+            embeddings_storage_mode="none",
         )
 
         test_results: Result = test_results
@@ -490,7 +490,7 @@ class ModelTrainer:
                         num_workers=num_workers,
                     ),
                     out_path=base_path / f"{subcorpus.name}-test.tsv",
-                    embedding_storage_mode="none",
+                    embeddings_storage_mode="none",
                 )
 
         # get and return the final test score of best model

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -60,7 +60,7 @@ class ModelTrainer:
         train_with_dev: bool = False,
         monitor_train: bool = False,
         monitor_test: bool = False,
-        embedding_storage_mode: str = "cpu",
+        embeddings_storage_mode: str = "cpu",
         checkpoint: bool = False,
         save_final_model: bool = True,
         anneal_with_restarts: bool = False,
@@ -84,7 +84,7 @@ class ModelTrainer:
         :param train_with_dev: If True, training is performed using both train+dev data
         :param monitor_train: If True, training data is evaluated at end of each epoch
         :param monitor_test: If True, test data is evaluated at end of each epoch
-        :param embedding_storage_mode: One of 'none' (all embeddings are deleted and freshly recomputed),
+        :param embeddings_storage_mode: One of 'none' (all embeddings are deleted and freshly recomputed),
         'cpu' (embeddings are stored on CPU) or 'gpu' (embeddings are stored on GPU)
         :param checkpoint: If True, a full checkpoint is saved at end of each epoch
         :param save_final_model: If True, final model is saved
@@ -101,10 +101,13 @@ class ModelTrainer:
         if self.use_tensorboard:
             try:
                 from torch.utils.tensorboard import SummaryWriter
+
                 writer = SummaryWriter()
             except:
                 log_line(log)
-                log.warning('ATTENTION! PyTorch >= 1.1.0 and pillow are required for TensorBoard support!')
+                log.warning(
+                    "ATTENTION! PyTorch >= 1.1.0 and pillow are required for TensorBoard support!"
+                )
                 log_line(log)
                 self.use_tensorboard = False
                 pass
@@ -136,7 +139,7 @@ class ModelTrainer:
         log_line(log)
         log.info(f"Device: {flair.device}")
         log_line(log)
-        log.info(f"Embedding storage mode: {embedding_storage_mode}")
+        log.info(f"Embeddings storage mode: {embeddings_storage_mode}")
 
         # determine what splits (train, dev, test) to evaluate and log
         log_train = True if monitor_train else False
@@ -246,7 +249,7 @@ class ModelTrainer:
                     train_loss += loss.item()
 
                     # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                    store_embeddings(batch, embedding_storage_mode)
+                    store_embeddings(batch, embeddings_storage_mode)
 
                     if batch_no % modulo == 0:
                         log.info(
@@ -269,7 +272,7 @@ class ModelTrainer:
                 )
 
                 if self.use_tensorboard:
-                    writer.add_scalar('train_loss', train_loss, epoch + 1)
+                    writer.add_scalar("train_loss", train_loss, epoch + 1)
 
                 # anneal against train loss if training with dev, otherwise anneal against dev score
                 current_score = train_loss
@@ -283,12 +286,13 @@ class ModelTrainer:
                             self.corpus.train,
                             batch_size=eval_mini_batch_size,
                             num_workers=num_workers,
-                        )
+                        ),
+                        embeddings_storage_mode=embeddings_storage_mode,
                     )
                     result_line += f"\t{train_eval_result.log_line}"
 
                     # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                    store_embeddings(self.corpus.train, embedding_storage_mode)
+                    store_embeddings(self.corpus.train, embeddings_storage_mode)
 
                 if log_dev:
                     dev_eval_result, dev_loss = self.model.evaluate(
@@ -296,7 +300,8 @@ class ModelTrainer:
                             self.corpus.dev,
                             batch_size=eval_mini_batch_size,
                             num_workers=num_workers,
-                        )
+                        ),
+                        embeddings_storage_mode=embeddings_storage_mode,
                     )
                     result_line += f"\t{dev_loss}\t{dev_eval_result.log_line}"
                     log.info(
@@ -310,11 +315,13 @@ class ModelTrainer:
                     current_score = dev_eval_result.main_score
 
                     # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                    store_embeddings(self.corpus.dev, embedding_storage_mode)
+                    store_embeddings(self.corpus.dev, embeddings_storage_mode)
 
                     if self.use_tensorboard:
-                        writer.add_scalar('dev_loss', dev_loss, epoch + 1)
-                        writer.add_scalar('dev_score', dev_eval_result.main_score, epoch + 1)
+                        writer.add_scalar("dev_loss", dev_loss, epoch + 1)
+                        writer.add_scalar(
+                            "dev_score", dev_eval_result.main_score, epoch + 1
+                        )
 
                 if log_test:
                     test_eval_result, test_loss = self.model.evaluate(
@@ -324,6 +331,7 @@ class ModelTrainer:
                             num_workers=num_workers,
                         ),
                         base_path / "test.tsv",
+                        embeddings_storage_mode=embeddings_storage_mode,
                     )
                     result_line += f"\t{test_loss}\t{test_eval_result.log_line}"
                     log.info(
@@ -331,11 +339,13 @@ class ModelTrainer:
                     )
 
                     # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                    store_embeddings(self.corpus.test, embedding_storage_mode)
+                    store_embeddings(self.corpus.test, embeddings_storage_mode)
 
                     if self.use_tensorboard:
-                        writer.add_scalar('test_loss', test_loss, epoch + 1)
-                        writer.add_scalar('test_score', test_eval_result.main_score, epoch + 1)
+                        writer.add_scalar("test_loss", test_loss, epoch + 1)
+                        writer.add_scalar(
+                            "test_score", test_eval_result.main_score, epoch + 1
+                        )
 
                 # determine learning rate annealing through scheduler
                 scheduler.step(current_score)
@@ -461,6 +471,7 @@ class ModelTrainer:
                 num_workers=num_workers,
             ),
             out_path=base_path / "test.tsv",
+            embedding_storage_mode="none",
         )
 
         test_results: Result = test_results
@@ -479,6 +490,7 @@ class ModelTrainer:
                         num_workers=num_workers,
                     ),
                     out_path=base_path / f"{subcorpus.name}-test.tsv",
+                    embedding_storage_mode="none",
                 )
 
         # get and return the final test score of best model


### PR DESCRIPTION
This PR continues refactoring work from #891 to make interfaces more general and allow for 
- additional atomic types of data points (currently only `Token` and `Sentence`) 
- more diverse downstream tasks (currently only `SequenceTagger`, `TextClassifier` and `TextRegressor`)

The PR also includes `embeddings_storage_mode` as a default parameter in the `.evaluate()` routine, and adds the `step` paramter to the `ExpandingChunkSampler` to control the number of epochs before chunk size is increased.