### PR TITLE
GH-1073: batch first

### DIFF
--- a/flair/nn.py
+++ b/flair/nn.py
@@ -144,16 +144,21 @@ class LockedDropout(torch.nn.Module):
     Implementation of locked (or variational) dropout. Randomly drops out entire parameters in embedding space.
     """
 
-    def __init__(self, dropout_rate=0.5, inplace=False):
+    def __init__(self, dropout_rate=0.5, batch_first=True, inplace=False):
         super(LockedDropout, self).__init__()
         self.dropout_rate = dropout_rate
+        self.batch_first = batch_first
         self.inplace = inplace
 
     def forward(self, x):
         if not self.training or not self.dropout_rate:
             return x
 
-        m = x.data.new(1, x.size(1), x.size(2)).bernoulli_(1 - self.dropout_rate)
+        if not self.batch_first:
+            m = x.data.new(1, x.size(1), x.size(2)).bernoulli_(1 - self.dropout_rate)
+        else:
+            m = x.data.new(x.size(0), 1, x.size(2)).bernoulli_(1 - self.dropout_rate)
+
         mask = torch.autograd.Variable(m, requires_grad=False) / (1 - self.dropout_rate)
         mask = mask.expand_as(x)
         return mask * x
@@ -177,9 +182,9 @@ class WordDropout(torch.nn.Module):
         if not self.training or not self.dropout_rate:
             return x
 
-        m = x.data.new(x.size(0), 1, 1).bernoulli_(1 - self.dropout_rate)
+        m = x.data.new(x.size(0), x.size(1), 1).bernoulli_(1 - self.dropout_rate)
+
         mask = torch.autograd.Variable(m, requires_grad=False)
-        mask = mask.expand_as(x)
         return mask * x
 
     def extra_repr(self):


### PR DESCRIPTION
Closes #1073 

This PR changes `WordDropout` and `LockedDropout` to be robust to `batch_first` mode. For `LockedDropout` this means adding a boolean parameter `batch_first` to the constructor that by default is set to `True`. 

The `WordDropout` is now implemented differently as the previous version was a 'lcoked' word dropout that would always drop the same index words across a mini-batch. Now, words are dropped fully at random. Some initial experiments show that this improves downstream task training. 

The PR also removes the transpose operations in the `SequenceTagger` and the `DocumentRNNEmbeddings` and removes the sorting logic from the `DocumentRNNEmbeddings`.
