### PR TITLE
[NER] improve inference perf by > 40% on GPU when CRF is used

### DIFF
--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -331,7 +331,7 @@ class LanguageModel(nn.Module):
             if not self.is_forward_lm:
                 text = text[::-1]
 
-            text = text.encode('utf-8')
+            text = text.encode("utf-8")
 
             return text, log_prob
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -535,7 +535,10 @@ class SequenceTagger(flair.nn.Model):
             return score
 
     def _obtain_labels(
-        self, feature: torch.Tensor, sentences: List[Sentence], get_all_tags: bool = False
+        self,
+        feature: torch.Tensor,
+        sentences: List[Sentence],
+        get_all_tags: bool = False,
     ) -> (List[List[Label]], List[List[List[Label]]]):
         """
         Returns a tuple of two lists:

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -551,13 +551,15 @@ class SequenceTagger(flair.nn.Model):
 
         tags = []
         all_tags = []
-        feature_cpu = feature.detach().cpu()
+        feature = feature.detach().cpu()
         if self.use_crf:
-            transitions_cpu = self.transitions.detach().cpu()
-        for feats, length in zip(feature_cpu, lengths):
+            transitions = self.transitions.detach().cpu()
+        else:
+            transitions = self.transitions
+        for feats, length in zip(feature, lengths):
             if self.use_crf:
                 confidences, tag_seq, scores = self._viterbi_decode(
-                    feats[:length], all_scores=get_all_tags, transitions=transitions_cpu
+                    feats[:length], all_scores=get_all_tags, transitions=transitions
                 )
             else:
                 tag_seq = []

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -548,12 +548,12 @@ class SequenceTagger(flair.nn.Model):
 
         tags = []
         all_tags = []
-        feature_cpu = feature.detach().to('cpu')
-        transitions_cpu = self.transitions.detach().to('cpu')
+        feature_cpu = feature.detach().to("cpu")
+        transitions_cpu = self.transitions.detach().to("cpu")
         for feats, length in zip(feature_cpu, lengths):
             if self.use_crf:
                 confidences, tag_seq, scores = self._viterbi_decode(
-                    feats[:length], all_scores=get_all_tags, transitions=transitions_cpu,
+                    feats[:length], all_scores=get_all_tags, transitions=transitions_cpu
                 )
             else:
                 tag_seq = []
@@ -593,9 +593,7 @@ class SequenceTagger(flair.nn.Model):
         backpointers = []
         backscores = []
 
-        init_vvars = (
-            torch.FloatTensor(1, self.tagset_size).fill_(-10000.0)
-        )
+        init_vvars = torch.FloatTensor(1, self.tagset_size).fill_(-10000.0)
         init_vvars[0][self.tag_dictionary.get_idx_for_item(START_TAG)] = 0
         forward_var = init_vvars
 
@@ -611,8 +609,7 @@ class SequenceTagger(flair.nn.Model):
             backpointers.append(bptrs_t)
 
         terminal_var = (
-            forward_var
-            + transitions[self.tag_dictionary.get_idx_for_item(STOP_TAG)]
+            forward_var + transitions[self.tag_dictionary.get_idx_for_item(STOP_TAG)]
         )
         terminal_var.detach()[self.tag_dictionary.get_idx_for_item(STOP_TAG)] = -10000.0
         terminal_var.detach()[

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -535,7 +535,7 @@ class SequenceTagger(flair.nn.Model):
             return score
 
     def _obtain_labels(
-        self, feature, sentences, get_all_tags: bool = False
+        self, feature: torch.Tensor, sentences: List[Sentence], get_all_tags: bool = False
     ) -> (List[List[Label]], List[List[List[Label]]]):
         """
         Returns a tuple of two lists:
@@ -548,8 +548,9 @@ class SequenceTagger(flair.nn.Model):
 
         tags = []
         all_tags = []
-        feature_cpu = feature.detach().to("cpu")
-        transitions_cpu = self.transitions.detach().to("cpu")
+        feature_cpu = feature.detach().cpu()
+        if self.use_crf:
+            transitions_cpu = self.transitions.detach().cpu()
         for feats, length in zip(feature_cpu, lengths):
             if self.use_crf:
                 confidences, tag_seq, scores = self._viterbi_decode(

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -365,11 +365,10 @@ class SequenceTagger(flair.nn.Model):
                 if verbose:
                     batches.set_description(f"Inferencing on batch {i}")
 
-                with torch.no_grad():
-                    feature = self.forward(batch)
-                    tags, all_tags = self._obtain_labels(
-                        feature, batch, get_all_tags=all_tag_prob
-                    )
+                feature = self.forward(batch)
+                tags, all_tags = self._obtain_labels(
+                    feature, batch, get_all_tags=all_tag_prob
+                )
 
                 for (sentence, sent_tags) in zip(batch, tags):
                     for (token, tag) in zip(sentence.tokens, sent_tags):

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -330,7 +330,7 @@ def log_line(log):
 
 def add_file_handler(log, output_file):
     init_output_file(output_file.parents[0], output_file.name)
-    fh = logging.FileHandler(output_file, mode='w', encoding='utf-8')
+    fh = logging.FileHandler(output_file, mode="w", encoding="utf-8")
     fh.setLevel(logging.INFO)
     formatter = logging.Formatter("%(asctime)-15s %(message)s")
     fh.setFormatter(formatter)


### PR DESCRIPTION
Viterbi seems to be the bottle neck of the inference part when GPU is used with CRF.

Here we simply move the computation of this part from GPU to CPU as the operations are not GPU optimized.
On my 2080TI with I7 (6 real cores), on the same data / same model, I went from 1mn 33s to 63 seconds inference time.
I have not made any test on other hardware but I expect perf improvement to be similar.

Moreover, this open the door to more optimizations as it removes the "lock" on GPU (we can easily do a better job at multithreading the process than Pytorch is currently doing), plus the same performance boost can probably be reproduced on the training part.