### PR TITLE
Show allennlp import errors when installed

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -707,7 +707,7 @@ class ELMoEmbeddings(TokenEmbeddings):
 
         try:
             import allennlp.commands.elmo
-        except:
+        except ModuleNotFoundError:
             log.warning("-" * 100)
             log.warning('ATTENTION! The library "allennlp" is not installed!')
             log.warning(
@@ -809,7 +809,7 @@ class ELMoTransformerEmbeddings(TokenEmbeddings):
             from allennlp.data.token_indexers.elmo_indexer import (
                 ELMoTokenCharactersIndexer,
             )
-        except:
+        except ModuleNotFoundError:
             log.warning("-" * 100)
             log.warning('ATTENTION! The library "allennlp" is not installed!')
             log.warning(


### PR DESCRIPTION
When allennlp is installed, but there is an issue with its installation (for example, the version of `protobuf` installed is too old), Flair produces the unhelpful error message "The library "allennlp" is not installed! To use ELMoEmbeddings, please first install with "pip install allennlp". These changes limit the scope of errors caught when loading `allennlp` in `embeddings.py` to only include `ModuleNotFoundError`s. This allows errors in actually loading the installed `allennlp` module to be displayed to the user.

Let me know if this PR needs any changes, or if Python 2 compatibility is needed. I made the PR without creating an issue since it's such a small change, but I'd be happy to discuss implementation details or anything else 😊

Thanks for making Flair! 😄