### PR TITLE
Decrease inference time of 30% when not using CRF for seq tagging

### DIFF
--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -1195,10 +1195,7 @@ class FeideggerDataset(FlairDataset):
 
                 # append Sentence-Image data point and split ID
                 self.data_points.append(
-                    DataPair(
-                        Sentence(preprocessor(caption), use_tokenizer=True),
-                        image,
-                    )
+                    DataPair(Sentence(preprocessor(caption), use_tokenizer=True), image)
                 )
                 self.split.append(split_id)
 

--- a/flair/models/similarity_learning_model.py
+++ b/flair/models/similarity_learning_model.py
@@ -240,18 +240,20 @@ class SimilarityLearner(flair.nn.Model):
             else:
                 hashmap[key] += [val]
 
-        index_map = {'first': {}, 'second': {}}
+        index_map = {"first": {}, "second": {}}
         for data_point_id, data_point in enumerate(data_points):
-            add_to_index_map(index_map['first'], str(data_point.first), data_point_id)
-            add_to_index_map(index_map['second'], str(data_point.second), data_point_id)
+            add_to_index_map(index_map["first"], str(data_point.first), data_point_id)
+            add_to_index_map(index_map["second"], str(data_point.second), data_point_id)
 
         targets = torch.zeros_like(similarity_matrix).to(flair.device)
 
         for data_point in data_points:
-            first_indices = index_map['first'][str(data_point.first)]
-            second_indices = index_map['second'][str(data_point.second)]
-            for first_index, second_index in itertools.product(first_indices, second_indices):
-                targets[first_index, second_index] = 1.
+            first_indices = index_map["first"][str(data_point.first)]
+            second_indices = index_map["second"][str(data_point.second)]
+            for first_index, second_index in itertools.product(
+                first_indices, second_indices
+            ):
+                targets[first_index, second_index] = 1.0
 
         loss = self.similarity_loss(similarity_matrix, targets)
 
@@ -276,10 +278,12 @@ class SimilarityLearner(flair.nn.Model):
                         target_index[str(data_point.second)] = len(target_index)
                         target_inputs.append(data_point)
                 if target_inputs:
-                    all_target_embeddings.append(self._embed_target(target_inputs).to(self.eval_device))
+                    all_target_embeddings.append(
+                        self._embed_target(target_inputs).to(self.eval_device)
+                    )
                 store_embeddings(data_points, embeddings_storage_mode)
             all_target_embeddings = torch.cat(all_target_embeddings, dim=0)  # [n0, d0]
-            assert(len(target_index) == all_target_embeddings.shape[0])
+            assert len(target_index) == all_target_embeddings.shape[0]
 
             ranks = []
             for data_points in data_loader:

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -134,6 +134,8 @@ class TextClassifier(flair.nn.Model):
         Predicts the class labels for the given sentences. The labels are directly added to the sentences.
         :param sentences: list of sentences
         :param mini_batch_size: mini batch size to use
+        :param embedding_storage_mode: 'none' for the minimum memory footprint, 'cpu' to store embeddings in Ram,
+        'gpu' to store embeddings in GPU memory.
         :param multi_class_prob : return probability for all class for multiclass
         :return: the list of sentences containing the labels
         """


### PR DESCRIPTION
When CRF is not used, data were slow down by a for loop.
In this little refactoring, this part have been vectorized.
I kept everything on Pytorch Tensor.
As always, I am interested in your timings on V100 :-)

On my 2080 TI, without refactoring on French data with a model trained without CRF, before I got 63 seconds, and after modification I get 43 seconds.