### PR TITLE
GH-1067: ray tune

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 env:
   - BOTO_CONFIG=/dev/null
 python:
-  - "3.6"
+  - "3.7"
 install:
   - python setup.py develop -q
 before_script: cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 python:
   - "3.6"
 install:
-  - python setup.py develop -q
+  - pip install -q -e .
 before_script: cd tests
 script:
   - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 env:
   - BOTO_CONFIG=/dev/null
 python:
-  - "3.7"
+  - "3.6"
 install:
   - python setup.py develop -q
 before_script: cd tests

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2695,14 +2695,11 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
         self.name = "document_" + self.rnn._get_name()
 
         # dropouts
-        if locked_dropout > 0.0:
-            self.dropout: torch.nn.Module = LockedDropout(locked_dropout)
-        else:
-            self.dropout = torch.nn.Dropout(dropout)
-
-        self.use_word_dropout: bool = word_dropout > 0.0
-        if self.use_word_dropout:
-            self.word_dropout = WordDropout(word_dropout)
+        self.dropout = torch.nn.Dropout(dropout) if dropout > 0.0 else None
+        self.locked_dropout = (
+            LockedDropout(locked_dropout) if locked_dropout > 0.0 else None
+        )
+        self.word_dropout = WordDropout(word_dropout) if word_dropout > 0.0 else None
 
         torch.nn.init.xavier_uniform_(self.word_reprojection_map.weight)
 
@@ -2746,30 +2743,32 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
                 [token.get_embedding().unsqueeze(0) for token in sentence], 0
             )
 
-        # --------------------------------------------------------------------
-        # FF PART
-        # --------------------------------------------------------------------
-        sentence_tensor = self.dropout(sentence_tensor)
-        # use word dropout if set
-        if self.use_word_dropout:
+        # before-RNN dropout
+        if self.dropout:
+            sentence_tensor = self.dropout(sentence_tensor)
+        if self.locked_dropout:
+            sentence_tensor = self.locked_dropout(sentence_tensor)
+        if self.word_dropout:
             sentence_tensor = self.word_dropout(sentence_tensor)
 
+        # reproject if set
         if self.reproject_words:
             sentence_tensor = self.word_reprojection_map(sentence_tensor)
 
+        # push through RNN
         packed = pack_padded_sequence(
             sentence_tensor, lengths, enforce_sorted=False, batch_first=True
         )
-
         rnn_out, hidden = self.rnn(packed)
-
         outputs, output_lengths = pad_packed_sequence(rnn_out, batch_first=True)
 
-        outputs = self.dropout(outputs)
+        # after-RNN dropout
+        if self.dropout:
+            outputs = self.dropout(outputs)
+        if self.locked_dropout:
+            sentence_tensor = self.locked_dropout(sentence_tensor)
 
-        # --------------------------------------------------------------------
-        # EXTRACT EMBEDDINGS FROM RNN
-        # --------------------------------------------------------------------
+        # extract embeddings from RNN
         for sentence_no, length in enumerate(lengths):
             last_rep = outputs[sentence_no, length - 1]
 

--- a/flair/hyperparameter/param_selection.py
+++ b/flair/hyperparameter/param_selection.py
@@ -102,14 +102,11 @@ class ParamSelector(object):
             }
 
             trainer: ModelTrainer = ModelTrainer(
-                model, self.corpus, **model_trainer_parameters
+                model, self.corpus, **model_trainer_parameters, **training_params
             )
 
             result = trainer.train(
-                self.base_path,
-                max_epochs=self.max_epochs,
-                param_selection_mode=True,
-                **training_params,
+                self.base_path, max_epochs=self.max_epochs, param_selection_mode=True
             )
 
             # take the average over the last three scores of training

--- a/flair/hyperparameter/tune.py
+++ b/flair/hyperparameter/tune.py
@@ -17,7 +17,9 @@ class FlairTune(Trainable):
         if not "epoch" in self.__dict__:
             self.epoch = 0
         # run training code
-        loss = self.trainer._train_one_epoch(self.epoch, embeddings_storage_mode="cpu")
+        loss = self.trainer._train_one_epoch(
+            self.epoch, embeddings_storage_mode=self.embeddings_storage_mode
+        )
         self.epoch += 1
         return loss
 
@@ -28,7 +30,7 @@ class FlairTune(Trainable):
         self.trainer.model.eval()
         results, test_loss = self.trainer.model.evaluate(
             self.test,
-            embeddings_storage_mode="cpu",
+            embeddings_storage_mode=self.embeddings_storage_mode,
             out_path=Path(self._logdir) / "test.txt",
         )
 
@@ -49,6 +51,8 @@ class FlairTune(Trainable):
         return result_dict
 
     def _train(self):
+        if not "embeddings_storage_mode" in self.__dict__:
+            self.embeddings_storage_mode = "cpu"
         loss = self._train_iteration()
         result_dict = self._test()
         result_dict["mean_loss"] = loss
@@ -85,7 +89,6 @@ def write_experiment_summary(trials, result_file_path):
                 else:
                     result_line += str(trial.config[config_key]) + "\t"
 
-            # result_line = '\t'.join([str(trial.config[config_key]) for config_key in sorted(trial.config.keys())])
             result_line += f"{1 - trial.last_result['1-lr']}\t{trial.last_result['mean_loss']}\t{trial.last_result['training_iteration']}\t{trial.last_result['mean_accuracy']}\n"
             outfile.write(result_line)
             logger.info(result_line)

--- a/flair/hyperparameter/tune.py
+++ b/flair/hyperparameter/tune.py
@@ -45,9 +45,13 @@ class TuneFlair(Trainable):
         with open(Path(self._logdir) / "eval.txt", "a", encoding="utf-8") as outfile:
             if self.epoch == 1:
                 outfile.write(results.log_header + "\n")
-            outfile.write(results.log_line + "\n")
+            outfile.write(f"{self.epoch}\t{learning_rate}\t{results.log_line}\n")
 
-        result_dict = {"mean_accuracy": results.main_score, "1-lr": 1 - learning_rate}
+        result_dict = {
+            "mean_accuracy": results.main_score,
+            "1-lr": 1 - learning_rate,
+            "patience": self.trainer.patience,
+        }
         return result_dict
 
     def _train(self):

--- a/flair/hyperparameter/tune.py
+++ b/flair/hyperparameter/tune.py
@@ -12,7 +12,7 @@ import logging
 logger = logging.getLogger("flair")
 
 
-class FlairTune(Trainable):
+class TuneFlair(Trainable):
     def _train_iteration(self):
         if not "epoch" in self.__dict__:
             self.epoch = 0

--- a/flair/hyperparameter/tune.py
+++ b/flair/hyperparameter/tune.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+from ray.tune import Trainable
+from ray.tune.trial import Trial
+
+from flair.datasets import DataLoader
+from flair.trainers import ModelTrainer
+
+from flair.training_utils import Result
+
+import logging
+
+logger = logging.getLogger("flair")
+
+
+class FlairTune(Trainable):
+    def _train_iteration(self):
+        if not "epoch" in self.__dict__:
+            self.epoch = 0
+        # run training code
+        loss = self.trainer._train_one_epoch(self.epoch, embeddings_storage_mode="cpu")
+        self.epoch += 1
+        return loss
+
+    def _test(self):
+        if not "test" in self.__dict__:
+            self.test = DataLoader(self.corpus.dev)
+
+        self.trainer.model.eval()
+        results, test_loss = self.trainer.model.evaluate(
+            self.test,
+            embeddings_storage_mode="cpu",
+            out_path=Path(self._logdir) / "test.txt",
+        )
+
+        results: Result = results
+
+        # determine learning rate annealing through scheduler
+        if results.main_score != 0.0:
+            self.trainer.scheduler.step(results.main_score)
+        for group in self.trainer.optimizer.param_groups:
+            learning_rate = group["lr"]
+
+        with open(Path(self._logdir) / "eval.txt", "a", encoding="utf-8") as outfile:
+            if self.epoch == 1:
+                outfile.write(results.log_header + "\n")
+            outfile.write(results.log_line + "\n")
+
+        result_dict = {"mean_accuracy": results.main_score, "1-lr": 1 - learning_rate}
+        return result_dict
+
+    def _train(self):
+        loss = self._train_iteration()
+        result_dict = self._test()
+        result_dict["mean_loss"] = loss
+        return result_dict
+
+    def _save(self, checkpoint_dir):
+        path = Path(checkpoint_dir) / "checkpoint.pt"
+        self.trainer.save_checkpoint(path)
+        return str(path)
+
+    def _restore(self, checkpoint_prefix):
+        self.trainer = ModelTrainer.load_checkpoint(
+            Path(checkpoint_prefix), self.corpus
+        )
+
+
+def write_experiment_summary(trials, result_file_path):
+
+    with open(result_file_path, "w", encoding="utf-8") as outfile:
+        header = None
+        for trial in trials:
+            trial: Trial = trial
+            if header is None:
+                header = "\t".join(sorted(trial.config.keys()))
+                header += "\tfinal LR\tmean_loss\titerations\tmean_accuracy\n"
+                outfile.write(header)
+                logger.info(header)
+
+            result_line = ""
+            for config_key in sorted(trial.config.keys()):
+                if type(trial.config[config_key]) == float:
+                    result_line += str(round(trial.config[config_key], 2)) + "\t"
+
+                else:
+                    result_line += str(trial.config[config_key]) + "\t"
+
+            # result_line = '\t'.join([str(trial.config[config_key]) for config_key in sorted(trial.config.keys())])
+            result_line += f"{1 - trial.last_result['1-lr']}\t{trial.last_result['mean_loss']}\t{trial.last_result['training_iteration']}\t{trial.last_result['mean_accuracy']}\n"
+            outfile.write(result_line)
+            logger.info(result_line)
+        outfile.close()

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -253,6 +253,9 @@ class SequenceTagger(flair.nn.Model):
         embeddings_storage_mode: str = "cpu",
     ) -> (Result, float):
 
