### PR TITLE
Little optimization on device check

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -235,7 +235,7 @@ class Token(DataPoint):
 
     def set_embedding(self, name: str, vector: torch.tensor):
         device = flair.device
-        if len(self._embeddings.keys()) > 0:
+        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device
         if device != vector.device:
             vector = vector.to(device)
@@ -645,7 +645,7 @@ class Sentence(DataPoint):
 
     def set_embedding(self, name: str, vector: torch.tensor):
         device = flair.device
-        if len(self._embeddings.keys()) > 0:
+        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device
         if device != vector.device:
             vector = vector.to(device)
@@ -879,9 +879,11 @@ class Image(DataPoint):
 
     def set_embedding(self, name: str, vector: torch.tensor):
         device = flair.device
-        if len(self._embeddings.keys()) > 0:
+        if (flair.embedding_storage_mode == "cpu") and len(self._embeddings.keys()) > 0:
             device = next(iter(self._embeddings.values())).device
-        self._embeddings[name] = vector.to(device, non_blocking=True)
+        if device != vector.device:
+            vector = vector.to(device)
+        self._embeddings[name] = vector
 
     def to(self, device: str, pin_memory: bool = False):
         for name, vector in self._embeddings.items():


### PR DESCRIPTION
close https://github.com/zalandoresearch/flair/issues/1104
Provide a constant 1s improvement on conll 2003. (26s -> 25s, I am now using batch of 256, because since I don't know when, it matters on inference speed, AFAIK on the last released version it didn't on my GPU)
The best thing is that it makes the global variable more useful :-)