### PR TITLE
Fixing a typo in Tutorial 2

### DIFF
--- a/resources/docs/TUTORIAL_2_TAGGING.md
+++ b/resources/docs/TUTORIAL_2_TAGGING.md
@@ -206,7 +206,7 @@ Here's an example:
 # load model
 tagger = SequenceTagger.load('frame')
 
-# make German sentence
+# make English sentence
 sentence_1 = Sentence('George returned to Berlin to return his hat .')
 sentence_2 = Sentence('He had a look at different hats .')
 


### PR DESCRIPTION
Changing German -> English as the subsequent sentences are in English.