### PR TITLE
GH-1089: Optimize FlairEmbeddings depending on storage mode

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -11,8 +11,8 @@ if torch.cuda.is_available():
 else:
     device = torch.device("cpu")
 
-# global variable: optimization_settings
-optimization_mode = "default"
+# global variable: embedding_storage_mode
+embedding_storage_mode = "default"
 
 from . import data
 from . import models

--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -11,6 +11,9 @@ if torch.cuda.is_available():
 else:
     device = torch.device("cpu")
 
+# global variable: optimization_settings
+optimization_mode = "default"
+
 from . import data
 from . import models
 from . import visual

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1878,7 +1878,7 @@ class FlairEmbeddings(TokenEmbeddings):
                     if not self.fine_tune:
                         embedding = embedding.detach()
 
-                    # embedding = embedding.clone()
+                    # only clone if optimization mode is 'gpu'
                     if flair.optimization_mode == "gpu":
                         embedding = embedding.clone()
 

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1878,7 +1878,11 @@ class FlairEmbeddings(TokenEmbeddings):
                     if not self.fine_tune:
                         embedding = embedding.detach()
 
-                    token.set_embedding(self.name, embedding.clone())
+                    # embedding = embedding.clone()
+                    if flair.optimization_mode == "gpu":
+                        embedding = embedding.clone()
+
+                    token.set_embedding(self.name, embedding)
 
             all_hidden_states_in_lm = all_hidden_states_in_lm.detach()
             del all_hidden_states_in_lm

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -1879,7 +1879,7 @@ class FlairEmbeddings(TokenEmbeddings):
                         embedding = embedding.detach()
 
                     # only clone if optimization mode is 'gpu'
-                    if flair.optimization_mode == "gpu":
+                    if flair.embedding_storage_mode == "gpu":
                         embedding = embedding.clone()
 
                     token.set_embedding(self.name, embedding)

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -251,7 +251,7 @@ class SequenceTagger(flair.nn.Model):
         self,
         data_loader: DataLoader,
         out_path: Path = None,
-        embeddings_storage_mode: str = "none",
+        embedding_storage_mode: str = "none",
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -320,7 +320,7 @@ class SequenceTagger(flair.nn.Model):
                         else:
                             metric.add_tn(tag)
 
-                store_embeddings(batch, embeddings_storage_mode)
+                store_embeddings(batch, embedding_storage_mode)
 
             eval_loss /= batch_no
 

--- a/flair/models/similarity_learning_model.py
+++ b/flair/models/similarity_learning_model.py
@@ -263,7 +263,7 @@ class SimilarityLearner(flair.nn.Model):
         self,
         data_loader: DataLoader,
         out_path: Path = None,
-        embeddings_storage_mode="none",
+        embedding_storage_mode="none",
     ) -> (Result, float):
         # assumes that for each data pair there's at least one embedding per modality
 
@@ -281,7 +281,7 @@ class SimilarityLearner(flair.nn.Model):
                     all_target_embeddings.append(
                         self._embed_target(target_inputs).to(self.eval_device)
                     )
-                store_embeddings(data_points, embeddings_storage_mode)
+                store_embeddings(data_points, embedding_storage_mode)
             all_target_embeddings = torch.cat(all_target_embeddings, dim=0)  # [n0, d0]
             assert len(target_index) == all_target_embeddings.shape[0]
 
@@ -315,7 +315,7 @@ class SimilarityLearner(flair.nn.Model):
                 ]
                 ranks.extend(batch_gt_ranks.tolist())
 
-                store_embeddings(data_points, embeddings_storage_mode)
+                store_embeddings(data_points, embedding_storage_mode)
 
         ranks = np.array(ranks)
         median_rank = np.median(ranks)

--- a/flair/models/text_classification_model.py
+++ b/flair/models/text_classification_model.py
@@ -171,7 +171,7 @@ class TextClassifier(flair.nn.Model):
         self,
         data_loader: DataLoader,
         out_path: Path = None,
-        embeddings_storage_mode: str = "none",
+        embedding_storage_mode: str = "none",
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -238,7 +238,7 @@ class TextClassifier(flair.nn.Model):
                         ):
                             metric.add_tn(label)
 
-                store_embeddings(batch, embeddings_storage_mode)
+                store_embeddings(batch, embedding_storage_mode)
 
             eval_loss /= batch_count
 

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -94,7 +94,7 @@ class TextRegressor(flair.models.TextClassifier):
         self,
         data_loader: DataLoader,
         out_path: Path = None,
-        embeddings_storage_mode: str = "none",
+        embedding_storage_mode: str = "none",
     ) -> (Result, float):
 
         with torch.no_grad():
@@ -137,7 +137,7 @@ class TextRegressor(flair.models.TextClassifier):
                     )
                     lines.append(eval_line)
 