+        if type(out_path) == str:
+            out_path = Path(out_path)
+
         with torch.no_grad():
             eval_loss = 0
 

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -66,24 +66,6 @@ class Model(torch.nn.Module):
 
         torch.save(model_state, str(model_file), pickle_protocol=4)
 
-    def save_checkpoint(
-        self,
-        model_file: Union[str, Path],
-        optimizer_state: dict,
-        scheduler_state: dict,
-        epoch: int,
-        loss: float,
-    ):
-        model_state = self._get_state_dict()
-
-        # additional fields for model checkpointing
-        model_state["optimizer_state_dict"] = optimizer_state
-        model_state["scheduler_state_dict"] = scheduler_state
-        model_state["epoch"] = epoch
-        model_state["loss"] = loss
-
-        torch.save(model_state, str(model_file), pickle_protocol=4)
-
     @classmethod
     def load(cls, model: Union[str, Path]):
         """
@@ -106,37 +88,6 @@ class Model(torch.nn.Module):
         model.to(flair.device)
 
         return model
-
-    @classmethod
-    def load_checkpoint(cls, checkpoint_file: Union[str, Path]):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            # load_big_file is a workaround by https://github.com/highway11git to load models on some Mac/Windows setups
-            # see https://github.com/zalandoresearch/flair/issues/351
-            f = flair.file_utils.load_big_file(str(checkpoint_file))
-            state = torch.load(f, map_location=flair.device)
-
-        model = cls._init_model_with_state_dict(state)
-
-        model.eval()
-        model.to(flair.device)
-
-        epoch = state["epoch"] if "epoch" in state else None
-        loss = state["loss"] if "loss" in state else None
-        optimizer_state_dict = (
-            state["optimizer_state_dict"] if "optimizer_state_dict" in state else None
-        )
-        scheduler_state_dict = (
-            state["scheduler_state_dict"] if "scheduler_state_dict" in state else None
-        )
-
-        return {
-            "model": model,
-            "epoch": epoch,
-            "loss": loss,
-            "optimizer_state_dict": optimizer_state_dict,
-            "scheduler_state_dict": scheduler_state_dict,
-        }
 
 
 class LockedDropout(torch.nn.Module):

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -39,72 +39,35 @@ class ModelTrainer:
         model: flair.nn.Model,
         corpus: Corpus,
         optimizer: torch.optim.Optimizer = SGD,
-        epoch: int = 0,
-        optimizer_state: dict = None,
-        scheduler_state: dict = None,
-        use_tensorboard: bool = False,
-    ):
-        """
-        Initialize a model trainer
-        :param model: The model that you want to train. The model should inherit from flair.nn.Model
-        :param corpus: The dataset used to train the model, should be of type Corpus
-        :param optimizer: The optimizer to use (typically SGD or Adam)
-        :param epoch: The starting epoch (normally 0 but could be higher if you continue training model)
-        :param optimizer_state: Optimizer state (necessary if continue training from checkpoint)
-        :param scheduler_state: Scheduler state (necessary if continue training from checkpoint)
-        :param use_tensorboard: If True, writes out tensorboard information
-        """
-        self.model: flair.nn.Model = model
-        self.corpus: Corpus = corpus
-        self.optimizer: torch.optim.Optimizer = optimizer
-        self.epoch: int = epoch
-        self.scheduler_state: dict = scheduler_state
-        self.optimizer_state: dict = optimizer_state
-        self.use_tensorboard: bool = use_tensorboard
-
-    def train(
-        self,
-        base_path: Union[Path, str],
         learning_rate: float = 0.1,
         mini_batch_size: int = 32,
-        eval_mini_batch_size: int = None,
-        max_epochs: int = 100,
         anneal_factor: float = 0.5,
         patience: int = 3,
         min_learning_rate: float = 0.0001,
-        train_with_dev: bool = False,
-        monitor_train: bool = False,
-        monitor_test: bool = False,
-        embeddings_storage_mode: str = "cpu",
-        checkpoint: bool = False,
-        save_final_model: bool = True,
-        anneal_with_restarts: bool = False,
+        eval_mini_batch_size: int = None,
         shuffle: bool = True,
-        param_selection_mode: bool = False,
-        num_workers: int = 6,
+        train_with_dev: bool = False,
+        anneal_with_restarts: bool = False,
         sampler=None,
+        num_workers: int = 6,
         use_amp: bool = False,
         amp_opt_level: str = "O1",
         **kwargs,
-    ) -> dict:
+    ):
         """
         Trains any class that implements the flair.nn.Model interface.
-        :param base_path: Main path to which all output during training is logged and models are saved
+        :param model: The model that you want to train. The model should inherit from flair.nn.Model
+        :param corpus: The dataset used to train the model, should be of type Corpus
+        :param optimizer: The optimizer to use (typically SGD or Adam)
+        :param use_tensorboard: If True, writes out tensorboard information
         :param learning_rate: Initial learning rate
         :param mini_batch_size: Size of mini-batches during training
         :param eval_mini_batch_size: Size of mini-batches during evaluation
-        :param max_epochs: Maximum number of epochs to train. Terminates training if this number is surpassed.
         :param anneal_factor: The factor by which the learning rate is annealed
         :param patience: Patience is the number of epochs with no improvement the Trainer waits
          until annealing the learning rate
         :param min_learning_rate: If the learning rate falls below this threshold, training terminates
         :param train_with_dev: If True, training is performed using both train+dev data
-        :param monitor_train: If True, training data is evaluated at end of each epoch
-        :param monitor_test: If True, test data is evaluated at end of each epoch
-        :param embeddings_storage_mode: One of 'none' (all embeddings are deleted and freshly recomputed),
-        'cpu' (embeddings are stored on CPU) or 'gpu' (embeddings are stored on GPU)
-        :param checkpoint: If True, a full checkpoint is saved at end of each epoch
-        :param save_final_model: If True, final model is saved
         :param anneal_with_restarts: If True, the last best model is restored when annealing the learning rate
         :param shuffle: If True, data is shuffled during training
         :param param_selection_mode: If True, testing is performed against dev data. Use this mode when doing
@@ -112,10 +75,98 @@ class ModelTrainer:
         :param num_workers: Number of workers in your data loader.
         :param sampler: You can pass a data sampler here for special sampling of data.
         :param kwargs: Other arguments for the Optimizer
