### PR TITLE
Fixed logging unicode encoding error.

### DIFF
--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -330,7 +330,7 @@ def log_line(log):
 
 def add_file_handler(log, output_file):
     init_output_file(output_file.parents[0], output_file.name)
-    fh = logging.FileHandler(output_file)
+    fh = logging.FileHandler(output_file, mode='w', encoding='utf-8')
     fh.setLevel(logging.INFO)
     formatter = logging.Formatter("%(asctime)-15s %(message)s")
     fh.setFormatter(formatter)


### PR DESCRIPTION
I fixed [issue#718](https://github.com/zalandoresearch/flair/issues/718), I think the problem is that the log file is not opened with 'utf-8'.