### PR TITLE
GH-804: add two multilingual character dictionaries

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -118,6 +118,16 @@ class Dictionary:
             char_dict = cached_path(base_path, cache_dir="datasets")
             return Dictionary.load_from_file(char_dict)
 
+        if name == "chars-large" or name == "common-chars-large":
+            base_path = "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources/models/common_characters_large"
+            char_dict = cached_path(base_path, cache_dir="datasets")
+            return Dictionary.load_from_file(char_dict)
+
+        if name == "chars-xl" or name == "common-chars-xl":
+            base_path = "https://s3.eu-central-1.amazonaws.com/alan-nlp/resources/models/common_characters_xl"
+            char_dict = cached_path(base_path, cache_dir="datasets")
+            return Dictionary.load_from_file(char_dict)
+
         return Dictionary.load_from_file(name)
 
 


### PR DESCRIPTION
This PR adds the two multilingual character dictionaries computed by @stefan-it. 

Load with 

```python
dictionary = Dictionary.load('chars-large')
print(len(dictionary.idx2item))

dictionary = Dictionary.load('chars-xl')
print(len(dictionary.idx2item))
```

Closes #804 - big thanks to @stefan-it!