### PR TITLE
GH-1087: refactor checkpointing mechanism

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -254,6 +254,9 @@ class SequenceTagger(flair.nn.Model):
         embedding_storage_mode: str = "none",
     ) -> (Result, float):
 
+        if type(out_path) == str:
+            out_path = Path(out_path)
+
         with torch.no_grad():
             eval_loss = 0
 

--- a/flair/nn.py
+++ b/flair/nn.py
@@ -66,24 +66,6 @@ class Model(torch.nn.Module):
 
         torch.save(model_state, str(model_file), pickle_protocol=4)
 
-    def save_checkpoint(
-        self,
-        model_file: Union[str, Path],
-        optimizer_state: dict,
-        scheduler_state: dict,
-        epoch: int,
-        loss: float,
-    ):
-        model_state = self._get_state_dict()
-
-        # additional fields for model checkpointing
-        model_state["optimizer_state_dict"] = optimizer_state
-        model_state["scheduler_state_dict"] = scheduler_state
-        model_state["epoch"] = epoch
-        model_state["loss"] = loss
-
-        torch.save(model_state, str(model_file), pickle_protocol=4)
-
     @classmethod
     def load(cls, model: Union[str, Path]):
         """
@@ -106,37 +88,6 @@ class Model(torch.nn.Module):
         model.to(flair.device)
 
         return model
-
-    @classmethod
-    def load_checkpoint(cls, checkpoint_file: Union[str, Path]):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            # load_big_file is a workaround by https://github.com/highway11git to load models on some Mac/Windows setups
-            # see https://github.com/zalandoresearch/flair/issues/351
-            f = flair.file_utils.load_big_file(str(checkpoint_file))
-            state = torch.load(f, map_location=flair.device)
-
-        model = cls._init_model_with_state_dict(state)
-
-        model.eval()
-        model.to(flair.device)
-
-        epoch = state["epoch"] if "epoch" in state else None
-        loss = state["loss"] if "loss" in state else None
-        optimizer_state_dict = (
-            state["optimizer_state_dict"] if "optimizer_state_dict" in state else None
-        )
-        scheduler_state_dict = (
-            state["scheduler_state_dict"] if "scheduler_state_dict" in state else None
-        )
-
-        return {
-            "model": model,
-            "epoch": epoch,
-            "loss": loss,
-            "optimizer_state_dict": optimizer_state_dict,
-            "scheduler_state_dict": scheduler_state_dict,
-        }
 
 
 class LockedDropout(torch.nn.Module):

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -40,8 +40,6 @@ class ModelTrainer:
         corpus: Corpus,
         optimizer: torch.optim.Optimizer = SGD,
         epoch: int = 0,
-        optimizer_state: dict = None,
-        scheduler_state: dict = None,
         use_tensorboard: bool = False,
     ):
         """
@@ -50,16 +48,12 @@ class ModelTrainer:
         :param corpus: The dataset used to train the model, should be of type Corpus
         :param optimizer: The optimizer to use (typically SGD or Adam)
         :param epoch: The starting epoch (normally 0 but could be higher if you continue training model)