+        """
+        self.model: flair.nn.Model = model
+        self.corpus: Corpus = corpus
+
+        # init optimizer
+        self.optimizer_type = optimizer
+        self.optimizer: torch.optim.Optimizer = optimizer(
+            self.model.parameters(), lr=learning_rate, **kwargs
+        )
+
+        # init scheduler
+        # minimize training loss if training with dev data, else maximize dev score
+        self.train_with_dev: bool = train_with_dev
+        anneal_mode = "min" if self.train_with_dev else "max"
+        self.scheduler: ReduceLROnPlateau = ReduceLROnPlateau(
+            self.optimizer,
+            factor=anneal_factor,
+            patience=patience,
+            mode=anneal_mode,
+            verbose=True,
+        )
+
+        self.epoch: int = 0
+
+        # training parameters
+        self.mini_batch_size: int = mini_batch_size
+        self.eval_mini_batch_size = (
+            mini_batch_size if eval_mini_batch_size is None else eval_mini_batch_size
+        )
+        self.learning_rate = learning_rate
+        self.anneal_factor = anneal_factor
+        self.patience: int = patience
+        self.anneal_with_restarts: bool = anneal_with_restarts
+        self.min_learning_rate: float = min_learning_rate
+
+        # set up training data loader
+        train_data = self.corpus.train
+
+        if self.train_with_dev:
+            train_data = ConcatDataset([self.corpus.train, self.corpus.dev])
+
+        if sampler is not None:
+            sampler = sampler(train_data)
+            shuffle = False
+
+        self.train_data_loader = DataLoader(
+            train_data,
+            batch_size=self.mini_batch_size,
+            shuffle=shuffle,
+            num_workers=num_workers,
+            sampler=sampler,
+        )
+        self.shuffle = shuffle
+
+        # speed optimizations
+        self.use_amp: bool = use_amp
+        if self.use_amp:
+            self.model, self.optimizer = amp.initialize(
+                self.model, self.optimizer, opt_level=amp_opt_level
+            )
+        self.num_workers = num_workers
+
+    def train(
+        self,
+        base_path: Union[Path, str],
+        max_epochs: int = 150,
+        embeddings_storage_mode: str = "cpu",
+        monitor_test: bool = False,
+        monitor_train: bool = False,
+        use_tensorboard: bool = False,
+        checkpoint: bool = False,
+        save_final_model: bool = True,
+        param_selection_mode: bool = False,
+    ) -> dict:
+        """
+        Trains any class that implements the flair.nn.Model interface.
+        :param base_path: Main path to which all output during training is logged and models are saved
+        :param max_epochs: Maximum number of epochs to train. Terminates training if this number is surpassed.
+        :param embeddings_storage_mode: One of 'none' (all embeddings are deleted and freshly recomputed),
+        'cpu' (embeddings are stored on CPU) or 'gpu' (embeddings are stored on GPU)
+        :param monitor_train: If True, training data is evaluated at end of each epoch
+        :param monitor_test: If True, test data is evaluated at end of each epoch
+        :param checkpoint: If True, a full checkpoint is saved at end of each epoch
+        :param save_final_model: If True, final model is saved
         :return:
         """
 
-        if self.use_tensorboard:
+        if type(base_path) == str:
+            base_path = Path(base_path)
+        weight_extractor = WeightExtractor(base_path)
+
+        if use_tensorboard:
             try:
                 from torch.utils.tensorboard import SummaryWriter
 
@@ -126,10 +177,10 @@ class ModelTrainer:
                     "ATTENTION! PyTorch >= 1.1.0 and pillow are required for TensorBoard support!"
                 )
                 log_line(log)
-                self.use_tensorboard = False
+                use_tensorboard = False
                 pass
 
-        if use_amp:
+        if self.use_amp:
             if sys.version_info < (3, 0):
                 raise RuntimeError("Apex currently only supports Python 3. Aborting.")
             if amp is None:
@@ -137,9 +188,6 @@ class ModelTrainer:
                     "Failed to import apex. Please install apex from https://www.github.com/nvidia/apex "
                     "to enable mixed-precision training."
                 )
-
-        if eval_mini_batch_size is None:
-            eval_mini_batch_size = mini_batch_size
 
         # cast string to Path
         if type(base_path) is str:
@@ -152,14 +200,14 @@ class ModelTrainer:
         log_line(log)
         log.info(f'Corpus: "{self.corpus}"')
         log_line(log)
-        log.info("Parameters:")
-        log.info(f' - learning_rate: "{learning_rate}"')
-        log.info(f' - mini_batch_size: "{mini_batch_size}"')
-        log.info(f' - patience: "{patience}"')
-        log.info(f' - anneal_factor: "{anneal_factor}"')
+        log.info("Learning Parameters:")
+        log.info(f' - learning_rate: "{self.learning_rate}"')
+        log.info(f' - mini_batch_size: "{self.mini_batch_size}"')
+        log.info(f' - patience: "{self.patience}"')
+        log.info(f' - anneal_factor: "{self.anneal_factor}"')
         log.info(f' - max_epochs: "{max_epochs}"')
-        log.info(f' - shuffle: "{shuffle}"')
-        log.info(f' - train_with_dev: "{train_with_dev}"')
+        log.info(f' - shuffle: "{self.shuffle}"')
+        log.info(f' - train_with_dev: "{self.train_with_dev}"')
         log_line(log)
         log.info(f'Model training base path: "{base_path}"')
         log_line(log)
@@ -174,47 +222,10 @@ class ModelTrainer:
             if (not param_selection_mode and self.corpus.test and monitor_test)
             else False
         )
-        log_dev = True if not train_with_dev else False
+        log_dev = True if not self.train_with_dev else False
 
         # prepare loss logging file and set up header
         loss_txt = init_output_file(base_path, "loss.tsv")
-
-        weight_extractor = WeightExtractor(base_path)
-
-        optimizer: torch.optim.Optimizer = self.optimizer(
-            self.model.parameters(), lr=learning_rate, **kwargs
-        )
-        if self.optimizer_state is not None:
-            optimizer.load_state_dict(self.optimizer_state)
-
-        if use_amp:
-            self.model, optimizer = amp.initialize(
-                self.model, optimizer, opt_level=amp_opt_level
-            )
-
-        # minimize training loss if training with dev data, else maximize dev score
-        anneal_mode = "min" if train_with_dev else "max"
-
-        scheduler: ReduceLROnPlateau = ReduceLROnPlateau(
-            optimizer,
-            factor=anneal_factor,
-            patience=patience,
-            mode=anneal_mode,
-            verbose=True,
-        )
-
-        if self.scheduler_state is not None:
-            scheduler.load_state_dict(self.scheduler_state)
-
-        train_data = self.corpus.train
-
-        # if training also uses dev data, include in training set
-        if train_with_dev:
-            train_data = ConcatDataset([self.corpus.train, self.corpus.dev])
-
-        if sampler is not None:
-            sampler = sampler(train_data)
-            shuffle = False
 
         dev_score_history = []
         dev_loss_history = []
@@ -222,19 +233,19 @@ class ModelTrainer:
 
         # At any point you can hit Ctrl + C to break out of training early.
         try:
-            previous_learning_rate = learning_rate
+            previous_learning_rate = self.learning_rate
 
-            for epoch in range(0 + self.epoch, max_epochs + self.epoch):
+            for self.epoch in range(0 + self.epoch, max_epochs + self.epoch):
                 log_line(log)
 
                 # get new learning rate
-                for group in optimizer.param_groups:
+                for group in self.optimizer.param_groups:
                     learning_rate = group["lr"]
 
                 # reload last best model if annealing with restarts is enabled
                 if (
                     learning_rate != previous_learning_rate
-                    and anneal_with_restarts
+                    and self.anneal_with_restarts
                     and (base_path / "best-model.pt").exists()
                 ):
                     log.info("resetting to best model")
@@ -243,76 +254,25 @@ class ModelTrainer:
                 previous_learning_rate = learning_rate
 
                 # stop training if learning rate becomes too small
-                if learning_rate < min_learning_rate:
+                if learning_rate < self.min_learning_rate:
                     log_line(log)
                     log.info("learning rate too small - quitting training!")
                     log_line(log)
                     break
 
-                batch_loader = DataLoader(
-                    train_data,
-                    batch_size=mini_batch_size,
-                    shuffle=shuffle,
-                    num_workers=num_workers,
-                    sampler=sampler,
+                train_loss = self._train_one_epoch(
+                    self.epoch, embeddings_storage_mode, weight_extractor
                 )
-
-                self.model.train()
-
-                train_loss: float = 0
-
-                seen_batches = 0
-                total_number_of_batches = len(batch_loader)
-
-                modulo = max(1, int(total_number_of_batches / 10))
-
-                # process mini-batches
-                batch_time = 0
-                for batch_no, batch in enumerate(batch_loader):
-                    start_time = time.time()
-                    loss = self.model.forward_loss(batch)
-
-                    optimizer.zero_grad()
-                    # Backward
-                    if use_amp:
-                        with amp.scale_loss(loss, optimizer) as scaled_loss:
-                            scaled_loss.backward()
-                    else:
-                        loss.backward()
-
-                    torch.nn.utils.clip_grad_norm_(self.model.parameters(), 5.0)
-                    optimizer.step()
-
-                    seen_batches += 1
-                    train_loss += loss.item()
-
-                    # depending on memory mode, embeddings are moved to CPU, GPU or deleted
-                    store_embeddings(batch, embeddings_storage_mode)
-
-                    batch_time += time.time() - start_time
-                    if batch_no % modulo == 0:
-                        log.info(
-                            f"epoch {epoch + 1} - iter {batch_no}/{total_number_of_batches} - loss "
-                            f"{train_loss / seen_batches:.8f} - samples/sec: {mini_batch_size * modulo / batch_time:.2f}"
-                        )
-                        batch_time = 0
-                        iteration = epoch * total_number_of_batches + batch_no
-                        if not param_selection_mode:
-                            weight_extractor.extract_weights(
-                                self.model.state_dict(), iteration
-                            )
-
-                train_loss /= seen_batches
 
                 self.model.eval()
 
                 log_line(log)
                 log.info(
-                    f"EPOCH {epoch + 1} done: loss {train_loss:.4f} - lr {learning_rate:.4f}"
+                    f"EPOCH {self.epoch + 1} done: loss {train_loss:.4f} - lr {learning_rate:.4f}"
                 )
 
-                if self.use_tensorboard:
-                    writer.add_scalar("train_loss", train_loss, epoch + 1)
+                if use_tensorboard:
+                    writer.add_scalar("train_loss", train_loss, self.epoch + 1)
 
                 # anneal against train loss if training with dev, otherwise anneal against dev score
                 current_score = train_loss
@@ -324,8 +284,8 @@ class ModelTrainer:
                     train_eval_result, train_loss = self.model.evaluate(
                         DataLoader(
                             self.corpus.train,
-                            batch_size=eval_mini_batch_size,
-                            num_workers=num_workers,
+                            batch_size=self.eval_mini_batch_size,
+                            num_workers=self.num_workers,
                         ),
                         embeddings_storage_mode=embeddings_storage_mode,
                     )
@@ -338,8 +298,8 @@ class ModelTrainer:
                     dev_eval_result, dev_loss = self.model.evaluate(
                         DataLoader(
                             self.corpus.dev,
-                            batch_size=eval_mini_batch_size,
-                            num_workers=num_workers,
+                            batch_size=self.eval_mini_batch_size,
+                            num_workers=self.num_workers,
                         ),
                         embeddings_storage_mode=embeddings_storage_mode,
                     )
@@ -357,18 +317,18 @@ class ModelTrainer:
                     # depending on memory mode, embeddings are moved to CPU, GPU or deleted
                     store_embeddings(self.corpus.dev, embeddings_storage_mode)
 
-                    if self.use_tensorboard:
-                        writer.add_scalar("dev_loss", dev_loss, epoch + 1)
+                    if use_tensorboard:
+                        writer.add_scalar("dev_loss", dev_loss, self.epoch + 1)
                         writer.add_scalar(
-                            "dev_score", dev_eval_result.main_score, epoch + 1
+                            "dev_score", dev_eval_result.main_score, self.epoch + 1
                         )
 
                 if log_test:
                     test_eval_result, test_loss = self.model.evaluate(
                         DataLoader(
                             self.corpus.test,
-                            batch_size=eval_mini_batch_size,
-                            num_workers=num_workers,
+                            batch_size=self.eval_mini_batch_size,
+                            num_workers=self.num_workers,
                         ),
                         base_path / "test.tsv",
                         embeddings_storage_mode=embeddings_storage_mode,
@@ -381,26 +341,26 @@ class ModelTrainer:
                     # depending on memory mode, embeddings are moved to CPU, GPU or deleted
                     store_embeddings(self.corpus.test, embeddings_storage_mode)
 
-                    if self.use_tensorboard:
-                        writer.add_scalar("test_loss", test_loss, epoch + 1)
+                    if use_tensorboard:
+                        writer.add_scalar("test_loss", test_loss, self.epoch + 1)
                         writer.add_scalar(
-                            "test_score", test_eval_result.main_score, epoch + 1
+                            "test_score", test_eval_result.main_score, self.epoch + 1
                         )
 
                 # determine learning rate annealing through scheduler
-                scheduler.step(current_score)
+                self.scheduler.step(current_score)
 
                 train_loss_history.append(train_loss)
 
                 # determine bad epoch number
                 try:
-                    bad_epochs = scheduler.num_bad_epochs
+                    bad_epochs = self.scheduler.num_bad_epochs
                 except:
                     bad_epochs = 0
-                for group in optimizer.param_groups:
+                for group in self.optimizer.param_groups:
                     new_learning_rate = group["lr"]
                 if new_learning_rate != previous_learning_rate:
-                    bad_epochs = patience + 1
+                    bad_epochs = self.patience + 1
 
                 # log bad epochs
                 log.info(f"BAD EPOCHS (no improvement): {bad_epochs}")
@@ -409,7 +369,7 @@ class ModelTrainer:
                 with open(loss_txt, "a") as f:
 
                     # make headers on first epoch
-                    if epoch == 0:
+                    if self.epoch == 0:
                         f.write(
                             f"EPOCH\tTIMESTAMP\tBAD_EPOCHS\tLEARNING_RATE\tTRAIN_LOSS"
                         )
@@ -435,25 +395,19 @@ class ModelTrainer:
                             )
 
                     f.write(
-                        f"\n{epoch}\t{datetime.datetime.now():%H:%M:%S}\t{bad_epochs}\t{learning_rate:.4f}\t{train_loss}"
+                        f"\n{self.epoch}\t{datetime.datetime.now():%H:%M:%S}\t{bad_epochs}\t{learning_rate:.4f}\t{train_loss}"
                     )
                     f.write(result_line)
 
-                # if checkpoint is enable, save model at each epoch
+                # if checkpoint is enabled, save model at each epoch
                 if checkpoint and not param_selection_mode:
-                    self.model.save_checkpoint(
-                        base_path / "checkpoint.pt",
-                        optimizer.state_dict(),
-                        scheduler.state_dict(),
-                        epoch + 1,
-                        train_loss,
-                    )
+                    self.save_checkpoint(base_path / "checkpoint.pt")
 
                 # if we use dev data, remember best model based on dev evaluation score
                 if (
-                    not train_with_dev
+                    not self.train_with_dev
                     and not param_selection_mode
-                    and current_score == scheduler.best
+                    and current_score == self.scheduler.best
                 ):
                     self.model.save(base_path / "best-model.pt")
 
@@ -465,7 +419,7 @@ class ModelTrainer:
             log_line(log)
             log.info("Exiting from training early.")
 
-            if self.use_tensorboard:
+            if use_tensorboard:
                 writer.close()
 
             if not param_selection_mode:
@@ -475,14 +429,14 @@ class ModelTrainer:
 
         # test best model if test data is present
         if self.corpus.test:
-            final_score = self.final_test(base_path, eval_mini_batch_size, num_workers)
+            final_score = self.final_test(base_path)
         else:
             final_score = 0
             log.info("Test data not provided setting final score to 0")
 
         log.removeHandler(log_handler)
 
-        if self.use_tensorboard:
+        if use_tensorboard:
             writer.close()
 
         return {
@@ -492,9 +446,70 @@ class ModelTrainer:
             "dev_loss_history": dev_loss_history,
         }
 
-    def final_test(
-        self, base_path: Path, eval_mini_batch_size: int, num_workers: int = 8
+    def save_checkpoint(self, model_file: Union[str, Path]):
+        corpus = self.corpus
+        self.corpus = None
+        torch.save(self, str(model_file), pickle_protocol=4)
+        self.corpus = corpus
+
+    @classmethod
+    def load_checkpoint(cls, checkpoint, corpus: Corpus):
+        model: ModelTrainer = torch.load(checkpoint, map_location=flair.device)
+        model.corpus = corpus
+        return model
+
+    def _train_one_epoch(
+        self, epoch: int, embeddings_storage_mode: str = "none", weight_extractor=None
     ):
+        self.model.train()
+
+        train_loss: float = 0
+
+        seen_batches = 0
+        total_number_of_batches = len(self.train_data_loader)
+
+        modulo = max(1, int(total_number_of_batches / 10))
+
+        use_amp = False
+
+        # process mini-batches
+        batch_time = 0
+        for batch_no, batch in enumerate(self.train_data_loader):
+            start_time = time.time()
+            loss = self.model.forward_loss(batch)
+
+            self.optimizer.zero_grad()
+            # Backward
+            if use_amp:
+                with amp.scale_loss(loss, self.optimizer) as scaled_loss:
+                    scaled_loss.backward()
+            else:
+                loss.backward()
+
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), 5.0)
+            self.optimizer.step()
+
+            seen_batches += 1
+            train_loss += loss.item()
+
+            # depending on memory mode, embeddings are moved to CPU, GPU or deleted
+            store_embeddings(batch, embeddings_storage_mode)
+
+            batch_time += time.time() - start_time
+            if batch_no % modulo == 0:
+                log.info(
+                    f"epoch {epoch + 1} - iter {batch_no}/{total_number_of_batches} - loss "
+                    f"{train_loss / seen_batches:.8f} - samples/sec: {self.mini_batch_size * modulo / batch_time:.2f}"
+                )
+                batch_time = 0
+                iteration = epoch * total_number_of_batches + batch_no
+                if weight_extractor:
+                    weight_extractor.extract_weights(self.model.state_dict(), iteration)
+
+        train_loss /= seen_batches
+        return train_loss
+
+    def final_test(self, base_path: Path):
 
         log_line(log)
         log.info("Testing using best model ...")
@@ -507,8 +522,8 @@ class ModelTrainer:
         test_results, test_loss = self.model.evaluate(
             DataLoader(
                 self.corpus.test,
-                batch_size=eval_mini_batch_size,
-                num_workers=num_workers,
+                batch_size=self.eval_mini_batch_size,
+                num_workers=self.num_workers,
             ),
             out_path=base_path / "test.tsv",
             embeddings_storage_mode="none",
@@ -526,8 +541,8 @@ class ModelTrainer:
                 self.model.evaluate(
                     DataLoader(
                         subcorpus.test,
-                        batch_size=eval_mini_batch_size,
-                        num_workers=num_workers,
+                        batch_size=self.eval_mini_batch_size,
+                        num_workers=self.num_workers,
                     ),
                     out_path=base_path / f"{subcorpus.name}-test.tsv",
                     embeddings_storage_mode="none",
@@ -537,19 +552,6 @@ class ModelTrainer:
         final_score = test_results.main_score
 
         return final_score
-
-    @classmethod
-    def load_from_checkpoint(
-        cls, checkpoint, corpus: Corpus, optimizer: torch.optim.Optimizer = SGD
-    ):
-        return ModelTrainer(
-            checkpoint["model"],
-            corpus,
-            optimizer,
-            epoch=checkpoint["epoch"],
-            optimizer_state=checkpoint["optimizer_state_dict"],
-            scheduler_state=checkpoint["scheduler_state_dict"],
-        )
 
     def find_learning_rate(
         self,
@@ -574,15 +576,15 @@ class ModelTrainer:
         with open(learning_rate_tsv, "a") as f:
             f.write("ITERATION\tTIMESTAMP\tLEARNING_RATE\tTRAIN_LOSS\n")
 
-        optimizer = self.optimizer(
-            self.model.parameters(), lr=start_learning_rate, **kwargs
-        )
+        # optimizer = self.optimizer(
+        #     self.model.parameters(), lr=start_learning_rate, **kwargs
+        # )
 
         train_data = self.corpus.train
 
         batch_loader = DataLoader(train_data, batch_size=mini_batch_size, shuffle=True)
 
-        scheduler = ExpAnnealLR(optimizer, end_learning_rate, iterations)
+        scheduler = ExpAnnealLR(self.optimizer, end_learning_rate, iterations)
 
         model_state = self.model.state_dict()
         model_device = next(self.model.parameters()).device
@@ -591,10 +593,10 @@ class ModelTrainer:
         for itr, batch in enumerate(batch_loader):
             loss = self.model.forward_loss(batch)
 
-            optimizer.zero_grad()
+            self.optimizer.zero_grad()
             loss.backward()
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), 5.0)
-            optimizer.step()
+            self.optimizer.step()
             scheduler.step(1)
             learning_rate = scheduler.get_lr()[0]
 

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -59,21 +59,19 @@ class ModelTrainer:
         :param model: The model that you want to train. The model should inherit from flair.nn.Model
         :param corpus: The dataset used to train the model, should be of type Corpus
         :param optimizer: The optimizer to use (typically SGD or Adam)
-        :param use_tensorboard: If True, writes out tensorboard information
         :param learning_rate: Initial learning rate
         :param mini_batch_size: Size of mini-batches during training
-        :param eval_mini_batch_size: Size of mini-batches during evaluation
         :param anneal_factor: The factor by which the learning rate is annealed
         :param patience: Patience is the number of epochs with no improvement the Trainer waits
          until annealing the learning rate
         :param min_learning_rate: If the learning rate falls below this threshold, training terminates
+        :param eval_mini_batch_size: Size of mini-batches during evaluation
+        :param shuffle: If True, data is shuffled during training
         :param train_with_dev: If True, training is performed using both train+dev data
         :param anneal_with_restarts: If True, the last best model is restored when annealing the learning rate
-        :param shuffle: If True, data is shuffled during training
-        :param param_selection_mode: If True, testing is performed against dev data. Use this mode when doing
-        parameter selection.
-        :param num_workers: Number of workers in your data loader.
         :param sampler: You can pass a data sampler here for special sampling of data.
+        :param num_workers: Number of workers in your data loader.
+        :param use_amp: If True, uses automatic mixed precision optimization (requires APEX to be installed).
         :param kwargs: Other arguments for the Optimizer
         """
         self.model: flair.nn.Model = model
