### PR TITLE
GH-1079: Increase CPU training speed by pinning tensors

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -153,7 +153,7 @@ class DataPoint:
         pass
 
     @abstractmethod
-    def to(self, device: str):
+    def to(self, device: str, pin_memory: bool = False):
         pass
 
     @abstractmethod
@@ -166,9 +166,9 @@ class DataPair(DataPoint):
         self.first = first
         self.second = second
 
-    def to(self, device: str):
-        self.first.to(device)
-        self.second.to(device)
+    def to(self, device: str, pin_memory: bool = False):
+        self.first.to(device, pin_memory)
+        self.second.to(device, pin_memory)
 
     def clear_embeddings(self, embedding_names: List[str] = None):
         self.first.clear_embeddings(embedding_names)
@@ -239,9 +239,15 @@ class Token(DataPoint):
             device = next(iter(self._embeddings.values())).device
         self._embeddings[name] = vector.to(device, non_blocking=True)
 
-    def to(self, device: str):
+    def to(self, device: str, pin_memory: bool = False):
         for name, vector in self._embeddings.items():
-            self._embeddings[name] = vector.to(device, non_blocking=True)
+            if str(vector.device) != str(device):
+                if pin_memory:
+                    self._embeddings[name] = vector.to(
+                        device, non_blocking=True
+                    ).pin_memory()
+                else:
+                    self._embeddings[name] = vector.to(device, non_blocking=True)
 
     def clear_embeddings(self, embedding_names: List[str] = None):
         if embedding_names is None:
@@ -580,15 +586,21 @@ class Sentence(DataPoint):
 
         return torch.Tensor()
 
-    def to(self, device: str):
+    def to(self, device: str, pin_memory: bool = False):
 
         # move sentence embeddings to device
         for name, vector in self._embeddings.items():
-            self._embeddings[name] = vector.to(device, non_blocking=True)
+            if str(vector.device) != str(device):
+                if pin_memory:
+                    self._embeddings[name] = vector.to(
+                        device, non_blocking=True
+                    ).pin_memory()
+                else:
+                    self._embeddings[name] = vector.to(device, non_blocking=True)
 
         # move token embeddings to device
         for token in self:
-            token.to(device)
+            token.to(device, pin_memory)
 
     def clear_embeddings(self, embedding_names: List[str] = None):
 
@@ -795,9 +807,15 @@ class Image(DataPoint):
             device = next(iter(self._embeddings.values())).device
         self._embeddings[name] = vector.to(device, non_blocking=True)
 
-    def to(self, device: str):
+    def to(self, device: str, pin_memory: bool = False):
         for name, vector in self._embeddings.items():
-            self._embeddings[name] = vector.to(device, non_blocking=True)
+            if str(vector.device) != str(device):
+                if pin_memory:
+                    self._embeddings[name] = vector.to(
+                        device, non_blocking=True
+                    ).pin_memory()
+                else:
+                    self._embeddings[name] = vector.to(device, non_blocking=True)
 
     def clear_embeddings(self, embedding_names: List[str] = None):
         if embedding_names is None:

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1867,7 +1867,7 @@ class FlairEmbeddings(TokenEmbeddings):
                     token.set_embedding(self.name, embedding.clone())
 
             all_hidden_states_in_lm = all_hidden_states_in_lm.detach()
-            all_hidden_states_in_lm = None
+            del all_hidden_states_in_lm
 
         return sentences
 

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 from enum import Enum
 from pathlib import Path
 from typing import List
+
+import flair
 from flair.data import Dictionary, Sentence
 from functools import reduce
 from sklearn.metrics import mean_squared_error, mean_absolute_error
@@ -358,7 +360,8 @@ def store_embeddings(sentences: List[Sentence], storage_mode: str):
         for sentence in sentences:
             sentence.clear_embeddings(delete_keys)
 
-    # memory management - option 1: send everything to CPU
+    # memory management - option 1: send everything to CPU (pin to memory if we train on GPU)
     if storage_mode == "cpu":
+        pin_memory = False if str(flair.device) == "cpu" else True
         for sentence in sentences:
-            sentence.to("cpu", pin_memory=True)
+            sentence.to("cpu", pin_memory=pin_memory)

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -361,4 +361,4 @@ def store_embeddings(sentences: List[Sentence], storage_mode: str):
     # memory management - option 1: send everything to CPU
     if storage_mode == "cpu":
         for sentence in sentences:
-            sentence.to("cpu")
+            sentence.to("cpu", pin_memory=True)


### PR DESCRIPTION
This PR makes minor modifications to the `.to()` method of the `DataPoint` base class and all implementing classes, namely adding the option of moving a data point tensor to pinned memory. Pinning a tensor is a one-time cost but then allows all subsequents GPU tensor copy operations to work faster. When training a model with `embeddings_storage_mode = 'cpu'`, we at each epoch move tensors from CPU to GPU, so this PR increases overall training speed (closes #1079).  

This PR also adds a check if the `.to()` operation is even necessary (not needed if a tensor is already on the relevant device), leading to a small increase in training speed. 