-        :param optimizer_state: Optimizer state (necessary if continue training from checkpoint)
-        :param scheduler_state: Scheduler state (necessary if continue training from checkpoint)
         :param use_tensorboard: If True, writes out tensorboard information
         """
         self.model: flair.nn.Model = model
         self.corpus: Corpus = corpus
         self.optimizer: torch.optim.Optimizer = optimizer
         self.epoch: int = epoch
-        self.scheduler_state: dict = scheduler_state
-        self.optimizer_state: dict = optimizer_state
         self.use_tensorboard: bool = use_tensorboard
 
     def train(
@@ -184,8 +178,6 @@ class ModelTrainer:
         optimizer: torch.optim.Optimizer = self.optimizer(
             self.model.parameters(), lr=learning_rate, **kwargs
         )
-        if self.optimizer_state is not None:
-            optimizer.load_state_dict(self.optimizer_state)
 
         if use_amp:
             self.model, optimizer = amp.initialize(
@@ -202,9 +194,6 @@ class ModelTrainer:
             mode=anneal_mode,
             verbose=True,
         )
-
-        if self.scheduler_state is not None:
-            scheduler.load_state_dict(self.scheduler_state)
 
         train_data = self.corpus.train
 
@@ -224,7 +213,7 @@ class ModelTrainer:
         try:
             previous_learning_rate = learning_rate
 
-            for epoch in range(0 + self.epoch, max_epochs + self.epoch):
+            for self.epoch in range(self.epoch + 1, max_epochs + 1):
                 log_line(log)
 
                 # get new learning rate
@@ -292,11 +281,11 @@ class ModelTrainer:
                     batch_time += time.time() - start_time
                     if batch_no % modulo == 0:
                         log.info(
-                            f"epoch {epoch + 1} - iter {batch_no}/{total_number_of_batches} - loss "
+                            f"epoch {self.epoch} - iter {batch_no}/{total_number_of_batches} - loss "
                             f"{train_loss / seen_batches:.8f} - samples/sec: {mini_batch_size * modulo / batch_time:.2f}"
                         )
                         batch_time = 0
-                        iteration = epoch * total_number_of_batches + batch_no
+                        iteration = self.epoch * total_number_of_batches + batch_no
                         if not param_selection_mode:
                             weight_extractor.extract_weights(
                                 self.model.state_dict(), iteration
@@ -308,11 +297,11 @@ class ModelTrainer:
 
                 log_line(log)
                 log.info(
-                    f"EPOCH {epoch + 1} done: loss {train_loss:.4f} - lr {learning_rate:.4f}"
+                    f"EPOCH {self.epoch} done: loss {train_loss:.4f} - lr {learning_rate:.4f}"
                 )
 
                 if self.use_tensorboard:
-                    writer.add_scalar("train_loss", train_loss, epoch + 1)
+                    writer.add_scalar("train_loss", train_loss, self.epoch)
 
                 # anneal against train loss if training with dev, otherwise anneal against dev score
                 current_score = train_loss
@@ -358,9 +347,9 @@ class ModelTrainer:
                     store_embeddings(self.corpus.dev, embeddings_storage_mode)
 
                     if self.use_tensorboard:
-                        writer.add_scalar("dev_loss", dev_loss, epoch + 1)
+                        writer.add_scalar("dev_loss", dev_loss, self.epoch)
                         writer.add_scalar(
-                            "dev_score", dev_eval_result.main_score, epoch + 1
+                            "dev_score", dev_eval_result.main_score, self.epoch
                         )
 
                 if log_test:
@@ -382,9 +371,9 @@ class ModelTrainer:
                     store_embeddings(self.corpus.test, embeddings_storage_mode)
 
                     if self.use_tensorboard:
-                        writer.add_scalar("test_loss", test_loss, epoch + 1)
+                        writer.add_scalar("test_loss", test_loss, self.epoch)
                         writer.add_scalar(
-                            "test_score", test_eval_result.main_score, epoch + 1
+                            "test_score", test_eval_result.main_score, self.epoch
                         )
 
                 # determine learning rate annealing through scheduler
@@ -409,7 +398,7 @@ class ModelTrainer:
                 with open(loss_txt, "a") as f:
 
                     # make headers on first epoch
-                    if epoch == 0:
+                    if self.epoch == 1:
                         f.write(
                             f"EPOCH\tTIMESTAMP\tBAD_EPOCHS\tLEARNING_RATE\tTRAIN_LOSS"
                         )
@@ -435,19 +424,13 @@ class ModelTrainer:
                             )
 
                     f.write(
-                        f"\n{epoch}\t{datetime.datetime.now():%H:%M:%S}\t{bad_epochs}\t{learning_rate:.4f}\t{train_loss}"
+                        f"\n{self.epoch}\t{datetime.datetime.now():%H:%M:%S}\t{bad_epochs}\t{learning_rate:.4f}\t{train_loss}"
                     )
                     f.write(result_line)
 
-                # if checkpoint is enable, save model at each epoch
+                # if checkpoint is enabled, save model at each epoch
                 if checkpoint and not param_selection_mode:
-                    self.model.save_checkpoint(
-                        base_path / "checkpoint.pt",
-                        optimizer.state_dict(),
-                        scheduler.state_dict(),
-                        epoch + 1,
-                        train_loss,
-                    )
+                    self.save_checkpoint(base_path / "checkpoint.pt")
 
                 # if we use dev data, remember best model based on dev evaluation score
                 if (
@@ -491,6 +474,18 @@ class ModelTrainer:
             "train_loss_history": train_loss_history,
             "dev_loss_history": dev_loss_history,
         }
+
+    def save_checkpoint(self, model_file: Union[str, Path]):
+        corpus = self.corpus
+        self.corpus = None
+        torch.save(self, str(model_file), pickle_protocol=4)
+        self.corpus = corpus
+
+    @classmethod
+    def load_checkpoint(cls, checkpoint: Union[Path, str], corpus: Corpus):
+        model: ModelTrainer = torch.load(checkpoint, map_location=flair.device)
+        model.corpus = corpus
+        return model
 
     def final_test(
         self, base_path: Path, eval_mini_batch_size: int, num_workers: int = 8
@@ -537,19 +532,6 @@ class ModelTrainer:
         final_score = test_results.main_score
 
         return final_score
-
-    @classmethod
-    def load_from_checkpoint(
-        cls, checkpoint, corpus: Corpus, optimizer: torch.optim.Optimizer = SGD
-    ):
-        return ModelTrainer(
-            checkpoint["model"],
-            corpus,
-            optimizer,
-            epoch=checkpoint["epoch"],
-            optimizer_state=checkpoint["optimizer_state_dict"],
-            scheduler_state=checkpoint["scheduler_state_dict"],
-        )
 
     def find_learning_rate(
         self,

--- a/tests/test_model_integration.py
+++ b/tests/test_model_integration.py
@@ -3,7 +3,6 @@ import shutil
 import pytest
 from torch.optim import SGD
 from torch.optim.adam import Adam
-from torch.optim.optimizer import Optimizer
 
 import flair.datasets
 from flair.data import Dictionary, Sentence, MultiCorpus
@@ -164,10 +163,8 @@ def test_train_optimizer(results_base_path, tasks_base_path):
         use_crf=False,
     )
 
-    optimizer: Optimizer = Adam
-
     # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus, optimizer=optimizer)
+    trainer: ModelTrainer = ModelTrainer(tagger, corpus, optimizer=Adam)
 
     trainer.train(
         results_base_path,
@@ -209,10 +206,8 @@ def test_train_optimizer_arguments(results_base_path, tasks_base_path):
         use_crf=False,
     )
 
-    optimizer: Optimizer = AdamW
-
     # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus, optimizer=optimizer)
+    trainer: ModelTrainer = ModelTrainer(tagger, corpus, optimizer=AdamW)
 
     trainer.train(
         results_base_path,
@@ -255,10 +250,8 @@ def test_find_learning_rate(results_base_path, tasks_base_path):
         use_crf=False,
     )
 
-    optimizer: Optimizer = SGD
-
     # initialize trainer
-    trainer: ModelTrainer = ModelTrainer(tagger, corpus, optimizer=optimizer)
+    trainer: ModelTrainer = ModelTrainer(tagger, corpus, optimizer=SGD)
 
     trainer.find_learning_rate(results_base_path, iterations=5)
 
@@ -297,7 +290,7 @@ def test_train_load_use_classifier(results_base_path, tasks_base_path):
         [word_embedding], 128, 1, False, 64, False, False
     )
 
-    model = TextClassifier(document_embeddings, label_dict, False)
+    model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)
@@ -333,7 +326,7 @@ def test_train_classifier_with_sampler(results_base_path, tasks_base_path):
         [word_embedding], 32, 1, False, 64, False, False
     )
 
-    model = TextClassifier(document_embeddings, label_dict, False)
+    model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(
@@ -367,7 +360,7 @@ def test_train_load_use_classifier_with_prob(results_base_path, tasks_base_path)
         [word_embedding], 128, 1, False, 64, False, False
     )
 
-    model = TextClassifier(document_embeddings, label_dict, False)
+    model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)
@@ -406,7 +399,9 @@ def test_train_load_use_classifier_multi_label(results_base_path, tasks_base_pat
         bidirectional=False,
     )
 
-    model = TextClassifier(document_embeddings, label_dict, multi_label=True)
+    model: TextClassifier = TextClassifier(
+        document_embeddings, label_dict, multi_label=True
+    )
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(
@@ -462,7 +457,7 @@ def test_train_charlm_load_use_classifier(results_base_path, tasks_base_path):
         [embedding], 128, 1, False, 64, False, False
     )
 
-    model = TextClassifier(document_embeddings, label_dict, False)
+    model: TextClassifier = TextClassifier(document_embeddings, label_dict, False)
 
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False)
@@ -515,7 +510,9 @@ def test_train_language_model(results_base_path, resources_path):
     )
 
     # use the character LM as embeddings to embed the example sentence 'I love Berlin'
-    char_lm_embeddings = FlairEmbeddings(str(results_base_path / "best-lm.pt"))
+    char_lm_embeddings: TokenEmbeddings = FlairEmbeddings(
+        str(results_base_path / "best-lm.pt")
+    )
     sentence = Sentence("I love Berlin")
     char_lm_embeddings.embed(sentence)
 
@@ -588,8 +585,7 @@ def test_train_resume_text_classification_training(results_base_path, tasks_base
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 
-    checkpoint = TextClassifier.load_checkpoint(results_base_path / "checkpoint.pt")
-    trainer = ModelTrainer.load_from_checkpoint(checkpoint, corpus)
+    trainer = ModelTrainer.load_checkpoint(results_base_path / "checkpoint.pt", corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 
     # clean up results directory
@@ -619,8 +615,7 @@ def test_train_resume_sequence_tagging_training(results_base_path, tasks_base_pa
     trainer = ModelTrainer(model, corpus)
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 
-    checkpoint = SequenceTagger.load_checkpoint(results_base_path / "checkpoint.pt")
-    trainer = ModelTrainer.load_from_checkpoint(checkpoint, corpus)
+    trainer = ModelTrainer.load_checkpoint(results_base_path / "checkpoint.pt", corpus)
 
     trainer.train(results_base_path, max_epochs=2, shuffle=False, checkpoint=True)
 


### PR DESCRIPTION
This PR refactors the model checkpointing mechanism and slims down interfaces / code required to load checkpoints. Closes #1087 

In detail: 

-  The methods `save_checkpoint` and `load_checkpoint` are no longer part of the `flair.nn.Model` interface. Instead, saving and restoring checkpoints is now (fully) performed by the `ModelTrainer`.
- The optimizer state and scheduler state are removed from the `ModelTrainer` constructor since they are no longer required here. 
- Loading a checkpoint is now one line of code (previously two lines).

```python
# 1. initialize trainer as always with a model and a corpus
from flair.trainers import ModelTrainer
trainer: ModelTrainer = ModelTrainer(model, corpus)

# 2. train your model for 2 epochs
trainer.train(
    'experiment/folder',
    max_epochs=2,
    # example checkpointing
    checkpoint=True,
)

# 3. load last checkpoint with one line of code
trainer = ModelTrainer.load_checkpoint('experiment/folder/checkpoint.pt', corpus)

# 4. continue training for 2 extra epochs
trainer.train('experiment/folder_2',  max_epochs=4) 
```