### PR TITLE
Star Wars: Episode II – Attack of the clone()

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1839,12 +1839,11 @@ class FlairEmbeddings(TokenEmbeddings):
                     padded = "{}{}{}{}".format(
                         start_marker, sentence_text, end_marker, pad_by * " "
                     )
-                    append_padded_sentence(padded)
                 else:
                     padded = "{}{}{}{}".format(
                         start_marker, sentence_text[::-1], end_marker, pad_by * " "
                     )
-                    append_padded_sentence(padded)
+                append_padded_sentence(padded)
 
             # get hidden states from language model
             # all_hidden_states_in_lm contains dimensions related to padding or character inside a token
@@ -1878,11 +1877,13 @@ class FlairEmbeddings(TokenEmbeddings):
                 # limit the size of the sentence embedding to the very strict minimum
                 # token embedding will keep a pointer toward sentence embedding, therefore in case of CPU or GPU storing
                 # this embedding will not be garbage collected
-                sentence_embedding = (
-                    all_hidden_states_in_lm[dimensions_to_extract, i, :]
-                    .detach()
-                    .clone()
-                )
+                sentence_embedding = all_hidden_states_in_lm[
+                    dimensions_to_extract, i, :
+                ].clone()
+
+                if not self.fine_tune:
+                    sentence_embedding = sentence_embedding.detach()
+
                 for index, token in enumerate(sentence.tokens):
                     # token embedding is just a pointer to sentence embedding plus a specific view over its data
                     # sentence embedding will live as long as an object will point towards it


### PR DESCRIPTION
In PR #1074 it has been noticed that removing call to `clone()` get us some nice improvement, however, when training with embedding storage set to GPU, we rapidly got OOM exceptions. Finally the optimization have been reverted.

Pytorch Tensor have a a data layer called `storage`. When we subset an existing tensor, the new one has just a pointer toward the original Tensor storage, plus some offset, etc., in this case they are just a new View over existing data. It means that the old Tensor will never be garbage collected if the new Tensor is alive. On the other side, we avoid data copy that can be very costly.

calling clone() realizes storage copy in the new tensor, so the old one have no more pointer towards it and goes out of scope -> gc -> ciao

The last remaining mystery (at least for me) was why is there some OOM? Because all embeddings are pointing to the same large Tensor. What I didn't realized is that most of the original big Tensor is garbage: it includes padding plus dimensions related to character inside a Token, however we don't care about those dimensions, we only use the dimensions related to the first / last character of each token.

So the optimization is quite simple: we limit the number of clone() call, from one per token to one per sentence. Basically we first extract the useful part of the Tensor for each sentence, then we detach / clone, and we point towards the new Tensor. All tokens from the same sentence will share the same medium large Tensor. Memory footprint is exactly the same as before but by reducing the number of calls we get some nice perf improvement (which is slightly lower than not calling clone at all but benefit to cpu storage training).

Processing time of my French data goes from 26s to 21s, a 19% decrease for NER inference.