### PR TITLE
GH-873: PyTorch-Transformers update

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -58,6 +58,7 @@ from flair.data import Corpus
 from .nn import LockedDropout, WordDropout
 from .data import Dictionary, Token, Sentence
 from .file_utils import cached_path, open_inside_zip
+from .training_utils import log_line
 
 log = logging.getLogger("flair")
 
@@ -1497,7 +1498,7 @@ class RoBERTaEmbeddings(TokenEmbeddings):
             self.model = torch.hub.load("pytorch/fairseq", model)
         except:
             log_line(log)
-            log.warning("ATTENTION! sacremoses and subword_nmt needs to be installed!")
+            log.warning("ATTENTION! fastBPE, sacremoses and subword_nmt needs to be installed!")
             log_line(log)
             pass
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2204,17 +2204,22 @@ class BertEmbeddings(TokenEmbeddings):
                 for token_index, _ in enumerate(feature.tokens):
                     all_layers = []
                     for layer_index in self.layer_indexes:
-                        layer_output = (
-                            all_encoder_layers[int(layer_index)]
-                            .detach()
-                            .cpu()[sentence_index]
-                        )
+                        if self.use_scalar_mix:
+                            layer_output = all_encoder_layers[int(layer_index)][
+                                sentence_index
+                            ]
+                        else:
+                            layer_output = (
+                                all_encoder_layers[int(layer_index)]
+                                .detach()
+                                .cpu()[sentence_index]
+                            )
                         all_layers.append(layer_output[token_index])
 
                     if self.use_scalar_mix:
-                        sm = ScalarMix(mixture_size=len(all_layers), trainable=False)
+                        sm = ScalarMix(mixture_size=len(all_layers))
                         sm_embeddings = sm(all_layers)
-                        all_layers = sm_embeddings
+                        all_layers = [sm_embeddings]
 
                     subtoken_embeddings.append(torch.cat(all_layers))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sklearn
 sqlitedict>=1.6.0
 deprecated>=1.2.4
 hyperopt>=0.1.1
-pytorch-pretrained-bert>=0.6.1
+pytorch-transformers>=1.0.0
 bpemb>=0.2.9
 regex
 tabulate

