### PR TITLE
fix get_each_embedding when storage embedding is set to CPU

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -260,31 +260,21 @@ class Token(DataPoint):
                     del self._embeddings[name]
 
     def get_each_embedding(self) -> torch.tensor:
-        result = []
+        embeddings = []
         for embed in sorted(self._embeddings.keys()):
             embed = self._embeddings[embed].to(flair.device)
             if (flair.embedding_storage_mode == "cpu") and embed.device != flair.device:
                 embed = embed.to(flair.device)
-            result.append(embed)
-        return result
+            embeddings.append(embed)
+        return embeddings
 
     def get_embedding(self) -> torch.tensor:
-        embeddings = [
-            self._embeddings[embed] for embed in sorted(self._embeddings.keys())
-        ]
+        embeddings = self.get_each_embedding()
 
         if embeddings:
             return torch.cat(embeddings, dim=0)
 
         return torch.tensor([], device=flair.device)
-
-    def get_subembedding(self, names: List[str]) -> torch.tensor:
-        embeddings = [self._embeddings[embed] for embed in sorted(names)]
-
-        if embeddings:
-            return torch.cat(embeddings, dim=0)
-
-        return torch.Tensor()
 
     @property
     def start_position(self) -> int:

--- a/flair/data.py
+++ b/flair/data.py
@@ -260,7 +260,13 @@ class Token(DataPoint):
                     del self._embeddings[name]
 
     def get_each_embedding(self) -> torch.tensor:
-        return [self._embeddings[embed] for embed in sorted(self._embeddings.keys())]
+        result = []
+        for embed in sorted(self._embeddings.keys()):
+            embed = self._embeddings[embed].to(flair.device)
+            if (flair.embedding_storage_mode == "cpu") and embed.device != flair.device:
+                embed = embed.to(flair.device)
+            result.append(embed)
+        return result
 
     def get_embedding(self) -> torch.tensor:
         embeddings = [

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -459,7 +459,9 @@ class SequenceTagger(flair.nn.Model):
 
         all_embs = list()
         for sentence in sentences:
-            all_embs += [emb for token in sentence for emb in token.get_each_embedding()]
+            all_embs += [
+                emb for token in sentence for emb in token.get_each_embedding()
+            ]
             nb_padding_tokens = longest_token_sequence_in_batch - len(sentence)
 
             if nb_padding_tokens > 0:


### PR DESCRIPTION
When run with CPU storage on a computer with CUDA / GPU, embeddings may not be on the right storage during training.

I don't know why, but it was not crashing on my own train task (French dataset)

`get_embedding` uses `get_each_embedding` now to get the same security.
`get_subembedding` has been deleted because it is not used in the project and would require to generalize get_embedding, implying more complexity.

The real issue I just realized is that Travis was not catching this bug because it doesn't run integration tests on GPU, and in this case it was a device storage issue. I don't know how to improve that.