### PR TITLE
Embeddings: add support for large ELMo model

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -729,6 +729,9 @@ class ELMoEmbeddings(TokenEmbeddings):
             if model == "medium":
                 options_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/2x2048_256_2048cnn_1xhighway/elmo_2x2048_256_2048cnn_1xhighway_options.json"
                 weight_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/2x2048_256_2048cnn_1xhighway/elmo_2x2048_256_2048cnn_1xhighway_weights.hdf5"
+            if model in ["large", "5.5B"]:
+                options_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/2x4096_512_2048cnn_2xhighway_5.5B/elmo_2x4096_512_2048cnn_2xhighway_5.5B_options.json"
+                weight_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/2x4096_512_2048cnn_2xhighway_5.5B/elmo_2x4096_512_2048cnn_2xhighway_5.5B_weights.hdf5"
             if model == "pt" or model == "portuguese":
                 options_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pt/elmo_pt_options.json"
                 weight_file = "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pt/elmo_pt_weights.hdf5"


### PR DESCRIPTION
Hi,

this PR adds support for the large ELMo model, that was trained on 5.5B tokens.

It can be used with:

```python
from flair.data import Sentence
from flair.embeddings import ELMoEmbeddings

embeddings = ELMoEmbeddings(model = "large")

s = Sentence("Berlin and Munich .")
embeddings.embed(s)
```

Results for ELMo on the complete CoNLL-2003 dataset (English, NER):

| Model | Dev | Test
| -------- | ----- | -----------
| ELMo (original) | 95.39 | 92.11
| ELMo (large, 5.5B tokens) | 95.68 | **92.15**

(notice: target branch for this PR is `GH-563-prepare-release-0-4-3`)