--- a/tests/test_transformer_embeddings.py
+++ b/tests/test_transformer_embeddings.py
@@ -1,0 +1,860 @@
+import flair
+import torch
+import pytest
+
+from flair.data import Sentence
+from flair.embeddings import (
+    RoBERTaEmbeddings,
+    OpenAIGPTEmbeddings,
+    OpenAIGPT2Embeddings,
+    XLNetEmbeddings,
+    TransformerXLEmbeddings,
+    XLMEmbeddings,
+)
+
+from pytorch_transformers import (
+    OpenAIGPTModel,
+    OpenAIGPTTokenizer,
+    GPT2Model,
+    GPT2Tokenizer,
+    XLNetModel,
+    XLNetTokenizer,
+    TransfoXLModel,
+    TransfoXLTokenizer,
+    XLMModel,
+    XLMTokenizer,
+)
+
+from typing import List
+
+
+def calculate_mean_embedding(
+    subword_embeddings: List[torch.FloatTensor]
+) -> torch.FloatTensor:
+    all_embeddings: List[torch.FloatTensor] = [
+        embedding.unsqueeze(0) for embedding in subword_embeddings
+    ]
+    return torch.mean(torch.cat(all_embeddings, dim=0), dim=0)
+
+
+@pytest.mark.integration
+def test_roberta_embeddings():
+    roberta_model = "roberta.base"
+
+    model = torch.hub.load("pytorch/fairseq", roberta_model)
+    model.to(flair.device)
+    model.eval()
+
+    s: str = "Berlin and Munich have a lot of puppeteer to see ."
+
+    with torch.no_grad():
+        tokens = model.encode(s)
+        all_layers = model.extract_features(tokens, return_all_hiddens=True)
+        first_layer = all_layers[1][0]
+
+    assert len(tokens) == len(first_layer)
+
+    #  0    1       2     3       4       5   6    7   8    9     10    11  12   13    14   15
+    #
+    #  0, 26795,  2614,   8,    10489,   33, 10,  319, 9, 32986, 9306, 254, 7,  192,  479,  2
+    #       \      /      |       |       |   |    |   |     \     |   /    |    |     |
+    #        Berlin      and    Munich  have  a   lot  of     puppeteer     to  see    .
+    #
+    #          0          1       2       3   4    5   6          7          8    9    10
+
+    def embed_sentence(
+        sentence: str,
+        pooling_operation,
+        layers: str = "1",
+        use_scalar_mix: bool = False,
+    ) -> Sentence:
+        embeddings = RoBERTaEmbeddings(
+            model=roberta_model,
+            layers=layers,
+            pooling_operation=pooling_operation,
+            use_scalar_mix=use_scalar_mix,
+        )
+        flair_sentence = Sentence(sentence)
+        embeddings.embed(flair_sentence)
+
+        return flair_sentence
+
+    # First subword embedding
+    sentence_first_subword = embed_sentence(sentence=s, pooling_operation="first")
+
+    first_token_embedding_ref = first_layer[1].tolist()
+    first_token_embedding_actual = sentence_first_subword.tokens[0].embedding.tolist()
+
+    puppeteer_first_subword_embedding_ref = first_layer[9].tolist()
+    puppeteer_first_subword_embedding_actual = sentence_first_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_subword_embedding_ref
+        == puppeteer_first_subword_embedding_actual
+    )
+
+    # Last subword embedding
+    sentence_last_subword = embed_sentence(sentence=s, pooling_operation="last")
+
+    # First token is splitted into two subwords.
+    # As we use "last" as pooling operation, we consider the last subword as "first token" here
+    first_token_embedding_ref = first_layer[2].tolist()
+    first_token_embedding_actual = sentence_last_subword.tokens[0].embedding.tolist()
+
+    puppeteer_last_subword_embedding_ref = first_layer[11].tolist()
+    puppeteer_last_subword_embedding_actual = sentence_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_last_subword_embedding_ref == puppeteer_last_subword_embedding_actual
+    )
+
+    # First and last subword embedding
+    sentence_first_last_subword = embed_sentence(
+        sentence=s, pooling_operation="first_last"
+    )
+
+    first_token_embedding_ref = torch.cat([first_layer[1], first_layer[2]]).tolist()
+    first_token_embedding_actual = sentence_first_last_subword.tokens[
+        0
+    ].embedding.tolist()
+
+    puppeteer_first_last_subword_embedding_ref = torch.cat(
+        [first_layer[9], first_layer[11]]
+    ).tolist()
+    puppeteer_first_last_subword_embedding_actual = sentence_first_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_last_subword_embedding_ref
+        == puppeteer_first_last_subword_embedding_actual
+    )
+
+    # Mean of all subword embeddings
+    sentence_mean_subword = embed_sentence(sentence=s, pooling_operation="mean")
+
+    first_token_embedding_ref = calculate_mean_embedding(
+        [first_layer[1], first_layer[2]]
+    ).tolist()
+    first_token_embedding_actual = sentence_mean_subword.tokens[0].embedding.tolist()
+
+    puppeteer_mean_subword_embedding_ref = calculate_mean_embedding(
+        [first_layer[9], first_layer[10], first_layer[11]]
+    ).tolist()
+    puppeteer_mean_subword_embedding_actual = sentence_mean_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_mean_subword_embedding_ref == puppeteer_mean_subword_embedding_actual
+    )
+
+    # Check embedding dimension when using multiple layers
+    sentence_mult_layers = embed_sentence(
+        sentence="Munich", pooling_operation="first", layers="1,2,3,4"
+    )
+
+    ref_embedding_size = 4 * 768
+    actual_embedding_size = len(sentence_mult_layers.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+    # Check embedding dimension when using multiple layers and scalar mix
+    sentence_mult_layers_scalar_mix = embed_sentence(
+        sentence="Berlin",
+        pooling_operation="first",
+        layers="1,2,3,4",
+        use_scalar_mix=True,
+    )
+
+    ref_embedding_size = 1 * 768
+    actual_embedding_size = len(sentence_mult_layers_scalar_mix.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+
+@pytest.mark.integration
+def test_gpt_embeddings():
+    gpt_model: str = "openai-gpt"
+
+    tokenizer = OpenAIGPTTokenizer.from_pretrained(gpt_model)
+    model = OpenAIGPTModel.from_pretrained(
+        pretrained_model_name_or_path=gpt_model, output_hidden_states=True
+    )
+    model.to(flair.device)
+    model.eval()
+
+    s: str = "Berlin and Munich have a lot of puppeteer to see ."
+
+    with torch.no_grad():
+        tokens = tokenizer.tokenize(s)
+
+        indexed_tokens = tokenizer.convert_tokens_to_ids(tokens)
+        tokens_tensor = torch.tensor([indexed_tokens])
+        tokens_tensor = tokens_tensor.to(flair.device)
+
+        hidden_states = model(tokens_tensor)[-1]
+
+        first_layer = hidden_states[1][0]
+
+    assert len(first_layer) == len(tokens)
+
+    #     0             1           2            3          4         5         6        7       8       9        10        11         12
+    #
+    # 'berlin</w>', 'and</w>', 'munich</w>', 'have</w>', 'a</w>', 'lot</w>', 'of</w>', 'pupp', 'ete', 'er</w>', 'to</w>', 'see</w>', '.</w>'
+    #     |             |           |            |          |         |         |         \      |      /          |         |          |
+    #   Berlin         and        Munich        have        a        lot        of           puppeteer             to       see         .
+    #
+    #     0             1           2            3          4         5         6                7                  8        9          10
+
+    def embed_sentence(
+        sentence: str,
+        pooling_operation,
+        layers: str = "1",
+        use_scalar_mix: bool = False,
+    ) -> Sentence:
+        embeddings = OpenAIGPTEmbeddings(
+            model=gpt_model,
+            layers=layers,
+            pooling_operation=pooling_operation,
+            use_scalar_mix=use_scalar_mix,
+        )
+        flair_sentence = Sentence(sentence)
+        embeddings.embed(flair_sentence)
+
+        return flair_sentence
+
+    # First subword embedding
+    sentence_first_subword = embed_sentence(sentence=s, pooling_operation="first")
+
+    first_token_embedding_ref = first_layer[0].tolist()
+    first_token_embedding_actual = sentence_first_subword.tokens[0].embedding.tolist()
+
+    puppeteer_first_subword_embedding_ref = first_layer[7].tolist()
+    puppeteer_first_subword_embedding_actual = sentence_first_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_subword_embedding_ref
+        == puppeteer_first_subword_embedding_actual
+    )
+
+    # Last subword embedding
+    sentence_last_subword = embed_sentence(sentence=s, pooling_operation="last")
+
+    first_token_embedding_ref = first_layer[0].tolist()
+    first_token_embedding_actual = sentence_last_subword.tokens[0].embedding.tolist()
+
+    puppeteer_last_subword_embedding_ref = first_layer[9].tolist()
+    puppeteer_last_subword_embedding_actual = sentence_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_last_subword_embedding_ref == puppeteer_last_subword_embedding_actual
+    )
+
+    # First and last subword embedding
+    sentence_first_last_subword = embed_sentence(
+        sentence=s, pooling_operation="first_last"
+    )
+
+    first_token_embedding_ref = torch.cat([first_layer[0], first_layer[0]]).tolist()
+    first_token_embedding_actual = sentence_first_last_subword.tokens[
+        0
+    ].embedding.tolist()
+
+    puppeteer_first_last_subword_embedding_ref = torch.cat(
+        [first_layer[7], first_layer[9]]
+    ).tolist()
+    puppeteer_first_last_subword_embedding_actual = sentence_first_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_last_subword_embedding_ref
+        == puppeteer_first_last_subword_embedding_actual
+    )
+
+    # Mean of all subword embeddings
+    sentence_mean_subword = embed_sentence(sentence=s, pooling_operation="mean")
+
+    first_token_embedding_ref = calculate_mean_embedding([first_layer[0]]).tolist()
+    first_token_embedding_actual = sentence_mean_subword.tokens[0].embedding.tolist()
+
+    puppeteer_mean_subword_embedding_ref = calculate_mean_embedding(
+        [first_layer[7], first_layer[8], first_layer[9]]
+    ).tolist()
+    puppeteer_mean_subword_embedding_actual = sentence_mean_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_mean_subword_embedding_ref == puppeteer_mean_subword_embedding_actual
+    )
+
+    # Check embedding dimension when using multiple layers
+    sentence_mult_layers = embed_sentence(
+        sentence="Munich", pooling_operation="first", layers="1,2,3,4"
+    )
+
+    ref_embedding_size = 4 * 768
+    actual_embedding_size = len(sentence_mult_layers.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+    # Check embedding dimension when using multiple layers and scalar mix
+    sentence_mult_layers_scalar_mix = embed_sentence(
+        sentence="Berlin",
+        pooling_operation="first",
+        layers="1,2,3,4",
+        use_scalar_mix=True,
+    )
+
+    ref_embedding_size = 1 * 768
+    actual_embedding_size = len(sentence_mult_layers_scalar_mix.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+
+@pytest.mark.integration
+def test_gpt2_embeddings():
+    gpt_model: str = "gpt2-medium"
+
+    tokenizer = GPT2Tokenizer.from_pretrained(gpt_model)
+    model = GPT2Model.from_pretrained(
+        pretrained_model_name_or_path=gpt_model, output_hidden_states=True
+    )
+    model.to(flair.device)
+    model.eval()
+
+    s: str = "Berlin and Munich have a lot of puppeteer to see ."
+
+    with torch.no_grad():
+        tokens = tokenizer.tokenize("<|endoftext|>" + s + "<|endoftext|>")
+
+        indexed_tokens = tokenizer.convert_tokens_to_ids(tokens)
+        tokens_tensor = torch.tensor([indexed_tokens])
+        tokens_tensor = tokens_tensor.to(flair.device)
+
+        hidden_states = model(tokens_tensor)[-1]
+
+        first_layer = hidden_states[1][0]
+
+    assert len(first_layer) == len(tokens)
+
+    #         0           1      2       3        4         5       6      7      8       9      10     11     12     13    14          15
+    #
+    #  '<|endoftext|>', 'Ber', 'lin', 'Ġand', 'ĠMunich', 'Ġhave', 'Ġa', 'Ġlot', 'Ġof', 'Ġpupp', 'ete', 'er', 'Ġto', 'Ġsee', 'Ġ.', '<|endoftext|>'
+    #                      \     /       |        |         |       |      |      |         \      |      /     |      |      |
+    #                       Berlin      and    Munich     have      a     lot     of           puppeteer        to    see     .
+    #
+    #                         0          1        2         3       4      5       6               7             8     9      10
+
+    def embed_sentence(
+        sentence: str,
+        pooling_operation,
+        layers: str = "1",
+        use_scalar_mix: bool = False,
+    ) -> Sentence:
+        embeddings = OpenAIGPT2Embeddings(
+            model=gpt_model,
+            layers=layers,
+            pooling_operation=pooling_operation,
+            use_scalar_mix=use_scalar_mix,
+        )
+        flair_sentence = Sentence(sentence)
+        embeddings.embed(flair_sentence)
+
+        return flair_sentence
+
+    # First subword embedding
+    sentence_first_subword = embed_sentence(sentence=s, pooling_operation="first")
+
+    first_token_embedding_ref = first_layer[1].tolist()
+    first_token_embedding_actual = sentence_first_subword.tokens[0].embedding.tolist()
+
+    puppeteer_first_subword_embedding_ref = first_layer[9].tolist()
+    puppeteer_first_subword_embedding_actual = sentence_first_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_subword_embedding_ref
+        == puppeteer_first_subword_embedding_actual
+    )
+
+    # Last subword embedding
+    sentence_last_subword = embed_sentence(sentence=s, pooling_operation="last")
+
+    # First token is splitted into two subwords.
+    # As we use "last" as pooling operation, we consider the last subword as "first token" here
+    first_token_embedding_ref = first_layer[2].tolist()
+    first_token_embedding_actual = sentence_last_subword.tokens[0].embedding.tolist()
+
+    puppeteer_last_subword_embedding_ref = first_layer[11].tolist()
+    puppeteer_last_subword_embedding_actual = sentence_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_last_subword_embedding_ref == puppeteer_last_subword_embedding_actual
+    )
+
+    # First and last subword embedding
+    sentence_first_last_subword = embed_sentence(
+        sentence=s, pooling_operation="first_last"
+    )
+
+    first_token_embedding_ref = torch.cat([first_layer[1], first_layer[2]]).tolist()
+    first_token_embedding_actual = sentence_first_last_subword.tokens[
+        0
+    ].embedding.tolist()
+
+    puppeteer_first_last_subword_embedding_ref = torch.cat(
+        [first_layer[9], first_layer[11]]
+    ).tolist()
+    puppeteer_first_last_subword_embedding_actual = sentence_first_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_last_subword_embedding_ref
+        == puppeteer_first_last_subword_embedding_actual
+    )
+
+    # Mean of all subword embeddings
+    sentence_mean_subword = embed_sentence(sentence=s, pooling_operation="mean")
+
+    first_token_embedding_ref = calculate_mean_embedding(
+        [first_layer[1], first_layer[2]]
+    ).tolist()
+    first_token_embedding_actual = sentence_mean_subword.tokens[0].embedding.tolist()
+
+    puppeteer_mean_subword_embedding_ref = calculate_mean_embedding(
+        [first_layer[9], first_layer[10], first_layer[11]]
+    ).tolist()
+    puppeteer_mean_subword_embedding_actual = sentence_mean_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_mean_subword_embedding_ref == puppeteer_mean_subword_embedding_actual
+    )
+
+    # Check embedding dimension when using multiple layers
+    sentence_mult_layers = embed_sentence(
+        sentence="Munich", pooling_operation="first", layers="1,2,3,4"
+    )
+
+    ref_embedding_size = 4 * 1024
+    actual_embedding_size = len(sentence_mult_layers.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+    # Check embedding dimension when using multiple layers and scalar mix
+    sentence_mult_layers_scalar_mix = embed_sentence(
+        sentence="Berlin",
+        pooling_operation="first",
+        layers="1,2,3,4",
+        use_scalar_mix=True,
+    )
+
+    ref_embedding_size = 1 * 1024
+    actual_embedding_size = len(sentence_mult_layers_scalar_mix.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+
+@pytest.mark.integration
+def test_xlnet_embeddings():
+    xlnet_model: str = "xlnet-large-cased"
+
+    tokenizer = XLNetTokenizer.from_pretrained(xlnet_model)
+    model = XLNetModel.from_pretrained(
+        pretrained_model_name_or_path=xlnet_model, output_hidden_states=True
+    )
+    model.to(flair.device)
+    model.eval()
+
+    s: str = "Berlin and Munich have a lot of puppeteer to see ."
+
+    with torch.no_grad():
+        tokens = tokenizer.tokenize("<s>" + s + "</s>")
+
+        print(tokens)
+
+        indexed_tokens = tokenizer.convert_tokens_to_ids(tokens)
+        tokens_tensor = torch.tensor([indexed_tokens])
+        tokens_tensor = tokens_tensor.to(flair.device)
+
+        hidden_states = model(tokens_tensor)[-1]
+
+        first_layer = hidden_states[1][0]
+
+    assert len(first_layer) == len(tokens)
+
+    #   0        1         2         3         4      5      6      7        8        9      10      11   12   13     14
+    #
+    # '<s>', '▁Berlin', '▁and', '▁Munich', '▁have', '▁a', '▁lot', '▁of', '▁puppet', 'eer', '▁to', '▁see', '▁', '.', '</s>'
+    #           |          |         |         |      |      |      |         \      /       |       |     \    /
+    #         Berlin      and     Munich     have     a     lot     of       puppeteer       to     see       .
+    #
+    #           0          1         2         3      4      5       6           7           8       9        10
+
+    def embed_sentence(
+        sentence: str,
+        pooling_operation,
+        layers: str = "1",
+        use_scalar_mix: bool = False,
+    ) -> Sentence:
+        embeddings = XLNetEmbeddings(
+            model=xlnet_model,
+            layers=layers,
+            pooling_operation=pooling_operation,
+            use_scalar_mix=use_scalar_mix,
+        )
+        flair_sentence = Sentence(sentence)
+        embeddings.embed(flair_sentence)
+
+        return flair_sentence
+
+    # First subword embedding
+    sentence_first_subword = embed_sentence(sentence=s, pooling_operation="first")
+
+    first_token_embedding_ref = first_layer[1].tolist()
+    first_token_embedding_actual = sentence_first_subword.tokens[0].embedding.tolist()
+
+    puppeteer_first_subword_embedding_ref = first_layer[8].tolist()
+    puppeteer_first_subword_embedding_actual = sentence_first_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_subword_embedding_ref
+        == puppeteer_first_subword_embedding_actual
+    )
+
+    # Last subword embedding
+    sentence_last_subword = embed_sentence(sentence=s, pooling_operation="last")
+
+    first_token_embedding_ref = first_layer[1].tolist()
+    first_token_embedding_actual = sentence_last_subword.tokens[0].embedding.tolist()
+
+    puppeteer_last_subword_embedding_ref = first_layer[9].tolist()
+    puppeteer_last_subword_embedding_actual = sentence_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_last_subword_embedding_ref == puppeteer_last_subword_embedding_actual
+    )
+
+    # First and last subword embedding
+    sentence_first_last_subword = embed_sentence(
+        sentence=s, pooling_operation="first_last"
+    )
+
+    first_token_embedding_ref = torch.cat([first_layer[1], first_layer[1]]).tolist()
+    first_token_embedding_actual = sentence_first_last_subword.tokens[
+        0
+    ].embedding.tolist()
+
+    puppeteer_first_last_subword_embedding_ref = torch.cat(
+        [first_layer[8], first_layer[9]]
+    ).tolist()
+    puppeteer_first_last_subword_embedding_actual = sentence_first_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_last_subword_embedding_ref
+        == puppeteer_first_last_subword_embedding_actual
+    )
+
+    # Mean of all subword embeddings
+    sentence_mean_subword = embed_sentence(sentence=s, pooling_operation="mean")
+
+    first_token_embedding_ref = calculate_mean_embedding([first_layer[1]]).tolist()
+    first_token_embedding_actual = sentence_mean_subword.tokens[0].embedding.tolist()
+
+    puppeteer_mean_subword_embedding_ref = calculate_mean_embedding(
+        [first_layer[8], first_layer[9]]
+    ).tolist()
+    puppeteer_mean_subword_embedding_actual = sentence_mean_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_mean_subword_embedding_ref == puppeteer_mean_subword_embedding_actual
+    )
+
+    # Check embedding dimension when using multiple layers
+    sentence_mult_layers = embed_sentence(
+        sentence="Munich", pooling_operation="first", layers="1,2,3,4"
+    )
+
+    ref_embedding_size = 4 * model.d_model
+    actual_embedding_size = len(sentence_mult_layers.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+    # Check embedding dimension when using multiple layers and scalar mix
+    sentence_mult_layers_scalar_mix = embed_sentence(
+        sentence="Berlin",
+        pooling_operation="first",
+        layers="1,2,3,4",
+        use_scalar_mix=True,
+    )
+
+    ref_embedding_size = 1 * model.d_model
+    actual_embedding_size = len(sentence_mult_layers_scalar_mix.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+
+@pytest.mark.integration
+def test_transformer_xl_embeddings():
+    transfo_model: str = "transfo-xl-wt103"
+
+    tokenizer = TransfoXLTokenizer.from_pretrained(transfo_model)
+    model = TransfoXLModel.from_pretrained(
+        pretrained_model_name_or_path=transfo_model, output_hidden_states=True
+    )
+    model.to(flair.device)
+    model.eval()
+
+    s: str = "Berlin and Munich have a lot of puppeteer to see ."
+
+    with torch.no_grad():
+        tokens = tokenizer.tokenize(s + "<eos>")
+
+        print(tokens)
+
+        indexed_tokens = tokenizer.convert_tokens_to_ids(tokens)
+        tokens_tensor = torch.tensor([indexed_tokens])
+        tokens_tensor = tokens_tensor.to(flair.device)
+
+        hidden_states = model(tokens_tensor)[-1]
+
+        first_layer = hidden_states[1][0]
+
+    assert len(first_layer) == len(tokens)
+
+    #     0       1        2        3     4     5      6        7        8      9     10     11
+    #
+    # 'Berlin', 'and', 'Munich', 'have', 'a', 'lot', 'of', 'puppeteer', 'to', 'see', '.', '<eos>'
+    #     |       |        |        |     |     |      |        |        |      |     |
+    #  Berlin    and    Munich    have    a    lot    of    puppeteer    to    see    .
+    #
+    #     0       1        2        3     4     5      6        7        8      9     10
+
+    def embed_sentence(
+        sentence: str, layers: str = "1", use_scalar_mix: bool = False
+    ) -> Sentence:
+        embeddings = TransformerXLEmbeddings(
+            model=transfo_model, layers=layers, use_scalar_mix=use_scalar_mix
+        )
+        flair_sentence = Sentence(sentence)
+        embeddings.embed(flair_sentence)
+
+        return flair_sentence
+
+    sentence = embed_sentence(sentence=s)
+
+    first_token_embedding_ref = first_layer[0].tolist()
+    first_token_embedding_actual = sentence.tokens[0].embedding.tolist()
+
+    puppeteer_embedding_ref = first_layer[7].tolist()
+    puppeteer_embedding_actual = sentence.tokens[7].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert puppeteer_embedding_ref == puppeteer_embedding_actual
+
+    # Check embedding dimension when using multiple layers
+    sentence_mult_layers = embed_sentence(sentence="Munich", layers="1,2,3,4")
+
+    ref_embedding_size = 4 * model.d_embed
+    actual_embedding_size = len(sentence_mult_layers.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+    # Check embedding dimension when using multiple layers and scalar mix
+    sentence_mult_layers_scalar_mix = embed_sentence(
+        sentence="Berlin", layers="1,2,3,4", use_scalar_mix=True
+    )
+
+    ref_embedding_size = 1 * model.d_embed
+    actual_embedding_size = len(sentence_mult_layers_scalar_mix.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+
+@pytest.mark.integration
+def test_xlm_embeddings():
+    xlm_model: str = "xlm-mlm-en-2048"
+
+    tokenizer = XLMTokenizer.from_pretrained(xlm_model)
+    model = XLMModel.from_pretrained(
+        pretrained_model_name_or_path=xlm_model, output_hidden_states=True
+    )
+    model.to(flair.device)
+    model.eval()
+
+    s: str = "Berlin and Munich have a lot of puppeteer to see ."
+
+    with torch.no_grad():
+        tokens = tokenizer.tokenize("<s>" + s + "</s>")
+
+        indexed_tokens = tokenizer.convert_tokens_to_ids(tokens)
+        tokens_tensor = torch.tensor([indexed_tokens])
+        tokens_tensor = tokens_tensor.to(flair.device)
+
+        hidden_states = model(tokens_tensor)[-1]
+
+        first_layer = hidden_states[1][0]
+
+    assert len(first_layer) == len(tokens)
+
+    #    0      1             2           3            4          5         6         7         8       9      10        11       12         13        14
+    #
+    #   <s>  'berlin</w>', 'and</w>', 'munich</w>', 'have</w>', 'a</w>', 'lot</w>', 'of</w>', 'pupp', 'ete', 'er</w>', 'to</w>', 'see</w>', '.</w>', '</s>
+    #           |             |           |            |          |         |         |         \      |      /          |         |          |
+    #         Berlin         and        Munich        have        a        lot        of           puppeteer             to       see         .
+    #
+    #           0             1           2            3          4         5          6               7                  8        9          10
+
+    def embed_sentence(
+        sentence: str,
+        pooling_operation,
+        layers: str = "1",
+        use_scalar_mix: bool = False,
+    ) -> Sentence:
+        embeddings = XLMEmbeddings(
+            model=xlm_model,
+            layers=layers,
+            pooling_operation=pooling_operation,
+            use_scalar_mix=use_scalar_mix,
+        )
+        flair_sentence = Sentence(sentence)
+        embeddings.embed(flair_sentence)
+
+        return flair_sentence
+
+    # First subword embedding
+    sentence_first_subword = embed_sentence(sentence=s, pooling_operation="first")
+
+    first_token_embedding_ref = first_layer[1].tolist()
+    first_token_embedding_actual = sentence_first_subword.tokens[0].embedding.tolist()
+
+    puppeteer_first_subword_embedding_ref = first_layer[8].tolist()
+    puppeteer_first_subword_embedding_actual = sentence_first_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_subword_embedding_ref
+        == puppeteer_first_subword_embedding_actual
+    )
+
+    # Last subword embedding
+    sentence_last_subword = embed_sentence(sentence=s, pooling_operation="last")
+
+    first_token_embedding_ref = first_layer[1].tolist()
+    first_token_embedding_actual = sentence_last_subword.tokens[0].embedding.tolist()
+
+    puppeteer_last_subword_embedding_ref = first_layer[10].tolist()
+    puppeteer_last_subword_embedding_actual = sentence_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_last_subword_embedding_ref == puppeteer_last_subword_embedding_actual
+    )
+
+    # First and last subword embedding
+    sentence_first_last_subword = embed_sentence(
+        sentence=s, pooling_operation="first_last"
+    )
+
+    first_token_embedding_ref = torch.cat([first_layer[1], first_layer[1]]).tolist()
+    first_token_embedding_actual = sentence_first_last_subword.tokens[
+        0
+    ].embedding.tolist()
+
+    puppeteer_first_last_subword_embedding_ref = torch.cat(
+        [first_layer[8], first_layer[10]]
+    ).tolist()
+    puppeteer_first_last_subword_embedding_actual = sentence_first_last_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_first_last_subword_embedding_ref
+        == puppeteer_first_last_subword_embedding_actual
+    )
+
+    # Mean of all subword embeddings
+    sentence_mean_subword = embed_sentence(sentence=s, pooling_operation="mean")
+
+    first_token_embedding_ref = calculate_mean_embedding([first_layer[1]]).tolist()
+    first_token_embedding_actual = sentence_mean_subword.tokens[0].embedding.tolist()
+
+    puppeteer_mean_subword_embedding_ref = calculate_mean_embedding(
+        [first_layer[8], first_layer[9], first_layer[10]]
+    ).tolist()
+    puppeteer_mean_subword_embedding_actual = sentence_mean_subword.tokens[
+        7
+    ].embedding.tolist()
+
+    assert first_token_embedding_ref == first_token_embedding_actual
+    assert (
+        puppeteer_mean_subword_embedding_ref == puppeteer_mean_subword_embedding_actual
+    )
+
+    # Check embedding dimension when using multiple layers
+    sentence_mult_layers = embed_sentence(
+        sentence="Munich", pooling_operation="first", layers="1,2,3,4"
+    )
+
+    ref_embedding_size = 4 * model.embeddings.embedding_dim
+    actual_embedding_size = len(sentence_mult_layers.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size
+
+    # Check embedding dimension when using multiple layers and scalar mix
+    sentence_mult_layers_scalar_mix = embed_sentence(
+        sentence="Berlin",
+        pooling_operation="first",
+        layers="1,2,3,4",
+        use_scalar_mix=True,
+    )
+
+    ref_embedding_size = 1 * model.embeddings.embedding_dim
+    actual_embedding_size = len(sentence_mult_layers_scalar_mix.tokens[0].embedding)
+
+    assert ref_embedding_size == actual_embedding_size

--- a/tests/test_transformer_embeddings.py
+++ b/tests/test_transformer_embeddings.py
@@ -37,7 +37,7 @@ def calculate_mean_embedding(
     return torch.mean(torch.cat(all_embeddings, dim=0), dim=0)
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_roberta_embeddings():
     roberta_model = "roberta.base"
 
@@ -181,7 +181,7 @@ def test_roberta_embeddings():
     assert ref_embedding_size == actual_embedding_size
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_gpt_embeddings():
     gpt_model: str = "openai-gpt"
 
@@ -330,7 +330,7 @@ def test_gpt_embeddings():
     assert ref_embedding_size == actual_embedding_size
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_gpt2_embeddings():
     gpt_model: str = "gpt2-medium"
 
@@ -483,7 +483,7 @@ def test_gpt2_embeddings():
     assert ref_embedding_size == actual_embedding_size
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_xlnet_embeddings():
     xlnet_model: str = "xlnet-large-cased"
 
@@ -634,7 +634,7 @@ def test_xlnet_embeddings():
     assert ref_embedding_size == actual_embedding_size
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_transformer_xl_embeddings():
     transfo_model: str = "transfo-xl-wt103"
 
@@ -711,7 +711,7 @@ def test_transformer_xl_embeddings():
     assert ref_embedding_size == actual_embedding_size
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 def test_xlm_embeddings():
     xlm_model: str = "xlm-mlm-en-2048"
 


### PR DESCRIPTION
Hi,

this PR updates the old `pytorch-pretrained-BERT` library to the latest version of `pytorch-transformers` to support various new Transformer-based architectures for embeddings.

A total of 7 (new/updated) embeddings can be used in Flair now:

```python
from flair.embeddings import (
    BertEmbeddings,
    OpenAIGPTEmbeddings,
    OpenAIGPT2Embeddings,
    TransformerXLEmbeddings,
    XLNetEmbeddings,
    XLMEmbeddings,
    RoBERTaEmbeddings,
)

bert_embeddings = BertEmbeddings()
gpt1_embeddings = OpenAIGPTEmbeddings()
gpt2_embeddings = OpenAIGPT2Embeddings()
txl_embeddings = TransformerXLEmbeddings()
xlnet_embeddings = XLNetEmbeddings()
xlm_embeddings = XLMEmbeddings()
roberta_embeddings = RoBERTaEmbeddings()
```

Detailed benchmarks on the downsampled CoNLL-2003 NER dataset for English can be found in #873 . This PR is the first working attempt to include various new Transformer-based embeddings.

Unit tests can be executed with `pytest --runslow tests`. These unit tests for Transformer embeddings will take ~ 4 minutes using GPU.