### PR TITLE
Reduce the number of concatenation for 10% inference time reduction

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -237,7 +237,9 @@ class Token(DataPoint):
         device = flair.device
         if len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device
-        self._embeddings[name] = vector.to(device)
+        if device != vector.device:
+            vector = vector.to(device)
+        self._embeddings[name] = vector
 
     def to(self, device: str, pin_memory: bool = False):
         for name, vector in self._embeddings.items():
@@ -645,7 +647,9 @@ class Sentence(DataPoint):
         device = flair.device
         if len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device
-        self._embeddings[name] = vector.to(device, non_blocking=True)
+        if device != vector.device:
+            vector = vector.to(device)
+        self._embeddings[name] = vector
 
     def get_embedding(self) -> torch.tensor:
         embeddings = []

--- a/flair/data.py
+++ b/flair/data.py
@@ -251,6 +251,9 @@ class Token(DataPoint):
                 if name in self._embeddings.keys():
                     del self._embeddings[name]
 
+    def get_each_embedding(self) -> torch.tensor:
+        return [self._embeddings[embed] for embed in sorted(self._embeddings.keys())]
+
     def get_embedding(self) -> torch.tensor:
         embeddings = [
             self._embeddings[embed] for embed in sorted(self._embeddings.keys())

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2754,12 +2754,6 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
             device=flair.device,
         )
 
-        # for s_id, sentence in enumerate(sentences):
-        #     # fill values with word embeddings
-        #     sentence_tensor[s_id][: len(sentence)] = torch.cat(
-        #         [token.get_embedding().unsqueeze(0) for token in sentence], 0
-        #     )
-
         for s_id, sentence in enumerate(sentences):
             # fill values with word embeddings
             all_embs = list()

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -457,9 +457,18 @@ class SequenceTagger(flair.nn.Model):
         )
 
         for s_id, sentence in enumerate(sentences):
-            # fill values with word embeddings
-            token_embeddings = [token.get_embedding() for token in sentence]
-            sentence_tensor[s_id][: len(sentence)] = torch.stack(token_embeddings)
+            all_embs = list()
+
+            for index_token, token in enumerate(sentence):
+                embs = token.get_each_embedding()
+                if not all_embs:
+                    all_embs = [list() for _ in range(len(embs))]
+                for index_emb, emb in enumerate(embs):
+                    all_embs[index_emb].append(emb)
+
+            concat_word_emb = [torch.stack(embs) for embs in all_embs]
+            concat_sentence_emb = torch.cat(concat_word_emb, dim=1)
+            sentence_tensor[s_id][: len(sentence)] = concat_sentence_emb
 
         # --------------------------------------------------------------------
         # FF PART


### PR DESCRIPTION
Instead of concatenating token representations at the token level (row approach) and then perform the sentence tokenization, we make the process lazy by retrieving each token representation before concat, reorganize them in nested lists and perform the concat per column (all Word embeddings are concatenated in one operation, then all LM are concatenated in one op), then columns (each column being a kind of representation) are concatenated together.
The idea is because there are much more tokens per sentence than different kind of representation per token, there are less concatenation operations performed.

On Conll2003, 40 -> 36s.
GPU use whole time over 70% (when it reaches 100 there may be some improvements remaining, but the main bottleneck will be the model itself).

Let me know if your measures match :-)

FWIW, on French dataset, it s a 20% improvement, I have stopped to try to guess why.

Nb. : I downloaded Connl 2003 from https://github.com/synalp/NER/tree/master/corpus/CoNLL-2003