### PR TITLE
fixed issue with changing the root logging

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -37,7 +37,6 @@ logging.config.dictConfig(
         "loggers": {
             "flair": {"handlers": ["console"], "level": "INFO", "propagate": False}
         },
-        "root": {"handlers": ["console"], "level": "WARNING"},
     }
 )
 


### PR DESCRIPTION
about [issue#1059](https://github.com/zalandoresearch/flair/issues/1059)，I think this problem is changing the root logging in `flair/__init__.py`.
I think set logging.config should not change root logging and only use `logging.getLogger("name of module")`, like this `logging.getLogger("flair")`.

and in my testing,
issue#1059 is fixed, in my computer.

Maybe I removed setting root logging in `flair/__init__.py` is too rash, we can talk about better solution for this issue.