@@ -155,10 +153,13 @@ class ModelTrainer:
         :param max_epochs: Maximum number of epochs to train. Terminates training if this number is surpassed.
         :param embeddings_storage_mode: One of 'none' (all embeddings are deleted and freshly recomputed),
         'cpu' (embeddings are stored on CPU) or 'gpu' (embeddings are stored on GPU)
-        :param monitor_train: If True, training data is evaluated at end of each epoch
         :param monitor_test: If True, test data is evaluated at end of each epoch
+        :param monitor_train: If True, training data is evaluated at end of each epoch
+        :param use_tensorboard: If True, writes out tensorboard information
         :param checkpoint: If True, a full checkpoint is saved at end of each epoch
         :param save_final_model: If True, final model is saved
+        :param param_selection_mode: If True, testing is performed against dev data. Use this mode when doing
+        parameter selection.
         :return:
         """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ langdetect
 torchvision
 ipython==7.6.1
 ipython-genutils==0.2.0
-ray==0.6.6
+ray

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ langdetect
 torchvision
 ipython==7.6.1
 ipython-genutils==0.2.0
+ray==0.7.4
+gt

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ langdetect
 torchvision
 ipython==7.6.1
 ipython-genutils==0.2.0
-ray
+ray==0.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,3 @@ torchvision
 ipython==7.6.1
 ipython-genutils==0.2.0
 ray==0.7.4
-gt

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ langdetect
 torchvision
 ipython==7.6.1
 ipython-genutils==0.2.0
-ray

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ langdetect
 torchvision
 ipython==7.6.1
 ipython-genutils==0.2.0
+ray

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -26,97 +26,97 @@ from flair.models import TextClassifier
 from flair.trainers import ModelTrainer
 
 
-@pytest.mark.integration
-def test_tune_classifier(results_base_path, tasks_base_path):
-
-    # setup experiment class
-    class TuneTextClassifier(FlairTune):
-        def _setup(self, config):
-            # A. set the corpus you are using
-            self.corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
-
-            # B. define your embeddings and hyperparameters
-            embeddings = DocumentRNNEmbeddings(
-                [WordEmbeddings("glove")],
-                hidden_size=config["hidden_size"] if "hidden_size" in config else 128,
-                dropout=config["dropout"] if "dropout" in config else 0.5,
-                locked_dropout=config["locked_dropout"]
-                if "locked_dropout" in config
-                else 0.0,
-                word_dropout=config["word_dropout"]
-                if "word_dropout" in config
-                else 0.0,
-            )
-
-            # define model
-            model = TextClassifier(
-                document_embeddings=embeddings,
-                label_dictionary=self.corpus.make_label_dictionary(),
-            )
-
-            # C. define training parameters
-            self.trainer = ModelTrainer(
-                model,
-                self.corpus,
-                learning_rate=config["initial_lr"] if "initial_lr" in config else 0.1,
-                patience=config["patience"] if "patience" in config else 3,
-                mini_batch_size=config["mini_batch_size"]
-                if "mini_batch_size" in config
-                else 8,
-            )
-
-            self.embeddings_storage_mode = "gpu"
-
-    # 1. set the number of parameter combinations to try
-    number_of_experiments: int = 2
-
-    # 2. set the maximum number of epochs per experiment
-    max_epochs: int = 2
-
-    # 3. set how many experiments at the same time and what resources does each get
-    max_concurrent: int = 2
-    resources_per_experiment = {"cpu": 1, "gpu": 0.0}
-
-    # 4. define your search space
-    search = HyperOptSearch(
-        {
-            "hidden_size": hp.choice("hidden_size", [32, 64, 128, 256]),
-            "dropout": hp.uniform("dropout", 0.00, 0.8),
-            "locked_dropout": hp.uniform("locked_dropout", 0.0, 0.8),
-            "word_dropout": hp.uniform("word_dropout", 0.0, 0.2),
-            "initial_lr": hp.uniform("initial_lr", 0.0, 0.5),
-            "patience": hp.choice("patience", [1, 2, 3]),
-            "mini_batch_size": hp.choice("mini_batch_size", [2, 4, 8, 16, 32]),
-        },
-        max_concurrent=max_concurrent,
-        reward_attr="mean_accuracy",
-    )
-
-    experiment_name = "experiment"
-
-    # Define scheduler (optional)
-    scheduler = ray.tune.schedulers.AsyncHyperBandScheduler(
-        time_attr="training_iteration",
-        metric="mean_accuracy",
-        mode="max",
-        grace_period=1,
-        max_t=max_epochs,
-    )
-
-    # run experiment
-    tune.run(
-        TuneTextClassifier,
-        local_dir=results_base_path,
-        name=experiment_name,
-        scheduler=scheduler,
-        stop={"1-lr": 0.9999, "training_iteration": max_epochs},
-        resources_per_trial=resources_per_experiment,
-        num_samples=number_of_experiments,
-        search_alg=search,
-        return_trials=False,
-    )
-
-    shutil.rmtree(results_base_path)
+# @pytest.mark.integration
+# def test_tune_classifier(results_base_path, tasks_base_path):
+#
+#     # setup experiment class
+#     class TuneTextClassifier(FlairTune):
+#         def _setup(self, config):
+#             # A. set the corpus you are using
+#             self.corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
+#
+#             # B. define your embeddings and hyperparameters
+#             embeddings = DocumentRNNEmbeddings(
+#                 [WordEmbeddings("glove")],
+#                 hidden_size=config["hidden_size"] if "hidden_size" in config else 128,
+#                 dropout=config["dropout"] if "dropout" in config else 0.5,
+#                 locked_dropout=config["locked_dropout"]
+#                 if "locked_dropout" in config
+#                 else 0.0,
+#                 word_dropout=config["word_dropout"]
+#                 if "word_dropout" in config
+#                 else 0.0,
+#             )
+#
+#             # define model
+#             model = TextClassifier(
+#                 document_embeddings=embeddings,
+#                 label_dictionary=self.corpus.make_label_dictionary(),
+#             )
+#
+#             # C. define training parameters
+#             self.trainer = ModelTrainer(
+#                 model,
+#                 self.corpus,
+#                 learning_rate=config["initial_lr"] if "initial_lr" in config else 0.1,
+#                 patience=config["patience"] if "patience" in config else 3,
+#                 mini_batch_size=config["mini_batch_size"]
+#                 if "mini_batch_size" in config
+#                 else 8,
+#             )
+#
+#             self.embeddings_storage_mode = "gpu"
+#
+#     # 1. set the number of parameter combinations to try
+#     number_of_experiments: int = 2
+#
+#     # 2. set the maximum number of epochs per experiment
+#     max_epochs: int = 2
+#
+#     # 3. set how many experiments at the same time and what resources does each get
+#     max_concurrent: int = 2
+#     resources_per_experiment = {"cpu": 1, "gpu": 0.0}
+#
+#     # 4. define your search space
+#     search = HyperOptSearch(
+#         {
+#             "hidden_size": hp.choice("hidden_size", [32, 64, 128, 256]),
+#             "dropout": hp.uniform("dropout", 0.00, 0.8),
+#             "locked_dropout": hp.uniform("locked_dropout", 0.0, 0.8),
+#             "word_dropout": hp.uniform("word_dropout", 0.0, 0.2),
+#             "initial_lr": hp.uniform("initial_lr", 0.0, 0.5),
+#             "patience": hp.choice("patience", [1, 2, 3]),
+#             "mini_batch_size": hp.choice("mini_batch_size", [2, 4, 8, 16, 32]),
+#         },
+#         max_concurrent=max_concurrent,
+#         reward_attr="mean_accuracy",
+#     )
+#
+#     experiment_name = "experiment"
+#
+#     # Define scheduler (optional)
+#     scheduler = ray.tune.schedulers.AsyncHyperBandScheduler(
+#         time_attr="training_iteration",
+#         metric="mean_accuracy",
+#         mode="max",
+#         grace_period=1,
+#         max_t=max_epochs,
+#     )
+#
+#     # run experiment
+#     tune.run(
+#         TuneTextClassifier,
+#         local_dir=results_base_path,
+#         name=experiment_name,
+#         scheduler=scheduler,
+#         stop={"1-lr": 0.9999, "training_iteration": max_epochs},
+#         resources_per_trial=resources_per_experiment,
+#         num_samples=number_of_experiments,
+#         search_alg=search,
+#         return_trials=False,
+#     )
+#
+#     shutil.rmtree(results_base_path)
 
 
 @pytest.mark.integration

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -1,10 +1,19 @@
 import shutil
 
 import pytest
+import ray
 from hyperopt import hp
+from ray import tune
+from ray.tune.schedulers import AsyncHyperBandScheduler
+from ray.tune.suggest.hyperopt import HyperOptSearch
 from torch.optim import SGD
 
-from flair.embeddings import WordEmbeddings, StackedEmbeddings, FlairEmbeddings
+from flair.embeddings import (
+    WordEmbeddings,
+    StackedEmbeddings,
+    FlairEmbeddings,
+    DocumentRNNEmbeddings,
+)
 from flair.hyperparameter import (
     SearchSpace,
     Parameter,
@@ -12,6 +21,102 @@ from flair.hyperparameter import (
     TextClassifierParamSelector,
 )
 import flair.datasets
+from flair.hyperparameter.tune import FlairTune
+from flair.models import TextClassifier
+from flair.trainers import ModelTrainer
+
+
+@pytest.mark.integration
+def test_tune_classifier(results_base_path, tasks_base_path):
+
+    # setup experiment class
+    class TuneTextClassifier(FlairTune):
+        def _setup(self, config):
+            # A. set the corpus you are using
+            self.corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
+
+            # B. define your embeddings and hyperparameters
+            embeddings = DocumentRNNEmbeddings(
+                [WordEmbeddings("glove")],
+                hidden_size=config["hidden_size"] if "hidden_size" in config else 128,
+                dropout=config["dropout"] if "dropout" in config else 0.5,
+                locked_dropout=config["locked_dropout"]
+                if "locked_dropout" in config
+                else 0.0,
+                word_dropout=config["word_dropout"]
+                if "word_dropout" in config
+                else 0.0,
+            )
+
+            # define model
+            model = TextClassifier(
+                document_embeddings=embeddings,
+                label_dictionary=self.corpus.make_label_dictionary(),
+            )
+
+            # C. define training parameters
+            self.trainer = ModelTrainer(
+                model,
+                self.corpus,
+                learning_rate=config["initial_lr"] if "initial_lr" in config else 0.1,
+                patience=config["patience"] if "patience" in config else 3,
+                mini_batch_size=config["mini_batch_size"]
+                if "mini_batch_size" in config
+                else 8,
+            )
+
+            self.embeddings_storage_mode = "gpu"
+
+    # 1. set the number of parameter combinations to try
+    number_of_experiments: int = 2
+
+    # 2. set the maximum number of epochs per experiment
+    max_epochs: int = 2
+
+    # 3. set how many experiments at the same time and what resources does each get
+    max_concurrent: int = 2
+    resources_per_experiment = {"cpu": 1, "gpu": 0.0}
+
+    # 4. define your search space
+    search = HyperOptSearch(
+        {
+            "hidden_size": hp.choice("hidden_size", [32, 64, 128, 256]),
+            "dropout": hp.uniform("dropout", 0.00, 0.8),
+            "locked_dropout": hp.uniform("locked_dropout", 0.0, 0.8),
+            "word_dropout": hp.uniform("word_dropout", 0.0, 0.2),
+            "initial_lr": hp.uniform("initial_lr", 0.0, 0.5),
+            "patience": hp.choice("patience", [1, 2, 3]),
+            "mini_batch_size": hp.choice("mini_batch_size", [2, 4, 8, 16, 32]),
+        },
+        max_concurrent=max_concurrent,
+        reward_attr="mean_accuracy",
+    )
+
+    experiment_name = "experiment"
+
+    # Define scheduler (optional)
+    scheduler = ray.tune.schedulers.AsyncHyperBandScheduler(
+        time_attr="training_iteration",
+        metric="mean_accuracy",
+        mode="max",
+        grace_period=1,
+        max_t=max_epochs,
+    )
+
+    # run experiment
+    tune.run(
+        TuneTextClassifier,
+        local_dir=results_base_path,
+        name=experiment_name,
+        scheduler=scheduler,
+        stop={"1-lr": 0.9999, "training_iteration": max_epochs},
+        resources_per_trial=resources_per_experiment,
+        num_samples=number_of_experiments,
+        search_alg=search,
+        return_trials=False,
+    )
+
+    shutil.rmtree(results_base_path)
 
 
 @pytest.mark.integration

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -1,11 +1,7 @@
 import shutil
 
 import pytest
-import ray
 from hyperopt import hp
-from ray import tune
-from ray.tune.schedulers import AsyncHyperBandScheduler
-from ray.tune.suggest.hyperopt import HyperOptSearch
 from torch.optim import SGD
 
 from flair.embeddings import (
@@ -21,10 +17,14 @@ from flair.hyperparameter import (
     TextClassifierParamSelector,
 )
 import flair.datasets
-from flair.hyperparameter.tune import FlairTune
-from flair.models import TextClassifier
-from flair.trainers import ModelTrainer
 
+# import ray
+# from ray import tune
+# from ray.tune.schedulers import AsyncHyperBandScheduler
+# from ray.tune.suggest.hyperopt import HyperOptSearch
+# from flair.hyperparameter.tune import FlairTune
+# from flair.models import TextClassifier
+# from flair.trainers import ModelTrainer
 
 # @pytest.mark.integration
 # def test_tune_classifier(results_base_path, tasks_base_path):

--- a/tests/test_hyperparameter.py
+++ b/tests/test_hyperparameter.py
@@ -27,97 +27,97 @@ from flair.models import TextClassifier
 from flair.trainers import ModelTrainer
 
 
-@pytest.mark.integration
-def test_tune_classifier(results_base_path, tasks_base_path):
-
-    # setup experiment class
-    class TuneTextClassifier(TuneFlair):
-        def _setup(self, config):
-            # A. set the corpus you are using
-            self.corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
-
-            # B. define your embeddings and hyperparameters
-            embeddings = DocumentRNNEmbeddings(
-                [WordEmbeddings("glove")],
-                hidden_size=config["hidden_size"] if "hidden_size" in config else 128,
-                dropout=config["dropout"] if "dropout" in config else 0.5,
-                locked_dropout=config["locked_dropout"]
-                if "locked_dropout" in config
-                else 0.0,
-                word_dropout=config["word_dropout"]
-                if "word_dropout" in config
-                else 0.0,
-            )
-
-            # define model
-            model = TextClassifier(
-                document_embeddings=embeddings,
-                label_dictionary=self.corpus.make_label_dictionary(),
-            )
-
-            # C. define training parameters
-            self.trainer = ModelTrainer(
-                model,
-                self.corpus,
-                learning_rate=config["initial_lr"] if "initial_lr" in config else 0.1,
-                patience=config["patience"] if "patience" in config else 3,
-                mini_batch_size=config["mini_batch_size"]
-                if "mini_batch_size" in config
-                else 8,
-            )
-
-            self.embeddings_storage_mode = "gpu"
-
-    # 1. set the number of parameter combinations to try
-    number_of_experiments: int = 2
-
-    # 2. set the maximum number of epochs per experiment
-    max_epochs: int = 2
-
-    # 3. set how many experiments at the same time and what resources does each get
-    max_concurrent: int = 2
-    resources_per_experiment = {"cpu": 1, "gpu": 0.0}
-
-    # 4. define your search space
-    search = HyperOptSearch(
-        {
-            "hidden_size": hp.choice("hidden_size", [32, 64, 128, 256]),
-            "dropout": hp.uniform("dropout", 0.00, 0.8),
-            "locked_dropout": hp.uniform("locked_dropout", 0.0, 0.8),
-            "word_dropout": hp.uniform("word_dropout", 0.0, 0.2),
-            "initial_lr": hp.uniform("initial_lr", 0.0, 0.5),
-            "patience": hp.choice("patience", [1, 2, 3]),
-            "mini_batch_size": hp.choice("mini_batch_size", [2, 4, 8, 16, 32]),
-        },
-        max_concurrent=max_concurrent,
-        reward_attr="mean_accuracy",
-    )
-
-    experiment_name = "experiment"
-
-    # Define scheduler (optional)
-    scheduler = ray.tune.schedulers.AsyncHyperBandScheduler(
-        time_attr="training_iteration",
-        metric="mean_accuracy",
-        mode="max",
-        grace_period=1,
-        max_t=max_epochs,
-    )
-
-    # run experiment
-    tune.run(
-        TuneTextClassifier,
-        local_dir=results_base_path,
-        name=experiment_name,
-        scheduler=scheduler,
-        stop={"1-lr": 0.9999, "training_iteration": max_epochs},
-        resources_per_trial=resources_per_experiment,
-        num_samples=number_of_experiments,
-        search_alg=search,
-        return_trials=False,
-    )
-
-    shutil.rmtree(results_base_path)
+# @pytest.mark.integration
+# def test_tune_classifier(results_base_path, tasks_base_path):
+#
+#     # setup experiment class
+#     class TuneTextClassifier(TuneFlair):
+#         def _setup(self, config):
+#             # A. set the corpus you are using
+#             self.corpus = flair.datasets.ClassificationCorpus(tasks_base_path / "imdb")
+#
+#             # B. define your embeddings and hyperparameters
+#             embeddings = DocumentRNNEmbeddings(
+#                 [WordEmbeddings("glove")],
+#                 hidden_size=config["hidden_size"] if "hidden_size" in config else 128,
+#                 dropout=config["dropout"] if "dropout" in config else 0.5,
+#                 locked_dropout=config["locked_dropout"]
+#                 if "locked_dropout" in config
+#                 else 0.0,
+#                 word_dropout=config["word_dropout"]
+#                 if "word_dropout" in config
+#                 else 0.0,
+#             )
+#
+#             # define model
+#             model = TextClassifier(
+#                 document_embeddings=embeddings,
+#                 label_dictionary=self.corpus.make_label_dictionary(),
+#             )
+#
+#             # C. define training parameters
+#             self.trainer = ModelTrainer(
+#                 model,
+#                 self.corpus,
+#                 learning_rate=config["initial_lr"] if "initial_lr" in config else 0.1,
+#                 patience=config["patience"] if "patience" in config else 3,
+#                 mini_batch_size=config["mini_batch_size"]
+#                 if "mini_batch_size" in config
+#                 else 8,
+#             )
+#
+#             self.embeddings_storage_mode = "gpu"
+#
+#     # 1. set the number of parameter combinations to try
+#     number_of_experiments: int = 2
+#
+#     # 2. set the maximum number of epochs per experiment
+#     max_epochs: int = 2
+#
+#     # 3. set how many experiments at the same time and what resources does each get
+#     max_concurrent: int = 2
+#     resources_per_experiment = {"cpu": 1, "gpu": 0.0}
+#
+#     # 4. define your search space
+#     search = HyperOptSearch(
+#         {
+#             "hidden_size": hp.choice("hidden_size", [32, 64, 128, 256]),
+#             "dropout": hp.uniform("dropout", 0.00, 0.8),
+#             "locked_dropout": hp.uniform("locked_dropout", 0.0, 0.8),
+#             "word_dropout": hp.uniform("word_dropout", 0.0, 0.2),
+#             "initial_lr": hp.uniform("initial_lr", 0.0, 0.5),
+#             "patience": hp.choice("patience", [1, 2, 3]),
+#             "mini_batch_size": hp.choice("mini_batch_size", [2, 4, 8, 16, 32]),
+#         },
+#         max_concurrent=max_concurrent,
+#         reward_attr="mean_accuracy",
+#     )
+#
+#     experiment_name = "experiment"
+#
+#     # Define scheduler (optional)
+#     scheduler = ray.tune.schedulers.AsyncHyperBandScheduler(
+#         time_attr="training_iteration",
+#         metric="mean_accuracy",
+#         mode="max",
+#         grace_period=1,
+#         max_t=max_epochs,
+#     )
+#
+#     # run experiment
+#     tune.run(
+#         TuneTextClassifier,
+#         local_dir=results_base_path,
+#         name=experiment_name,
+#         scheduler=scheduler,
+#         stop={"1-lr": 0.9999, "training_iteration": max_epochs},
+#         resources_per_trial=resources_per_experiment,
+#         num_samples=number_of_experiments,
+#         search_alg=search,
+#         return_trials=False,
+#     )
+#
+#     shutil.rmtree(results_base_path)
 
 
 @pytest.mark.integration

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -38,15 +38,11 @@ def test_train_load_use_tagger(results_base_path, tasks_base_path):
     )
 
     # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus)
-
-    trainer.train(
-        results_base_path,
-        learning_rate=0.1,
-        mini_batch_size=2,
-        max_epochs=2,
-        shuffle=False,
+    trainer: ModelTrainer = ModelTrainer(
+        tagger, corpus, learning_rate=0.1, mini_batch_size=2, shuffle=False
     )
+
+    trainer.train(results_base_path, max_epochs=2)
 
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
@@ -79,15 +75,11 @@ def test_train_load_use_tagger_large(results_base_path, tasks_base_path):
     )
 
     # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus)
-
-    trainer.train(
-        results_base_path,
-        learning_rate=0.1,
-        mini_batch_size=32,
-        max_epochs=2,
-        shuffle=False,
+    trainer: ModelTrainer = ModelTrainer(
+        tagger, corpus, learning_rate=0.1, mini_batch_size=32, shuffle=False
     )
+
+    trainer.train(results_base_path, max_epochs=2)
 
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
@@ -122,15 +114,11 @@ def test_train_charlm_load_use_tagger(results_base_path, tasks_base_path):
     )
 
     # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus)
-
-    trainer.train(
-        results_base_path,
-        learning_rate=0.1,
-        mini_batch_size=2,
-        max_epochs=2,
-        shuffle=False,
+    trainer: ModelTrainer = ModelTrainer(
+        tagger, corpus, learning_rate=0.1, mini_batch_size=2, shuffle=False
     )
+
+    trainer.train(results_base_path, max_epochs=2)
 
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
@@ -167,15 +155,16 @@ def test_train_optimizer(results_base_path, tasks_base_path):
     optimizer: Optimizer = Adam
 
     # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus, optimizer=optimizer)
-
-    trainer.train(
-        results_base_path,
+    trainer: ModelTrainer = ModelTrainer(
+        tagger,
+        corpus,
+        optimizer=optimizer,
         learning_rate=0.1,
         mini_batch_size=2,
-        max_epochs=2,
         shuffle=False,
     )
+
+    trainer.train(results_base_path, max_epochs=2)
 
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
@@ -212,16 +201,17 @@ def test_train_optimizer_arguments(results_base_path, tasks_base_path):
     optimizer: Optimizer = AdamW
 
     # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus, optimizer=optimizer)
-
-    trainer.train(
-        results_base_path,
+    trainer: ModelTrainer = ModelTrainer(
+        tagger,
+        corpus,
+        optimizer=optimizer,
         learning_rate=0.1,
         mini_batch_size=2,
-        max_epochs=2,
         shuffle=False,
         weight_decay=1e-3,
     )
+
+    trainer.train(results_base_path, max_epochs=2)
 
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
@@ -299,8 +289,8 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
 
     model = TextClassifier(document_embeddings, label_dict, False)
 
-    trainer = ModelTrainer(model, corpus)
-    trainer.train(results_base_path, max_epochs=2, shuffle=False)
+    trainer = ModelTrainer(model, corpus, shuffle=False)
+    trainer.train(results_base_path, max_epochs=2)
 
     sentence = Sentence("Berlin is a really nice city.")
 
@@ -335,13 +325,10 @@ def test_train_classifier_with_sampler(results_base_path, tasks_base_path):
 
     model = TextClassifier(document_embeddings, label_dict, False)
 
-    trainer = ModelTrainer(model, corpus)
-    trainer.train(
-        results_base_path,
-        max_epochs=2,
-        shuffle=False,
-        sampler=ImbalancedClassificationDatasetSampler,
+    trainer = ModelTrainer(
+        model, corpus, shuffle=False, sampler=ImbalancedClassificationDatasetSampler
     )
+    trainer.train(results_base_path, max_epochs=2)
 
     sentence = Sentence("Berlin is a really nice city.")
 
@@ -369,8 +356,8 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
 
     model = TextClassifier(document_embeddings, label_dict, False)
 
-    trainer = ModelTrainer(model, corpus)
-    trainer.train(results_base_path, max_epochs=2, shuffle=False)
+    trainer = ModelTrainer(model, corpus, shuffle=False)
+    trainer.train(results_base_path, max_epochs=2)
 
     sentence = Sentence("Berlin is a really nice city.")
 
@@ -408,14 +395,8 @@ def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_pat
 
     model = TextClassifier(document_embeddings, label_dict, multi_label=True)
 
-    trainer = ModelTrainer(model, corpus)
-    trainer.train(
-        results_base_path,
-        mini_batch_size=1,
-        max_epochs=100,
-        shuffle=False,
-        checkpoint=False,
-    )
+    trainer = ModelTrainer(model, corpus, mini_batch_size=1, shuffle=False)
+    trainer.train(results_base_path, checkpoint=False, max_epochs=100)
 
     sentence = Sentence("apple tv")
 
@@ -464,8 +445,8 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
 
     model = TextClassifier(document_embeddings, label_dict, False)
 
-    trainer = ModelTrainer(model, corpus)
-    trainer.train(results_base_path, max_epochs=2, shuffle=False)
+    trainer = ModelTrainer(model, corpus, shuffle=False)
+    trainer.train(results_base_path, max_epochs=2)
 
     sentence = Sentence("Berlin is a really nice city.")
 
@@ -548,15 +529,11 @@ def test_train_load_use_tagger_multicorpus(results_base_path, tasks_base_path):
     )
 
     # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus)
-
-    trainer.train(
-        results_base_path,
-        learning_rate=0.1,
-        mini_batch_size=2,
-        max_epochs=2,
-        shuffle=False,
+    trainer: ModelTrainer = ModelTrainer(
+        tagger, corpus, learning_rate=0.1, mini_batch_size=2, shuffle=False
     )
+
+    trainer.train(results_base_path, max_epochs=2)
 
     loaded_model: SequenceTagger = SequenceTagger.load(
         results_base_path / "final-model.pt"
@@ -585,12 +562,11 @@ def test_train_resume_text_classification_training(results_base_path, tasks_base
 
     model = TextClassifier(document_embeddings, label_dict, False)
 
-    trainer = ModelTrainer(model, corpus)
-    trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
+    trainer = ModelTrainer(model, corpus, shuffle=False)
+    trainer.train(results_base_path, max_epochs=2, checkpoint=True)
 
-    checkpoint = TextClassifier.load_checkpoint(results_base_path / "checkpoint.pt")
-    trainer = ModelTrainer.load_from_checkpoint(checkpoint, corpus)
-    trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
+    trainer = ModelTrainer.load_checkpoint(results_base_path / "checkpoint.pt", corpus)
+    trainer.train(results_base_path, max_epochs=4, checkpoint=True)
 
     # clean up results directory
     shutil.rmtree(results_base_path)
@@ -616,13 +592,12 @@ def test_train_resume_sequence_tagging_training(results_base_path, tasks_base_pa
         use_crf=False,
     )
 
-    trainer = ModelTrainer(model, corpus)
-    trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
+    trainer = ModelTrainer(model, corpus, shuffle=False)
+    trainer.train(results_base_path, max_epochs=2, checkpoint=True)
 
-    checkpoint = SequenceTagger.load_checkpoint(results_base_path / "checkpoint.pt")
-    trainer = ModelTrainer.load_from_checkpoint(checkpoint, corpus)
+    trainer = ModelTrainer.load_checkpoint(results_base_path / "checkpoint.pt", corpus)
 
-    trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
+    trainer.train(results_base_path, max_epochs=2, checkpoint=True)
 
     # clean up results directory
     shutil.rmtree(results_base_path)


### PR DESCRIPTION
This PR adds a first version of scalable hyperparameter tuning to Flair (see #1067), using the `tune` module of `ray`. It refactors the training interfaces to be more compatible: 

- The `ModelTrainer` gets refactored such that parameters that influence training become part of the constructor and only parameters that influence logging stay in the `.train()` method. Training parameters thus become variables of the class. Also, the method `_train_one_epoch()` is added that executes training of one epoch.
- Checkpointing is refactored such that it now belongs to the `ModelTrainer` and no longer to the respective downstream task classes.

The PR adds a `FlairTune` base class that needs to be extended for a specific experiment involving a corpus and embeddings, as well as the hyperparameters one wishes to tune. For instance, to set up a simple `TextClassifier` tuning experiment for the hyperparameters `dropout` and `mini_batch_size`, the base class can be extended as follows: 

```python
class TuneTextClassifier(FlairTune):

    def _setup(self, config):
        # A. set the corpus you are using
        self.corpus = TREC_6(in_memory=True)

        # B. define your embeddings and hyperparameters
        embeddings = DocumentRNNEmbeddings(
            [
                WordEmbeddings('en'),
            ],
            dropout=config["dropout"] if "dropout" in config else 0.5,
        )

        # define model
        model: SequenceTagger = TextClassifier(
            document_embeddings=embeddings,
            label_dictionary=self.corpus.make_label_dictionary(),
        )

        # C. define training parameters
        self.trainer = ModelTrainer(
            model,
            self.corpus,
            mini_batch_size=config["mini_batch_size"] if "mini_batch_size" in config else 8,
        )
```

In this example, we allow two variables for hyperparameter tuning: the model parameter of `dropout` and the training parameter of `mini_batch_size`.

Now, to run an experiment, execute tune for instance like this: 

```python
    # 1. set the number of parameter combinations to try
    number_of_experiments: int = 50

    # 2. set the maximum number of epochs per experiment
    max_epochs: int = 100

    # 3. set how many experiments at the same time and what resources does each get
    max_concurrent: int = 5
    resources_per_experiment = {
        "cpu": 1,
        "gpu": 0.2,
    }

    # 4. define your search space (the two parameters we wish to tune)
    search = HyperOptSearch(
        {
            "dropout": hp.uniform("dropout", 0.00, 0.8),
            "mini_batch_size": hp.choice("mini_batch_size", [2, 4, 8, 16, 32]),
        },
        max_concurrent=max_concurrent,
        reward_attr="mean_accuracy")

    experiment_base_folder = os.path.expanduser('~/sweep/')
    experiment_name = "experiment-" + datetime.today().strftime("%Y-%m-%d_%H-%M-%S")

    # Define scheduler (optional)
    scheduler = ray.tune.schedulers.AsyncHyperBandScheduler(
        time_attr='training_iteration',
        metric='mean_accuracy',
        mode='max',
        grace_period=10,
        max_t=max_epochs)

    # from ray.tune.util import validate_save_restore
    ray.init(ignore_reinit_error=True, temp_dir='tune')

    # run experiment
    trials: List[Trial] = tune.run(
        TuneTextClassifier,
        local_dir=experiment_base_folder,
        name=experiment_name,

        scheduler=scheduler,

        stop={
            "1-lr": 0.9999,
            "training_iteration": max_epochs
        },

        resources_per_trial=resources_per_experiment,
        num_samples=number_of_experiments,

        search_alg=search,

        return_trials=True,
    )

    # summarize results
    path = experiment_base_folder + experiment_name + '/results.tsv'
    write_experiment_summary(trials, path)
```