### PR TITLE
Fix transpose_() to transpose()

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2741,7 +2741,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
             )
 
         # TODO: this can only be removed once the implementations of word_dropout and locked_dropout have a batch_first mode
-        sentence_tensor = sentence_tensor.transpose_(0, 1)
+        sentence_tensor = sentence_tensor.transpose(0, 1)
 
         # --------------------------------------------------------------------
         # FF PART

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -435,7 +435,7 @@ class SequenceTagger(flair.nn.Model):
             )
 
         # TODO: this can only be removed once the implementations of word_dropout and locked_dropout have a batch_first mode
-        sentence_tensor = sentence_tensor.transpose_(0, 1)
+        sentence_tensor = sentence_tensor.transpose(0, 1)
 
         # --------------------------------------------------------------------
         # FF PART
@@ -478,7 +478,7 @@ class SequenceTagger(flair.nn.Model):
                 sentence_tensor = self.locked_dropout(sentence_tensor)
         else:
             # transpose to batch_first mode
-            sentence_tensor = sentence_tensor.transpose_(0, 1)
+            sentence_tensor = sentence_tensor.transpose(0, 1)
 
         features = self.linear(sentence_tensor)
 


### PR DESCRIPTION
Hi, 

transpose_() is in-place version of transpose()
https://pytorch.org/docs/stable/tensors.html#torch.Tensor.transpose
You don't need asign althogh it makes no errors.

I reccomend use transpose() as like other files in flair.