### PR TITLE
[NER] fix inference bug introduced by #1016 (tags are not saved in token object)

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -371,13 +371,18 @@ class SequenceTagger(flair.nn.Model):
                         feature, batch, get_all_tags=all_tag_prob
                     )
 
-                for (sentence, sent_tags, sent_all_tags) in zip(batch, tags, all_tags):
-                    for (token, tag, token_all_tags) in zip(
-                        sentence.tokens, sent_tags, sent_all_tags
+                for (sentence, sent_tags) in zip(batch, tags):
+                    for (token, tag) in zip(
+                        sentence.tokens, sent_tags
                     ):
                         token.add_tag_label(self.tag_type, tag)
-                        if all_tag_prob:
-                            token.add_tags_proba_dist(self.tag_type, token_all_tags)
+
+                # all_tags will be empty if all_tag_prob is set to False, so the for loop will be avoided
+                for (sentence,  sent_all_tags) in zip(batch, all_tags):
+                    for (token, token_all_tags) in zip(
+                        sentence.tokens, sent_all_tags
+                    ):
+                        token.add_tags_proba_dist(self.tag_type, token_all_tags)
 
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -372,16 +372,12 @@ class SequenceTagger(flair.nn.Model):
                     )
 
                 for (sentence, sent_tags) in zip(batch, tags):
-                    for (token, tag) in zip(
-                        sentence.tokens, sent_tags
-                    ):
+                    for (token, tag) in zip(sentence.tokens, sent_tags):
                         token.add_tag_label(self.tag_type, tag)
 
                 # all_tags will be empty if all_tag_prob is set to False, so the for loop will be avoided
-                for (sentence,  sent_all_tags) in zip(batch, all_tags):
-                    for (token, token_all_tags) in zip(
-                        sentence.tokens, sent_all_tags
-                    ):
+                for (sentence, sent_all_tags) in zip(batch, all_tags):
+                    for (token, token_all_tags) in zip(sentence.tokens, sent_all_tags):
                         token.add_tags_proba_dist(self.tag_type, token_all_tags)
 
                 # clearing token embeddings to save memory


### PR DESCRIPTION
PR #1016 has introduced a new parameter to avoid computing scores for each tag and accelerating inference.
Now, when `all_tag_prob=False` during NER inference, predictions are not saved in `Token.tags`... so it is like nothing happened.
It is because of the `zip()` function taking multiple lists but if they have different sizes, the length of the shortest is taken as reference. When `all_tag_prob` is `False`, `all_tags` list is empty, so `zip` function acts like all of its parameters/lists are empty, and no iteration happens in the for loop saving results in `Token` objects.

It is a tricky bug as when you test the same sentence with `all_tag_prob=True` and then `all_tag_prob=False` the inference is working... I have not understood why.

The fix is to simply divide operations in 2 parts without any call to `zip`.