### PR TITLE
embeddings: deprecate ELMoTransformerEmbeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -799,6 +799,10 @@ class ELMoEmbeddings(TokenEmbeddings):
 class ELMoTransformerEmbeddings(TokenEmbeddings):
     """Contextual word embeddings using word-level Transformer-based LM, as proposed in Peters et al., 2018."""
 
+    @deprecated(
+        version="0.4.2",
+        reason="Not possible to load or save ELMo Transformer models. @stefan-it is working on it.",
+    )
     def __init__(self, model_file: str):
         super().__init__()
 


### PR DESCRIPTION
Hi,

the loading/saving logic for Flair models changed quite a while ago, so it is no longer possible to use another pickle framework. The `ELMoTransformerEmbeddings` could only be loaded and saved using `dill`.

This PR temporarily deprecates the `ELMoTransformerEmbeddings` implementation until a better solution is found!