### PR TITLE
Another strong reduce of concatenation for a small optimization (-4% inference time)

### DIFF
--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -144,7 +144,9 @@ class LanguageModel(nn.Module):
                 ]
 
                 sequences_as_char_indices.append(char_indices)
-            t = torch.tensor(sequences_as_char_indices, dtype=torch.long).to(device=flair.device, non_blocking=True)
+            t = torch.tensor(sequences_as_char_indices, dtype=torch.long).to(
+                device=flair.device, non_blocking=True
+            )
             batches.append(t)
 
         output_parts = []

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -457,12 +457,10 @@ class SequenceTagger(flair.nn.Model):
             dtype=torch.float,
             device=flair.device,
         )
+
         all_embs = list()
         for sentence in sentences:
-            for token in sentence:
-                embs = token.get_each_embedding()
-                for emb in embs:
-                    all_embs.append(emb)
+            all_embs += [emb for token in sentence for emb in token.get_each_embedding()]
             nb_padding_tokens = longest_token_sequence_in_batch - len(sentence)
 
             if nb_padding_tokens > 0:

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -458,16 +458,16 @@ class SequenceTagger(flair.nn.Model):
             device=flair.device,
         )
         all_embs = list()
-        for s_id, sentence in enumerate(sentences):
+        for sentence in sentences:
             for token in sentence:
                 embs = token.get_each_embedding()
-                for index_emb, emb in enumerate(embs):
+                for emb in embs:
                     all_embs.append(emb)
-            nb_padding_token = longest_token_sequence_in_batch - len(sentence)
+            nb_padding_tokens = longest_token_sequence_in_batch - len(sentence)
 
-            if nb_padding_token > 0:
+            if nb_padding_tokens > 0:
                 t = pre_allocated_zero_tensor[
-                    : self.embeddings.embedding_length * nb_padding_token
+                    : self.embeddings.embedding_length * nb_padding_tokens
                 ]
                 all_embs.append(t)
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -452,30 +452,32 @@ class SequenceTagger(flair.nn.Model):
         lengths: List[int] = [len(sentence.tokens) for sentence in sentences]
         longest_token_sequence_in_batch: int = max(lengths)
 
-        # initialize zero-padded word embeddings tensor
-        sentence_tensor = torch.zeros(
+        pre_allocated_zero_tensor = t = torch.zeros(
+            self.embeddings.embedding_length * longest_token_sequence_in_batch,
+            dtype=torch.float,
+            device=flair.device,
+        )
+        all_embs = list()
+        for s_id, sentence in enumerate(sentences):
+            for token in sentence:
+                embs = token.get_each_embedding()
+                for index_emb, emb in enumerate(embs):
+                    all_embs.append(emb)
+            nb_padding_token = longest_token_sequence_in_batch - len(sentence)
+
+            if nb_padding_token > 0:
+                t = pre_allocated_zero_tensor[
+                    : self.embeddings.embedding_length * nb_padding_token
+                ]
+                all_embs.append(t)
+
+        sentence_tensor = torch.cat(all_embs).view(
             [
                 len(sentences),
                 longest_token_sequence_in_batch,
                 self.embeddings.embedding_length,
-            ],
-            dtype=torch.float,
-            device=flair.device,
+            ]
         )
-
-        for s_id, sentence in enumerate(sentences):
-            all_embs = list()
-
-            for index_token, token in enumerate(sentence):
-                embs = token.get_each_embedding()
-                if not all_embs:
-                    all_embs = [list() for _ in range(len(embs))]
-                for index_emb, emb in enumerate(embs):
-                    all_embs[index_emb].append(emb)
-
-            concat_word_emb = [torch.stack(embs) for embs in all_embs]
-            concat_sentence_emb = torch.cat(concat_word_emb, dim=1)
-            sentence_tensor[s_id][: len(sentence)] = concat_sentence_emb
 
         # --------------------------------------------------------------------
         # FF PART

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -452,7 +452,7 @@ class SequenceTagger(flair.nn.Model):
         lengths: List[int] = [len(sentence.tokens) for sentence in sentences]
         longest_token_sequence_in_batch: int = max(lengths)
 
-        pre_allocated_zero_tensor = t = torch.zeros(
+        pre_allocated_zero_tensor = torch.zeros(
             self.embeddings.embedding_length * longest_token_sequence_in_batch,
             dtype=torch.float,
             device=flair.device,


### PR DESCRIPTION
Reorganize embeddings + add some padding such a way we have only one call to concat (and no stack operation). Padding is preallocated to limit memory allocation. Get a constant 1 second inference time reduction on CONLL 2003 on 2080TI (25 -> 24s).
Had no measurable effect on my French dataset.

Good thing, the code is easier to read :-)

Nb: not related but I made a mistake in my measures... unfortunately memory transfer is not the main remaining bottleneck, I measured some synchronization operation which was happening before memory transfer. now I am using `;CUDA_LAUNCH_BLOCKING=1 ` before using cProfile instead of trying to be smart and calling synchronize manually here and there... Another thing, little functions called million of times appears slower than they are with the profiler...