### PR TITLE
[Sentence] Fix infinite loop bug

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -299,7 +299,7 @@ class Span:
     def to_original_text(self) -> str:
         pos = self.tokens[0].start_pos
         if pos is None:
-            return ' '.join([t.text for t in self.tokens])
+            return " ".join([t.text for t in self.tokens])
         str = ""
         for t in self.tokens:
             while t.start_pos != pos:
@@ -670,6 +670,8 @@ class Sentence(DataPoint):
         return self
 
     def to_original_text(self) -> str:
+        if len(self.tokens) > 0 and (self.tokens[0].start_pos is None):
+            return " ".join([t.text for t in self.tokens])
         str = ""
         pos = 0
         for t in self.tokens:

--- a/flair/data.py
+++ b/flair/data.py
@@ -297,8 +297,10 @@ class Span:
         return " ".join([t.text for t in self.tokens])
 
     def to_original_text(self) -> str:
-        str = ""
         pos = self.tokens[0].start_pos
+        if pos is None:
+            return ' '.join([t.text for t in self.tokens])
+        str = ""
         for t in self.tokens:
             while t.start_pos != pos:
                 str += " "


### PR DESCRIPTION
Sometimes, `start_pos` in `Token` is set to None.
This is for instance the case when loading a `Corpus` in columnar format.

In those cases `while t.start_pos != pos` from `to_original_text` method is always True.
This fix manages this case.

Another solution would be to just throw an Exception. Let me know what you prefer. In this case it may be good to forbid to have `start_pos` being `None` in any case and to rewrite `Corpus` class. May be to put in another PR