### PR TITLE
Accept string as input in NER predict

### DIFF
--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -570,7 +570,11 @@ class StringDataset(FlairDataset):
     A Dataset taking string as input and returning Sentence during iteration
     """
 
-    def __init__(self, texts: Union[str, List[str]], use_tokenizer: Union[bool, Callable[[str], List[Token]]] = space_tokenizer):
+    def __init__(
+        self,
+        texts: Union[str, List[str]],
+        use_tokenizer: Union[bool, Callable[[str], List[Token]]] = space_tokenizer,
+    ):
         """
         Instantiate StringDataset
         :param texts: a string or List of string that make up StringDataset

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -565,6 +565,38 @@ class SentenceDataset(FlairDataset):
         return self.sentences[index]
 
 
+class StringDataset(FlairDataset):
+    """
+    A Dataset taking string as input and returning Sentence during iteration
+    """
+
+    def __init__(self, texts: Union[str, List[str]], use_tokenizer: Union[bool, Callable[[str], List[Token]]] = space_tokenizer):
+        """
+        Instantiate StringDataset
+        :param texts: a string or List of string that make up StringDataset
+        :param use_tokenizer: a custom tokenizer (default is space based tokenizer,
+        more advanced options are segtok_tokenizer to use segtok or build_spacy_tokenizer to use Spacy library
+        if available). Check the code of space_tokenizer to implement your own (if you need it).
+        If instead of providing a function, this parameter is just set to True, segtok will be used.
+        """
+        # cast to list if necessary
+        if type(texts) == Sentence:
+            texts = [texts]
+        self.texts = texts
+        self.use_tokenizer = use_tokenizer
+
+    @abstractmethod
+    def is_in_memory(self) -> bool:
+        return True
+
+    def __len__(self):
+        return len(self.texts)
+
+    def __getitem__(self, index: int = 0) -> Sentence:
+        text = self.texts[index]
+        return Sentence(text, use_tokenizer=self.use_tokenizer)
+
+
 class ColumnDataset(FlairDataset):
     def __init__(
         self,

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -275,6 +275,9 @@ class SequenceTagger(flair.nn.Model):
         :return: List of Sentence enriched by the predicted tags
         """
         with torch.no_grad():
+            if not sentences:
+                return sentences
+
             if isinstance(sentences, Sentence) or isinstance(sentences, str):
                 sentences = [sentences]
 

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -412,18 +412,13 @@ class SequenceTagger(flair.nn.Model):
             else:
                 dataset = StringDataset(filtered_sentences)
             dataloader = DataLoader(dataset=dataset,
-                                    batch_size=mini_batch_size)
+                                    batch_size=mini_batch_size,
+                                    collate_fn=lambda x: x)
 
             if self.use_crf:
                 transitions = self.transitions.detach().cpu().numpy()
             else:
                 transitions = None
-
-            # make mini-batches
-            # batches = [
-            #     filtered_sentences[x : x + mini_batch_size]
-            #     for x in range(0, len(filtered_sentences), mini_batch_size)
-            # ]
 
             # progress bar for verbosity
             if verbose:

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -365,12 +365,12 @@ class SequenceTagger(flair.nn.Model):
         return self._calculate_loss(features, data_points)
 
     def predict(
-        self,
-        sentences: Union[List[Sentence], Sentence, List[str], str],
-        mini_batch_size=32,
-        embedding_storage_mode="none",
-        all_tag_prob: bool = False,
-        verbose=False,
+            self,
+            sentences: Union[List[Sentence], Sentence, List[str], str],
+            mini_batch_size=32,
+            embedding_storage_mode="none",
+            all_tag_prob: bool = False,
+            verbose=False,
     ) -> List[Sentence]:
         """
         Predict sequence tags for Named Entity Recognition task
@@ -420,12 +420,12 @@ class SequenceTagger(flair.nn.Model):
             if verbose:
                 dataloader = tqdm(dataloader)
 
-            results: List[Sentence] = list()
+            results: List[Sentence] = []
             for i, batch in enumerate(dataloader):
 
                 if verbose:
                     dataloader.set_description(f"Inferencing on batch {i}")
-                results.append(batch)
+                results += batch
                 batch = self._filter_empty_sentences(batch)
                 # stop if all sentences are empty
                 if not batch:
@@ -452,6 +452,7 @@ class SequenceTagger(flair.nn.Model):
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
             results: List[Union[Sentence, str]] = [results[index] for index in original_order]
+            assert len(sentences) == len(results)
             return results
 
     def forward(self, sentences: List[Sentence]):

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -253,13 +253,13 @@ class SequenceTagger(flair.nn.Model):
         return model
 
     def predict(
-            self,
-            sentences: Union[List[Sentence], Sentence, List[str], str],
-            mini_batch_size=32,
-            embedding_storage_mode="none",
-            all_tag_prob: bool = False,
-            verbose: bool = False,
-            use_tokenizer: Union[bool, Callable[[str], List[Token]]] = space_tokenizer,
+        self,
+        sentences: Union[List[Sentence], Sentence, List[str], str],
+        mini_batch_size=32,
+        embedding_storage_mode="none",
+        all_tag_prob: bool = False,
+        verbose: bool = False,
+        use_tokenizer: Union[bool, Callable[[str], List[Token]]] = space_tokenizer,
     ) -> List[Sentence]:
         """
         Predict sequence tags for Named Entity Recognition task
@@ -286,20 +286,28 @@ class SequenceTagger(flair.nn.Model):
                 )
 
             # reverse sort all sequences by their length
-            rev_order_len_index = sorted(range(len(sentences)), key=lambda k: len(sentences[k]), reverse=True)
-            original_order_index = sorted(range(len(rev_order_len_index)), key=lambda k: rev_order_len_index[k])
+            rev_order_len_index = sorted(
+                range(len(sentences)), key=lambda k: len(sentences[k]), reverse=True
+            )
+            original_order_index = sorted(
+                range(len(rev_order_len_index)), key=lambda k: rev_order_len_index[k]
+            )
 
-            reordered_sentences: List[Union[Sentence, str]] = [sentences[index] for index in rev_order_len_index]
+            reordered_sentences: List[Union[Sentence, str]] = [
+                sentences[index] for index in rev_order_len_index
+            ]
 
             if isinstance(sentences[0], Sentence):
                 # remove previous embeddings
                 store_embeddings(reordered_sentences, "none")
                 dataset = SentenceDataset(reordered_sentences)
             else:
-                dataset = StringDataset(reordered_sentences, use_tokenizer=use_tokenizer)
-            dataloader = DataLoader(dataset=dataset,
-                                    batch_size=mini_batch_size,
-                                    collate_fn=lambda x: x)
+                dataset = StringDataset(
+                    reordered_sentences, use_tokenizer=use_tokenizer
+                )
+            dataloader = DataLoader(
+                dataset=dataset, batch_size=mini_batch_size, collate_fn=lambda x: x
+            )
 
             if self.use_crf:
                 transitions = self.transitions.detach().cpu().numpy()
@@ -341,7 +349,9 @@ class SequenceTagger(flair.nn.Model):
                 # clearing token embeddings to save memory
                 store_embeddings(batch, storage_mode=embedding_storage_mode)
 
-            results: List[Union[Sentence, str]] = [results[index] for index in original_order_index]
+            results: List[Union[Sentence, str]] = [
+                results[index] for index in original_order_index
+            ]
             assert len(sentences) == len(results)
             return results
 
@@ -473,7 +483,9 @@ class SequenceTagger(flair.nn.Model):
 
         all_embs = list()
         for sentence in sentences:
-            all_embs += [emb for token in sentence for emb in token.get_each_embedding()]
+            all_embs += [
+                emb for token in sentence for emb in token.get_each_embedding()
+            ]
             nb_padding_tokens = longest_token_sequence_in_batch - len(sentence)
 
             if nb_padding_tokens > 0:

--- a/resources/docs/TUTORIAL_2_TAGGING.md
+++ b/resources/docs/TUTORIAL_2_TAGGING.md
@@ -259,6 +259,11 @@ Using the `mini_batch_size` parameter of the `.predict()` method, you can set th
 tagger. Depending on your resources, you might want to play around with this parameter to optimize speed.
 
 
+**If you are using `Flair` with a version > 0.4.3 or installed it from `master` branch**
+
+`predict` can receive string.   
+Simply use `use_tokenizer` parameter with the tokenizer you want to use (more info on TUTORIAL_1_BASICS.md).
+
 ## Tagging with Pre-Trained Text Classification Models
 
 Let's use a pre-trained model for detecting positive or negative comments.


### PR DESCRIPTION
Add a new kind of dataset for strings and a dataloader to load them. That way new user wanted to make test doesn't need to understand how to build a Sentence. Plus it's more convenient to use in general for advanced users.
Has no impact on speed, however multiprocessing (to tokenize during GPU is working) makes things slower so it's kept disabled.
