### PR TITLE
GH-1041: add support for DistilBERT

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -16,6 +16,8 @@ from torch.nn import ParameterList, Parameter
 from pytorch_transformers import (
     BertTokenizer,
     BertModel,
+    DistilBertTokenizer,
+    DistilBertModel,
     RobertaTokenizer,
     RobertaModel,
     TransfoXLTokenizer,
@@ -1976,10 +1978,18 @@ class BertEmbeddings(TokenEmbeddings):
         """
         super().__init__()
 
-        self.tokenizer = BertTokenizer.from_pretrained(bert_model_or_path)
-        self.model = BertModel.from_pretrained(
-            pretrained_model_name_or_path=bert_model_or_path, output_hidden_states=True
-        )
+        if bert_model_or_path.startswith("distilbert"):
+            self.tokenizer = DistilBertTokenizer.from_pretrained(bert_model_or_path)
+            self.model = DistilBertModel.from_pretrained(
+                pretrained_model_name_or_path=bert_model_or_path,
+                output_hidden_states=True,
+            )
+        else:
+            self.tokenizer = BertTokenizer.from_pretrained(bert_model_or_path)
+            self.model = BertModel.from_pretrained(
+                pretrained_model_name_or_path=bert_model_or_path,
+                output_hidden_states=True,
+            )
         self.layer_indexes = [int(x) for x in layers.split(",")]
         self.pooling_operation = pooling_operation
         self.use_scalar_mix = use_scalar_mix
@@ -2088,9 +2098,9 @@ class BertEmbeddings(TokenEmbeddings):
         # put encoded batch through BERT model to get all hidden states of all encoder layers
         self.model.to(flair.device)
         self.model.eval()
-        _, _, all_encoder_layers = self.model(
-            all_input_ids, token_type_ids=None, attention_mask=all_input_masks
-        )
+        all_encoder_layers = self.model(all_input_ids, attention_mask=all_input_masks)[
+            -1
+        ]
 
         with torch.no_grad():
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -16,8 +16,6 @@ from torch.nn import ParameterList, Parameter
 from pytorch_transformers import (
     BertTokenizer,
     BertModel,
-    DistilBertTokenizer,
-    DistilBertModel,
     RobertaTokenizer,
     RobertaModel,
     TransfoXLTokenizer,
@@ -1979,6 +1977,16 @@ class BertEmbeddings(TokenEmbeddings):
         super().__init__()
 
         if bert_model_or_path.startswith("distilbert"):
+            try:
+                from pytorch_transformers import DistilBertTokenizer, DistilBertModel
+            except ImportError:
+                log.warning("-" * 100)
+                log.warning(
+                    "ATTENTION! To use DistilBert, please first install a recent version of pytorch-transformers!"
+                )
+                log.warning("-" * 100)
+                pass
+
             self.tokenizer = DistilBertTokenizer.from_pretrained(bert_model_or_path)
             self.model = DistilBertModel.from_pretrained(
                 pretrained_model_name_or_path=bert_model_or_path,

--- a/resources/docs/embeddings/TRANSFOMER_EMBEDDINGS.md
+++ b/resources/docs/embeddings/TRANSFOMER_EMBEDDINGS.md
@@ -84,6 +84,18 @@ You can load any of the pre-trained BERT models by providing `bert_model_or_path
 |                                                         | The `bert-base-cased` model fine-tuned on MRPC
 |                                                         | (see [details of fine-tuning in the example section of PyTorch-Transformers](https://huggingface.co/pytorch-transformers/examples.html))
 
+It is also possible to use [distilled versions](https://medium.com/huggingface/distilbert-8cf3380435b5)
+of BERT (DistilBERT):
+
+| Model                                     | Details
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------
+| `distilbert-base-uncased`                 | 6-layer, 768-hidden, 12-heads, 66M parameters
+|                                           | The DistilBERT model distilled from the BERT model `bert-base-uncased` checkpoint
+|                                           | (see [details](https://medium.com/huggingface/distilbert-8cf3380435b5))
+| `distilbert-base-uncased-distilled-squad` | 6-layer, 768-hidden, 12-heads, 66M parameters
+|                                           | The DistilBERT model distilled from the BERT model `bert-base-uncased` checkpoint, with an additional linear layer.
+|                                           | (see [details](https://medium.com/huggingface/distilbert-8cf3380435b5))
+
 ## OpenAI GPT Embeddings
 
 The OpenAI GPT model was proposed by [Radford et. al (2018)](https://s3-us-west-2.amazonaws.com/openai-assets/research-covers/language-unsupervised/language_understanding_paper.pdf).


### PR DESCRIPTION
Hi,

this PR adds support for `DistilBERT`, a distilled version of BERT.

The following example shows how to use it in Flair:

```python
from flair.data import Sentence
from flair.embeddings import BertEmbeddings

embeddings = BertEmbeddings("distilbert-base-uncased")

s = Sentence("Berlin and Munich are nice cities .")
embeddings.embed(s)

for token in s.tokens:
  print(token.embedding)
  print(token.embedding.shape)
```

Please also refer to this great [blog post](https://medium.com/huggingface/distilbert-8cf3380435b5) about distillation 🤗 🤗

I made [some experiments](https://github.com/stefan-it/flair-experiments/blob/master/conll2003-ner-english/README.md) on the full CoNLL-2003 corpus. `DistilBERT` (with this PR-ready version) is only -0.35% behind the BERT (base, uncased) model.

**Notice**: to try `DistilBERT` please make sure that you've installed the latest `master` version of `pytorch-transformers` (currently, no released version with `DistilBERT` exists).