### PR TITLE
Use $HOME instead of ~ for cache_root

### DIFF
--- a/flair/__init__.py
+++ b/flair/__init__.py
@@ -1,8 +1,8 @@
 import torch
-import os
+from pathlib import Path
 
 # global variable: cache_root
-cache_root = os.path.expanduser(os.path.join("~", ".flair"))
+cache_root = Path(Path.home(), ".flair")
 
 # global variable: device
 device = None


### PR DESCRIPTION
The directory `.flair` is created in the home directory, which is currently determined with `~` and `os.path.expanduser()`.

The [`home()`](https://github.com/python/cpython/blob/3368f3c6ae4140a0883e19350e672fd09c9db616/Lib/pathlib.py#L252-L281) classmethod of a `pathlib.Path` object determines the home directory via the `$HOME` environment variable --- which can easily be modified (makes sense, for example, on an Elastic Beanstalk instance where there is no user and no home folder).

However, I think `pathlib` is widely used in this beautiful library, so it would even make sense for consistency reasons :)