### PR TITLE
Fixed unicode error when terminal encoding is not utf-8

### DIFF
--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -331,6 +331,8 @@ class LanguageModel(nn.Module):
             if not self.is_forward_lm:
                 text = text[::-1]
 
+            text = text.encode('utf-8')
+
             return text, log_prob
 
     def calculate_perplexity(self, text: str) -> float:


### PR DESCRIPTION
Hello, about [issue #718](https://github.com/zalandoresearch/flair/issues/718), I did more tests.

On my Ubuntu computer, if terminal is not working with utf-8, it may get same problem.

Therefore, I make function `generate_text` output text encode to utf-8 in `language_model.py`.
And then, it will work well at runtime, but the log file will been written a lot of unicodes,
like below,
`(b'\n \xca\x95\xe6\x99\x82  y \xe7\xaa\xa0  \xe5\x85\xb1\xe5\x9c\x8b \xe9\x80\xa0 \xe5\x9b\x9b \xe8\xaa\x9e \xf0\x90\xad\xae \xe9\xab\x98\xe5\xad\xb8\xe6\x96\xbc \xe7\xb4\x80 \xe7\xbd\xbe \xe5\x8c\x97 \xe5\x85\x8b \xe9\x80\x8d\xe5\x85\x8b ah\xe5\x8f\x83 ..., 7.52521240234375)`

If you want to write correct word in log file.
You should do below,

```
export LC_ALL=C.UTF-8
export LANG=C.UTF-8
```

If I find a better solution, I will fix it.




