### PR TITLE
Optimize character to index conversion for a 4% decrease on CONNL 2003

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -78,6 +78,9 @@ class Dictionary:
         self.item2idx_not_encoded = dict([(key.decode("UTF-8"), value) for key, value in self.item2idx.items()])
 
     def save(self, savefile):
+        if not hasattr(self, "item2idx_not_encoded"):
+            self.__decode_utf_internal()
+
         import pickle
 
         with open(file=savefile, mode="wb") as f:
@@ -93,8 +96,8 @@ class Dictionary:
             mappings = pickle.load(f, encoding="latin1")
             idx2item = mappings["idx2item"]
             item2idx = mappings["item2idx"]
-            dictionary.item2idx_not_encoded = item2idx
-            dictionary.idx2item_not_encoded = idx2item
+            dictionary.item2idx = item2idx
+            dictionary.idx2item = idx2item
         return dictionary
 
     @classmethod

--- a/flair/data.py
+++ b/flair/data.py
@@ -28,7 +28,7 @@ class Dictionary:
         # init dictionaries
         self.item2idx: Dict[str, int] = {}
         self.idx2item: List[str] = []
-        self.item2idx_not_encoded: Dict[str, int] = defaultdict(lambda: 0)
+        self.item2idx_not_encoded: Dict[str, int] = defaultdict(int)
         self.idx2item_not_encoded: List[str] = []
         self.multi_label: bool = False
         # in order to deal with unknown tokens, add <unk>
@@ -91,8 +91,10 @@ class Dictionary:
     def decode_utf_internal(self):
         if not hasattr(self, "item2idx_not_encoded"):
             self.idx2item_not_encoded = [item.decode("UTF-8") for item in self.idx2item]
-            d = dict([(key.decode("UTF-8"), value) for key, value in self.item2idx.items()])
-            self.item2idx_not_encoded = defaultdict(lambda: 0, d)
+            d = dict(
+                [(key.decode("UTF-8"), value) for key, value in self.item2idx.items()]
+            )
+            self.item2idx_not_encoded = defaultdict(int, d)
 
     def save(self, savefile):
         if not hasattr(self, "item2idx_not_encoded"):
@@ -101,7 +103,11 @@ class Dictionary:
         import pickle
 
         with open(file=savefile, mode="wb") as f:
-            mappings = {"idx2item": self.idx2item_not_encoded, "item2idx": dict(self.item2idx_not_encoded), "UTF-8": True}
+            mappings = {
+                "idx2item": self.idx2item_not_encoded,
+                "item2idx": dict(self.item2idx_not_encoded),
+                "UTF-8": True,
+            }
             pickle.dump(mappings, f)
 
     @classmethod

--- a/flair/data.py
+++ b/flair/data.py
@@ -28,7 +28,7 @@ class Dictionary:
         # init dictionaries
         self.item2idx: Dict[str, int] = {}
         self.idx2item: List[str] = []
-        self.item2idx_not_encoded: Dict[str, int] = defaultdict(int)
+        self.item2idx_not_encoded: Dict[str, int] = defaultdict(lambda: 0)
         self.idx2item_not_encoded: List[str] = []
         self.multi_label: bool = False
         # in order to deal with unknown tokens, add <unk>
@@ -59,9 +59,19 @@ class Dictionary:
         return self.item2idx_not_encoded[item]
 
     def get_idx_for_items(self, items: List[str]) -> List[int]:
+        """
+        returns the IDs for each item of the list of string, otherwise 0 if not found
+        :param items: List of string for which IDs are requested
+        :return: List of ID of strings
+        """
         if not hasattr(self, "item2idx_not_encoded"):
             self.decode_utf_internal()
-        return itemgetter(*items)(self.item2idx_not_encoded)
+        if not items:
+            return []
+        results = itemgetter(*items)(self.item2idx_not_encoded)
+        if isinstance(results, int):
+            return [results]
+        return list(results)
 
     def get_items(self) -> List[str]:
         if not hasattr(self, "item2idx_not_encoded"):
@@ -82,7 +92,7 @@ class Dictionary:
         if not hasattr(self, "item2idx_not_encoded"):
             self.idx2item_not_encoded = [item.decode("UTF-8") for item in self.idx2item]
             d = dict([(key.decode("UTF-8"), value) for key, value in self.item2idx.items()])
-            self.item2idx_not_encoded = defaultdict(int, d)
+            self.item2idx_not_encoded = defaultdict(lambda: 0, d)
 
     def save(self, savefile):
         if not hasattr(self, "item2idx_not_encoded"):
@@ -91,7 +101,7 @@ class Dictionary:
         import pickle
 
         with open(file=savefile, mode="wb") as f:
-            mappings = {"idx2item": self.idx2item_not_encoded, "item2idx": self.item2idx_not_encoded, "UTF-8": True}
+            mappings = {"idx2item": self.idx2item_not_encoded, "item2idx": dict(self.item2idx_not_encoded), "UTF-8": True}
             pickle.dump(mappings, f)
 
     @classmethod

--- a/flair/data.py
+++ b/flair/data.py
@@ -40,9 +40,8 @@ class Dictionary:
         :param item: a string for which to assign an id.
         :return: ID of string
         """
-        # item = item.encode("utf-8")
         if not hasattr(self, "item2idx_not_encoded"):
-            self.__decode_utf_internal()
+            self.decode_utf_internal()
         if item not in self.item2idx_not_encoded:
             self.idx2item_not_encoded.append(item)
             self.item2idx_not_encoded[item] = len(self.idx2item_not_encoded) - 1
@@ -55,36 +54,36 @@ class Dictionary:
         :return: ID of string, otherwise 0
         """
         if not hasattr(self, "item2idx_not_encoded"):
