### PR TITLE
GH-1072: Batch-growth annealing

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -445,7 +445,6 @@ class SequenceTagger(flair.nn.Model):
             return sentences
 
     def forward(self, sentences: List[Sentence]):
-        self.zero_grad()
 
         self.embeddings.embed(sentences)
 

--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -73,7 +73,7 @@ class ModelTrainer:
         checkpoint: bool = False,
         save_final_model: bool = True,
         anneal_with_restarts: bool = False,
-        double_back_size_when_annealing: bool = False,
+        batch_growth_annealing: bool = False,
         shuffle: bool = True,
         param_selection_mode: bool = False,
         num_workers: int = 6,
@@ -155,9 +155,7 @@ class ModelTrainer:
         log.info(f' - max_epochs: "{max_epochs}"')
         log.info(f' - shuffle: "{shuffle}"')
         log.info(f' - train_with_dev: "{train_with_dev}"')
-        log.info(
-            f' - double_back_size_when_annealing: "{double_back_size_when_annealing}"'
-        )
+        log.info(f' - batch_growth_annealing: "{batch_growth_annealing}"')
         log_line(log)
         log.info(f'Model training base path: "{base_path}"')
         log_line(log)
@@ -226,10 +224,7 @@ class ModelTrainer:
                 for group in optimizer.param_groups:
                     learning_rate = group["lr"]
 
-                if (
-                    learning_rate != previous_learning_rate
-                    and double_back_size_when_annealing
-                ):
+                if learning_rate != previous_learning_rate and batch_growth_annealing:
                     mini_batch_size *= 2
 
                 # reload last best model if annealing with restarts is enabled


### PR DESCRIPTION
The paper [Don't Decay the Learning Rate, Increase the Batch Size](https://arxiv.org/abs/1711.00489) makes the case for increasing the batch size over time instead of annealing the learning rate. 

This PR adds the possibility to have arbitrarily large mini-batch sizes with an accumulating gradient strategy (closes #1072). It introduces the parameter `mini_batch_chunk_size` that you can set to break down large mini-batches into smaller chunks for processing purposes. 

So let's say you want to have a mini-batch size of 128, but your memory cannot handle more than 32 samples at a time. Then you can train like this: 

```python
trainer = ModelTrainer(tagger, corpus)
trainer.train(
    "path/to/experiment/folder",
    # set large mini-batch size
    mini_batch_size=128,
    # set chunk size to lower memory requirements
    mini_batch_chunk_size=32,
)
```

Because we now can arbitrarly raise mini-batch size, we can now execute the annealing strategy in the above paper. Do it like this: 

```python
trainer = ModelTrainer(tagger, corpus)
trainer.train(
    "path/to/experiment/folder",
    # set initial mini-batch size
    mini_batch_size=32,
    # choose batch growth annealing 
    batch_growth_annealing=True,
)
```

This will double the mini-batch size each time the learning rate anneals. You can also combine this with "annealing with restarts" in which the last best model state is restored each time the learning rate anneals. 

```python
trainer = ModelTrainer(tagger, corpus)
trainer.train(
    "path/to/experiment/folder",
    # set initial mini-batch size
    mini_batch_size=32,
    # choose batch growth annealing 
    batch_growth_annealing=True,
    # reset model state to best on each anneal
    anneal_with_restarts=True,
)
```