### PR TITLE
GH-1092: simple mechanism to keep embedding order in StackedEmbeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -143,7 +143,8 @@ class StackedEmbeddings(TokenEmbeddings):
 
         # IMPORTANT: add embeddings as torch modules
         for i, embedding in enumerate(embeddings):
-            self.add_module("list_embedding_{}".format(i), embedding)
+            embedding.name = f"{str(i)}-{embedding.name}"
+            self.add_module(f"list_embedding_{str(i)}", embedding)
 
         self.name: str = "Stack"
         self.static_embeddings: bool = True


### PR DESCRIPTION
closes #1092 by adding a number to each embedding name to keep ordering fixed across different setups.