### PR TITLE
Another 28% decrease in inference time in NER on GPU when CRF is used

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -597,10 +597,13 @@ class SequenceTagger(flair.nn.Model):
         tags = []
         all_tags = []
 
+        if self.use_crf:
+            feature = feature.cpu().numpy()
+
         for feats, length in zip(feature, lengths):
             if self.use_crf:
                 confidences, tag_seq, scores = self._viterbi_decode(
-                    feats=feats.detach().cpu().numpy()[:length],
+                    feats=feats[:length],
                     transitions=transitions,
                     all_scores=get_all_tags,
                 )

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -689,11 +689,6 @@ class SequenceTagger(flair.nn.Model):
         assert start == id_start
         best_path.reverse()
 
-        # best_path = np.flip(backpointers)[:, best_tag_id].astype(np.int_)
-        # best_path = np.append(best_tag_id, best_path)
-        # assert best_path[-1] == id_start
-        # best_path = np.flip(best_path[:-1])
-
         best_scores_softmax = self._softmax(backscores, axis=1)
         best_scores_np = np.max(best_scores_softmax, axis=1)
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -656,7 +656,9 @@ class SequenceTagger(flair.nn.Model):
             shape=(feats.shape[0], self.tagset_size), dtype=np.float32
         )
 
-        init_vvars = np.expand_dims(np.repeat(-10000.0, self.tagset_size), axis=0).astype(np.float32)
+        init_vvars = np.expand_dims(
+            np.repeat(-10000.0, self.tagset_size), axis=0
+        ).astype(np.float32)
         init_vvars[0][id_start] = 0
 
         forward_var = init_vvars

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -263,7 +263,7 @@ class SequenceTagger(flair.nn.Model):
             lines: List[str] = []
 
             if self.use_crf:
-                transitions = self.transitions.detach().cpu()
+                transitions = self.transitions.cpu().numpy()
             else:
                 transitions = None
 
@@ -271,7 +271,7 @@ class SequenceTagger(flair.nn.Model):
                 batch_no += 1
 
                 with torch.no_grad():
-                    features = self.forward(batch)
+                    features = self.forward(batch).cpu().numpy()
                     loss = self._calculate_loss(features, batch)
                     tags, _ = self._obtain_labels(features, batch, transitions)
 
@@ -358,6 +358,18 @@ class SequenceTagger(flair.nn.Model):
         all_tag_prob: bool = False,
         verbose=False,
     ) -> List[Sentence]:
+        """
+        Predict sequence tags for Named Entity Recognition task
+        :param sentences: a Sentence or a List of Sentence. Empty sentences will be removed.
+        :param mini_batch_size: size of the minibatch, usually bigger is more rapid but consume more memory,
+        up to a point when it has no more effect.
+        :param embedding_storage_mode: 'none' for the minimum memory footprint, 'cpu' to store embeddings in Ram,
+        'gpu' to store embeddings in GPU memory.
+        :param all_tag_prob: True to compute the score for each tag on each token,
+        otherwise only the score of the best tag is returned
+        :param verbose: set to True to display a progress bar
+        :return: List of Sentence enriched by the predicted tags
+        """
         with torch.no_grad():
             if isinstance(sentences, Sentence):
                 sentences = [sentences]
@@ -371,7 +383,7 @@ class SequenceTagger(flair.nn.Model):
             filtered_sentences.sort(key=lambda x: len(x), reverse=True)
 
             if self.use_crf:
-                transitions = self.transitions.detach().cpu()
+                transitions = self.transitions.cpu().numpy()
             else:
                 transitions = None
 
@@ -390,9 +402,12 @@ class SequenceTagger(flair.nn.Model):
                 if verbose:
                     batches.set_description(f"Inferencing on batch {i}")
 
-                feature = self.forward(batch)
+                feature: np.ndarray = self.forward(batch).cpu().numpy()
                 tags, all_tags = self._obtain_labels(
-                    feature, batch, transitions, get_all_tags=all_tag_prob
+                    feature=feature,
+                    sentences=batch,
+                    transitions=transitions,
+                    get_all_tags=all_tag_prob,
                 )
 
                 for (sentence, sent_tags) in zip(batch, tags):