-                store_embeddings(batch, embeddings_storage_mode)
+                store_embeddings(batch, embedding_storage_mode)
 
             eval_loss /= total_count
 

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -29,13 +29,13 @@ class Model(torch.nn.Module):
         self,
         data_loader: DataLoader,
         out_path: Path = None,
-        embeddings_storage_mode: str = "none",
+        embedding_storage_mode: str = "none",
     ) -> (Result, float):
         """Evaluates the model. Returns a Result object containing evaluation
         results and a loss value. Implement this to enable evaluation.
         :param data_loader: DataLoader that iterates over dataset to be evaluated
         :param out_path: Optional output path to store predictions
-        :param embeddings_storage_mode: One of 'none', 'cpu' or 'gpu'. 'none' means all embeddings are deleted and
+        :param embedding_storage_mode: One of 'none', 'cpu' or 'gpu'. 'none' means all embeddings are deleted and
         freshly recomputed, 'cpu' means all embeddings are stored on CPU, or 'gpu' means all embeddings are stored on GPU
         :return: Returns a Tuple consisting of a Result object and a loss float value
         """

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -327,7 +327,7 @@ class ModelTrainer:
                             batch_size=eval_mini_batch_size,
                             num_workers=num_workers,
                         ),
-                        embeddings_storage_mode=embeddings_storage_mode,
+                        embedding_storage_mode=embeddings_storage_mode,
                     )
                     result_line += f"\t{train_eval_result.log_line}"
 
@@ -341,7 +341,7 @@ class ModelTrainer:
                             batch_size=eval_mini_batch_size,
                             num_workers=num_workers,
                         ),
-                        embeddings_storage_mode=embeddings_storage_mode,
+                        embedding_storage_mode=embeddings_storage_mode,
                     )
                     result_line += f"\t{dev_loss}\t{dev_eval_result.log_line}"
                     log.info(
@@ -371,7 +371,7 @@ class ModelTrainer:
                             num_workers=num_workers,
                         ),
                         base_path / "test.tsv",
-                        embeddings_storage_mode=embeddings_storage_mode,
+                        embedding_storage_mode=embeddings_storage_mode,
                     )
                     result_line += f"\t{test_loss}\t{test_eval_result.log_line}"
                     log.info(
@@ -511,7 +511,7 @@ class ModelTrainer:
                 num_workers=num_workers,
             ),
             out_path=base_path / "test.tsv",
-            embeddings_storage_mode="none",
+            embedding_storage_mode="none",
         )
 
         test_results: Result = test_results
@@ -530,7 +530,7 @@ class ModelTrainer:
                         num_workers=num_workers,
                     ),
                     out_path=base_path / f"{subcorpus.name}-test.tsv",
-                    embeddings_storage_mode="none",
+                    embedding_storage_mode="none",
                 )
 
         # get and return the final test score of best model

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -366,6 +366,7 @@ def store_embeddings(sentences: List[Sentence], storage_mode: str):
         for sentence in sentences:
             sentence.to("cpu", pin_memory=pin_memory)
 
+    # if storage mode is GPU, set global variable to let FlairEmbeddings know that optimization is possible
     if storage_mode == "gpu":
         flair.optimization_mode = "gpu"
     else:

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -366,8 +366,5 @@ def store_embeddings(sentences: List[Sentence], storage_mode: str):
         for sentence in sentences:
             sentence.to("cpu", pin_memory=pin_memory)
 
-    # if storage mode is GPU, set global variable to let FlairEmbeddings know that optimization is possible
-    if storage_mode == "gpu":
-        flair.optimization_mode = "gpu"
-    else:
-        flair.optimization_mode = "default"
+    # record current embedding storage mode to allow optimization (for instance in FlairEmbeddings class)
+    flair.embedding_storage_mode = storage_mode

--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -365,3 +365,8 @@ def store_embeddings(sentences: List[Sentence], storage_mode: str):
         pin_memory = False if str(flair.device) == "cpu" else True
         for sentence in sentences:
             sentence.to("cpu", pin_memory=pin_memory)
+
+    if storage_mode == "gpu":
+        flair.optimization_mode = "gpu"
+    else:
+        flair.optimization_mode = "default"


### PR DESCRIPTION
As discussed in #1089, the `clone()` operation in `FlairEmbeddings` is expensive and only required if the `embedding_storage_mode` is 'gpu'. However, information of which storage mode is selected is not visible in `FlairEmbeddings`. To address this, this PR adds a new global variable `embedding_storage_mode` that is set in the `store_embeddings()` method and checked in `FlairEmbeddings`. This gives us a roughly 10% improvement in inference speed. 

The PR also renames the `embeddings_storage_mode` parameter of the `evaluate()` functions to `embedding_storage_mode` to make it consistent.