-            self.__decode_utf_internal()
+            self.decode_utf_internal()
         return self.item2idx_not_encoded.get(item, 0)
 
     def get_items(self) -> List[str]:
         if not hasattr(self, "item2idx_not_encoded"):
-            self.__decode_utf_internal()
+            self.decode_utf_internal()
         return self.idx2item_not_encoded
 
     def __len__(self) -> int:
         if not hasattr(self, "item2idx_not_encoded"):
-            self.__decode_utf_internal()
+            self.decode_utf_internal()
         return len(self.idx2item_not_encoded)
 
     def get_item_for_index(self, idx):
         if not hasattr(self, "item2idx_not_encoded"):
-            self.__decode_utf_internal()
+            self.decode_utf_internal()
         return self.idx2item_not_encoded[idx]
 
-    def __decode_utf_internal(self):
+    def decode_utf_internal(self):
         self.idx2item_not_encoded = [item.decode("UTF-8") for item in self.idx2item]
         self.item2idx_not_encoded = dict([(key.decode("UTF-8"), value) for key, value in self.item2idx.items()])
 
     def save(self, savefile):
         if not hasattr(self, "item2idx_not_encoded"):
-            self.__decode_utf_internal()
+            self.decode_utf_internal()
 
         import pickle
 
         with open(file=savefile, mode="wb") as f:
-            mappings = {"idx2item": self.idx2item_not_encoded, "item2idx": self.item2idx_not_encoded}
+            mappings = {"idx2item": self.idx2item_not_encoded, "item2idx": self.item2idx_not_encoded, "UTF-8": True}
             pickle.dump(mappings, f)
 
     @classmethod
@@ -98,6 +97,12 @@ class Dictionary:
             item2idx = mappings["item2idx"]
             dictionary.item2idx = item2idx
             dictionary.idx2item = idx2item
+            if "UTF-8" not in mappings:
+                dictionary.decode_utf_internal()
+            else:
+                dictionary.item2idx_not_encoded = item2idx
+                dictionary.idx2item_not_encoded = idx2item
+
         return dictionary
 
     @classmethod

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -140,10 +140,7 @@ class LanguageModel(nn.Module):
             len_longest_chunk: int = len(max(chunk, key=len))
             sequences_as_char_indices: List[List[int]] = []
             for string in chunk:
-                char_indices = [
-                    self.dictionary.get_idx_for_item(char) for char in string
-                ]
-
+                char_indices = self.dictionary.get_idx_for_items(list(string))
                 char_indices += [padding_char_index] * (len_longest_chunk - len(string))
 
                 sequences_as_char_indices.append(char_indices)

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -144,7 +144,7 @@ class LanguageModel(nn.Module):
                     self.dictionary.get_idx_for_item(char) for char in string
                 ]
 
-                char_indices += [padding_char_index] * (len_longest_str - len(string))
+                char_indices += [padding_char_index] * (chars_per_chunk - len(string))
 
                 sequences_as_char_indices.append(char_indices)
             t = torch.tensor(sequences_as_char_indices, dtype=torch.long).to(

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -137,14 +137,14 @@ class LanguageModel(nn.Module):
         batches: List[torch.Tensor] = []
         # push each chunk through the RNN language model
         for chunk in chunks:
-
+            len_longest_chunk: int = len(max(chunk, key=len))
             sequences_as_char_indices: List[List[int]] = []
             for string in chunk:
                 char_indices = [
                     self.dictionary.get_idx_for_item(char) for char in string
                 ]
 
-                char_indices += [padding_char_index] * (chars_per_chunk - len(string))
+                char_indices += [padding_char_index] * (len_longest_chunk - len(string))
 
                 sequences_as_char_indices.append(char_indices)
             t = torch.tensor(sequences_as_char_indices, dtype=torch.long).to(

--- a/flair/models/language_model.py
+++ b/flair/models/language_model.py
@@ -132,7 +132,7 @@ class LanguageModel(nn.Module):
         )
         hidden = self.init_hidden(len(chunks[0]))
 
-        padding_char_index = self.dictionary.get_idx_for_item(' ')
+        padding_char_index = self.dictionary.get_idx_for_item(" ")
 
         batches: List[torch.Tensor] = []
         # push each chunk through the RNN language model

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -459,7 +459,9 @@ class SequenceTagger(flair.nn.Model):
 
         all_embs = list()
         for sentence in sentences:
-            all_embs += [emb for token in sentence for emb in token.get_each_embedding()]
+            all_embs += [
+                emb for token in sentence for emb in token.get_each_embedding()
+            ]
             nb_padding_tokens = longest_token_sequence_in_batch - len(sentence)
 
             if nb_padding_tokens > 0:


### PR DESCRIPTION
Optimize the way padding is done by reducing the number of dictionary call.
Remove the conversion to UTF-8, and take care of old models in old format.
In the future, the conversion may be removed safely.

close https://github.com/zalandoresearch/flair/issues/1133
@alanakbik finally I did both, change in dictionary deserialization and change inside the class itself.

CONNL 2003 from 24s to 23s (-4%)
French dataset from 12s to 11s (-8%)