### PR TITLE
Set a LRU cache for word embeddings for a decrease of 20% of inference time

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -237,11 +237,11 @@ class Token(DataPoint):
         device = flair.device
         if len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device
-        self._embeddings[name] = vector.to(device, non_blocking=True)
+        self._embeddings[name] = vector.to(device)
 
     def to(self, device: str):
         for name, vector in self._embeddings.items():
-            self._embeddings[name] = vector.to(device, non_blocking=True)
+            self._embeddings[name] = vector.to(device)
 
     def clear_embeddings(self, embedding_names: List[str] = None):
         if embedding_names is None:

--- a/flair/data.py
+++ b/flair/data.py
@@ -563,7 +563,7 @@ class Sentence(DataPoint):
     def embedding(self):
         return self.get_embedding()
 
-    def set_embedding(self, name: str, vector):
+    def set_embedding(self, name: str, vector: torch.tensor):
         device = flair.device
         if len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -339,7 +339,9 @@ class WordEmbeddings(TokenEmbeddings):
         else:
             word_embedding = np.zeros(self.embedding_length, dtype="float")
 
-        word_embedding = torch.tensor(word_embedding, device=flair.device, dtype=torch.float)
+        word_embedding = torch.tensor(
+            word_embedding, device=flair.device, dtype=torch.float
+        )
         return word_embedding
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
@@ -418,7 +420,9 @@ class FastTextEmbeddings(TokenEmbeddings):
         except:
             word_embedding = np.zeros(self.embedding_length, dtype="float")
 
-        word_embedding = torch.tensor(word_embedding, device=flair.device, dtype=torch.float)
+        word_embedding = torch.tensor(
+            word_embedding, device=flair.device, dtype=torch.float
+        )
         return word_embedding
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
@@ -581,7 +585,9 @@ class MuseCrosslingualEmbeddings(TokenEmbeddings):
             word_embedding = current_embedding_model[re.sub(r"\d", "0", word.lower())]
         else:
             word_embedding = np.zeros(self.embedding_length, dtype="float")
-        word_embedding = torch.tensor(word_embedding, device=flair.device, dtype=torch.float)
+        word_embedding = torch.tensor(
+            word_embedding, device=flair.device, dtype=torch.float
+        )
         return word_embedding
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -339,8 +339,7 @@ class WordEmbeddings(TokenEmbeddings):
         else:
             word_embedding = np.zeros(self.embedding_length, dtype="float")
 
-        word_embedding = torch.FloatTensor(word_embedding)
-        word_embedding = word_embedding.to(flair.device)
+        word_embedding = torch.tensor(word_embedding, device=flair.device, dtype=torch.float)
         return word_embedding
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
@@ -419,8 +418,7 @@ class FastTextEmbeddings(TokenEmbeddings):
         except:
             word_embedding = np.zeros(self.embedding_length, dtype="float")
 
-        word_embedding = torch.FloatTensor(word_embedding)
-        word_embedding.to(flair.device)
+        word_embedding = torch.tensor(word_embedding, device=flair.device, dtype=torch.float)
         return word_embedding
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
@@ -583,9 +581,7 @@ class MuseCrosslingualEmbeddings(TokenEmbeddings):
             word_embedding = current_embedding_model[re.sub(r"\d", "0", word.lower())]
         else:
             word_embedding = np.zeros(self.embedding_length, dtype="float")
-
-        word_embedding = torch.FloatTensor(word_embedding)
-        word_embedding = word_embedding.to(flair.device)
+        word_embedding = torch.tensor(word_embedding, device=flair.device, dtype=torch.float)
         return word_embedding
 
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -458,9 +458,8 @@ class SequenceTagger(flair.nn.Model):
 
         for s_id, sentence in enumerate(sentences):
             # fill values with word embeddings
-            sentence_tensor[s_id][: len(sentence)] = torch.cat(
-                [token.get_embedding().unsqueeze(0) for token in sentence], 0
-            )
+            token_embeddings = [token.get_embedding() for token in sentence]
+            sentence_tensor[s_id][: len(sentence)] = torch.stack(token_embeddings)
 
         # --------------------------------------------------------------------
         # FF PART

--- a/flair/visual/ner_html.py
+++ b/flair/visual/ner_html.py
@@ -16,7 +16,7 @@ HTML_PAGE = """
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>Flair</title>
+        <title>{title}</title>
     </head>
 
     <body style="font-size: 16px; font-family: 'Segoe UI'; padding: 4rem 2rem">{text}</body>
@@ -41,6 +41,7 @@ def split_to_spans(s: Sentence):
 
 def render_ner_html(
     sentences: Union[List[Sentence], Sentence],
+    title: str = "Flair",
     colors={
         "PER": "#F7FF53",
         "ORG": "#E8902E",
@@ -53,6 +54,7 @@ def render_ner_html(
 ) -> str:
     """
     :param sentences: single sentence or list of sentences to convert to HTML
+    :param title: title of the HTML page
     :param colors: dict where keys are tags and values are color HTML codes
     :param default_color: color to use if colors parameter is missing a tag
     :param wrap_page: if True method returns result of processing sentences wrapped by &lt;html&gt; and &lt;body&gt; tags, otherwise - without these tags
@@ -79,6 +81,6 @@ def render_ner_html(
     final_text = "".join(sentences_html)
 
     if wrap_page:
-        return HTML_PAGE.format(text=final_text)
+        return HTML_PAGE.format(text=final_text, title=title)
     else:
         return final_text

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -79,7 +79,7 @@ def test_html_rendering():
             + TAGGED_ENTITY.format(color="yellow", entity="UK", label="LOC")
             + " prime minister. &amp;"
         ),
-        title="Flair"
+        title="Flair",
     )
 
     assert expected_res == actual

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -78,7 +78,8 @@ def test_html_rendering():
             + " leader in a ballot of party members and will become the next "
             + TAGGED_ENTITY.format(color="yellow", entity="UK", label="LOC")
             + " prime minister. &amp;"
-        )
+        ),
+        title="Flair"
     )
 
     assert expected_res == actual


### PR DESCRIPTION
Set an embedding LRU cache of Tensor of word embeddings.
This approach avoid to convert most used Gensim embeddings to Pytorch Tensor and even more important to avoid to transfer from computer RAM to GPU Ram (this is a slow operation).
Because of zipf law, the effect of such caching approach are magnified.
LRU cache is set to 10000 because it s very small and still provide most of the performance boost compared to loading all embeddings in GPU Ram. A 1000 embedding LRU cache is slightly less performant on my own dataset.

A second little optimization is to replace a call of `unsqueeze` on each token followed by a `cat` by a single call of `stack`.

Time to process 100 French documents decreased from 33s to 26s with this PR.
For what it worths, Spacy takes exactly the same time (26s) on my dataset with much lower accuracy on some tricky entities (and same accuracy on easiest to recognize entities).
Another change is on Ner HTML viewer with the introduction of a HTML title parameter.