@@ -560,9 +575,9 @@ class SequenceTagger(flair.nn.Model):
 
     def _obtain_labels(
         self,
-        feature: torch.Tensor,
+        feature: np.ndarray,
         sentences: List[Sentence],
-        transitions: Optional[Parameter],
+        transitions: np.ndarray,
         get_all_tags: bool = False,
     ) -> (List[List[Label]], List[List[List[Label]]]):
         """
@@ -576,12 +591,11 @@ class SequenceTagger(flair.nn.Model):
 
         tags = []
         all_tags = []
-        feature = feature.detach().cpu()
 
         for feats, length in zip(feature, lengths):
             if self.use_crf:
                 confidences, tag_seq, scores = self._viterbi_decode(
-                    feats[:length], all_scores=get_all_tags, transitions=transitions
+                    feats=feats[:length], transitions=transitions, all_scores=False
                 )
             else:
                 tag_seq = []
@@ -617,73 +631,142 @@ class SequenceTagger(flair.nn.Model):
 
         return tags, all_tags
 
-    def _viterbi_decode(self, feats, transitions, all_scores: bool = False):
-        backpointers = []
-        backscores = []
+    @staticmethod
+    def softmax(x, axis):
+        # reduce raw values to avoid NaN during exp
+        x_norm = x - x.max(axis=axis, keepdims=True)
+        y = np.exp(x_norm)
+        return y / y.sum(axis=axis, keepdims=True)
 
-        init_vvars = torch.FloatTensor(1, self.tagset_size).fill_(-10000.0)
-        init_vvars[0][self.tag_dictionary.get_idx_for_item(START_TAG)] = 0
-        forward_var = init_vvars
+    def _viterbi_decode(
+        self, feats: np.ndarray, transitions: np.ndarray, all_scores: bool
+    ):
+        id_start = self.tag_dictionary.get_idx_for_item(START_TAG)
+        id_stop = self.tag_dictionary.get_idx_for_item(STOP_TAG)
 
-        for feat in feats:
-            next_tag_var = (
-                forward_var.view(1, -1).expand(self.tagset_size, self.tagset_size)
-                + transitions
-            )
-            _, bptrs_t = torch.max(next_tag_var, dim=1)
-            viterbivars_t = next_tag_var[range(len(bptrs_t)), bptrs_t]
-            forward_var = viterbivars_t + feat
-            backscores.append(forward_var)
-            backpointers.append(bptrs_t)
-
-        terminal_var = (
-            forward_var + transitions[self.tag_dictionary.get_idx_for_item(STOP_TAG)]
+        backpointers = np.empty(
+            shape=(feats.shape[0], self.tagset_size), dtype=np.float64
         )
-        terminal_var.detach()[self.tag_dictionary.get_idx_for_item(STOP_TAG)] = -10000.0
-        terminal_var.detach()[
-            self.tag_dictionary.get_idx_for_item(START_TAG)
-        ] = -10000.0
-        best_tag_id = argmax(terminal_var.unsqueeze(0))
+        backscores = np.empty(
+            shape=(feats.shape[0], self.tagset_size), dtype=np.float64
+        )
 
-        best_path = [best_tag_id]
+        init_vvars = np.expand_dims(np.repeat(-10000.0, self.tagset_size), 0)
+        init_vvars[0][id_start] = 0
 
-        for bptrs_t in reversed(backpointers):
-            best_tag_id = bptrs_t[best_tag_id]
-            best_path.append(best_tag_id)
+        forward_var = init_vvars
+        for index, feat in enumerate(feats):
+            # broadcasting will do the job of reshaping and is more efficient than calling repeat
+            next_tag_var = forward_var + transitions
+            bptrs_t = next_tag_var.argmax(axis=1)
+            viterbivars_t = next_tag_var[np.arange(bptrs_t.shape[0]), bptrs_t]
+            forward_var = viterbivars_t + feat
+            backscores[index] = forward_var
+            forward_var = forward_var[np.newaxis, :]
+            backpointers[index] = bptrs_t
 
-        best_scores = []
-        for backscore in backscores:
-            softmax = F.softmax(backscore, dim=0)
-            _, idx = torch.max(backscore, 0)
-            prediction = idx.item()
-            best_scores.append(softmax[prediction].item())
+        terminal_var = forward_var.squeeze() + transitions[id_stop]
+        terminal_var[id_stop] = -10000.0
+        terminal_var[id_start] = -10000.0
+        best_tag_id = terminal_var.argmax()
 
-        start = best_path.pop()
-        assert start == self.tag_dictionary.get_idx_for_item(START_TAG)
-        best_path.reverse()
+        best_path = np.flip(backpointers)[:, int(best_tag_id)].astype(np.int32)
+        assert best_path[-1] == id_start
+        best_path = np.flip(best_path[:-1])
 
-        scores = []
-        # return all scores if so selected
+        best_scores_softmax = self.softmax(backscores, axis=1)
+        best_scores_np = np.max(best_scores_softmax, axis=1)
+
+        all_scores_np = np.zeros(0, dtype=np.float64)
         if all_scores:
-            for backscore in backscores:
-                softmax = F.softmax(backscore, dim=0)
-                scores.append([elem.item() for elem in softmax.flatten()])
-
-            for index, (tag_id, tag_scores) in enumerate(zip(best_path, scores)):
-                if type(tag_id) != int and tag_id.item() != np.argmax(tag_scores):
-                    swap_index_score = np.argmax(tag_scores)
-                    scores[index][tag_id.item()], scores[index][swap_index_score] = (
-                        scores[index][swap_index_score],
-                        scores[index][tag_id.item()],
+            all_scores_np = best_scores_softmax
+            for index, (tag_id, tag_scores) in enumerate(zip(best_path, all_scores_np)):
+                if type(tag_id) != int and tag_id.item() != tag_scores.argmax():
+                    swap_index_score = tag_scores.argmax()
+                    all_scores_np[index][tag_id.item()], all_scores_np[index][
+                        swap_index_score
+                    ] = (
+                        all_scores_np[index][swap_index_score],
+                        all_scores_np[index][tag_id.item()],
                     )
-                elif type(tag_id) == int and tag_id != np.argmax(tag_scores):
-                    swap_index_score = np.argmax(tag_scores)
-                    scores[index][tag_id], scores[index][swap_index_score] = (
-                        scores[index][swap_index_score],
-                        scores[index][tag_id],
+                elif type(tag_id) == int and tag_id != tag_scores.argmax():
+                    swap_index_score = tag_scores.argmax()
+                    all_scores_np[index][tag_id], all_scores_np[index][
+                        swap_index_score
+                    ] = (
+                        all_scores_np[index][swap_index_score],
+                        all_scores_np[index][tag_id],
                     )
 
-        return best_scores, best_path, scores
+        return best_scores_np.tolist(), best_path.tolist(), all_scores_np.tolist()
+
+    # def _viterbi_decode(self, feats, transitions, all_scores: bool = False):
+    #     backpointers = []
+    #     backscores = []
+    #
+    #     init_vvars = torch.FloatTensor(1, self.tagset_size).fill_(-10000.0)
+    #     init_vvars[0][self.tag_dictionary.get_idx_for_item(START_TAG)] = 0
+    #     forward_var = init_vvars
+    #
+    #     for feat in feats:
+    #         next_tag_var = (
+    #             forward_var.view(1, -1).expand(self.tagset_size, self.tagset_size)
+    #             + transitions
+    #         )
+    #         _, bptrs_t = torch.max(next_tag_var, dim=1)
+    #         viterbivars_t = next_tag_var[range(len(bptrs_t)), bptrs_t]
+    #         forward_var = viterbivars_t + feat
+    #         backscores.append(forward_var)
+    #         backpointers.append(bptrs_t)
+    #
+    #     terminal_var = (
+    #         forward_var + transitions[self.tag_dictionary.get_idx_for_item(STOP_TAG)]
+    #     )
+    #     terminal_var.detach()[self.tag_dictionary.get_idx_for_item(STOP_TAG)] = -10000.0
+    #     terminal_var.detach()[
+    #         self.tag_dictionary.get_idx_for_item(START_TAG)
+    #     ] = -10000.0
+    #     best_tag_id = argmax(terminal_var.unsqueeze(0))
+    #
+    #     best_path = [best_tag_id]
+    #
+    #     for bptrs_t in reversed(backpointers):
+    #         best_tag_id = bptrs_t[best_tag_id]
+    #         best_path.append(best_tag_id)
+    #
+    #     best_scores = []
+    #     for backscore in backscores:
+    #         softmax = F.softmax(backscore, dim=0)
+    #         _, idx = torch.max(backscore, 0)
+    #         prediction = idx.item()
+    #         best_scores.append(softmax[prediction].item())
+    #
+    #     start = best_path.pop()
+    #     assert start == self.tag_dictionary.get_idx_for_item(START_TAG)
+    #     best_path.reverse()
+    #
+    #     scores = []
+    #     # return all scores if so selected
+    #     if all_scores:
+    #         for backscore in backscores:
+    #             softmax = F.softmax(backscore, dim=0)
+    #             scores.append([elem.item() for elem in softmax.flatten()])
+    #
+    #         for index, (tag_id, tag_scores) in enumerate(zip(best_path, scores)):
+    #             if type(tag_id) != int and tag_id.item() != np.argmax(tag_scores):
+    #                 swap_index_score = np.argmax(tag_scores)
+    #                 scores[index][tag_id.item()], scores[index][swap_index_score] = (
+    #                     scores[index][swap_index_score],
+    #                     scores[index][tag_id.item()],
+    #                 )
+    #             elif type(tag_id) == int and tag_id != np.argmax(tag_scores):
+    #                 swap_index_score = np.argmax(tag_scores)
+    #                 scores[index][tag_id], scores[index][swap_index_score] = (
+    #                     scores[index][swap_index_score],
+    #                     scores[index][tag_id],
+    #                 )
+    #
+    #     return best_scores, best_path, scores
 
     def _forward_alg(self, feats, lens_):
 

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -678,8 +678,8 @@ def test_keep_word_embeddings():
     sentence = Sentence("I love Berlin")
     loaded_model.predict(sentence)
     for token in sentence:
-        assert len(token.embedding.numpy()) == 0
+        assert len(token.embedding.cpu().numpy()) == 0
 
     loaded_model.predict(sentence, embedding_storage_mode="cpu")
     for token in sentence:
-        assert len(token.embedding.numpy()) > 0
+        assert len(token.embedding.cpu().numpy()) > 0

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -1,10 +1,9 @@
-import os
 import shutil
+
 import pytest
 from torch.optim import SGD
-
-from torch.optim.optimizer import Optimizer
 from torch.optim.adam import Adam
+from torch.optim.optimizer import Optimizer
 
 import flair.datasets
 from flair.data import Dictionary, Sentence, MultiCorpus
@@ -15,10 +14,10 @@ from flair.embeddings import (
     DocumentRNNEmbeddings,
 )
 from flair.models import SequenceTagger, TextClassifier, LanguageModel
+from flair.optim import AdamW
 from flair.samplers import ImbalancedClassificationDatasetSampler
 from flair.trainers import ModelTrainer
 from flair.trainers.language_model_trainer import LanguageModelTrainer, TextCorpus
-from flair.optim import AdamW
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Like PR #1038, this is an optimization of the Viterbi decoding.
On my French dataset, using the same setup than #1038 , I went from 63 seconds to 45 seconds (`all_tag_prob` set to False).

This time, no easy trick but careful rewriting of Viterbi decoding using Numpy only and lots of vectorization.  It appeared than Pytorch Tensor is both slightly slower on CPU and offers less opportunities of vectorization and broadcasting.

2 interesting points:
- this optimization will also benefit to users inferring on CPU only
- the decrease in processing time is much stronger when `all_tag_prob` is set to True

FYI, I tried to parallelize with Ray and Numba.
Ray adds too much overhead compared to the time to process one Sentence and batching the minibatch introduces too much complexity for very small gain and lots of GPU memory issues.
Numba support of Numpy is too limited for now, most axis parameter are still not supported, and at the end it is not able to optimize the process.

If you see some other optimization opportunity in NER, let me know.