### PR TITLE
Classification changes

### DIFF
--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -255,13 +255,21 @@ class ClassificationCorpus(Corpus):
             max_chars_per_doc=max_chars_per_doc,
             in_memory=in_memory,
         )
-        test: Dataset = ClassificationDataset(
-            test_file,
-            tokenizer=tokenizer,
-            max_tokens_per_doc=max_tokens_per_doc,
-            max_chars_per_doc=max_chars_per_doc,
-            in_memory=in_memory,
-        )
+
+        if test_file is not None:
+            test: Dataset = ClassificationDataset(
+                dev_file,
+                tokenizer=tokenizer,
+                max_tokens_per_doc=max_tokens_per_doc,
+                max_chars_per_doc=max_chars_per_doc,
+                in_memory=in_memory,
+            )
+        else:
+            train_length = len(train)
+            test_size: int = round(train_length / 10)
+            splits = random_split(train, [train_length - test_size, test_size])
+            train = splits[0]
+            test = splits[1]
 
         if dev_file is not None:
             dev: Dataset = ClassificationDataset(

--- a/flair/datasets.py
+++ b/flair/datasets.py
@@ -256,14 +256,16 @@ class ClassificationCorpus(Corpus):
             in_memory=in_memory,
         )
 
+        # use test_file to create test split if available
         if test_file is not None:
             test: Dataset = ClassificationDataset(
-                dev_file,
+                test_file,
                 tokenizer=tokenizer,
                 max_tokens_per_doc=max_tokens_per_doc,
                 max_chars_per_doc=max_chars_per_doc,
                 in_memory=in_memory,
             )
+        # otherwise, sample test data from train data
         else:
             train_length = len(train)
             test_size: int = round(train_length / 10)
@@ -271,6 +273,7 @@ class ClassificationCorpus(Corpus):
             train = splits[0]
             test = splits[1]
 
+        # use dev_file to create test split if available
         if dev_file is not None:
             dev: Dataset = ClassificationDataset(
                 dev_file,
@@ -279,6 +282,7 @@ class ClassificationCorpus(Corpus):
                 max_chars_per_doc=max_chars_per_doc,
                 in_memory=in_memory,
             )
+        # otherwise, sample dev data from dev data
         else:
             train_length = len(train)
             dev_size: int = round(train_length / 10)

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2710,9 +2710,9 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
         # before-RNN dropout
         if self.dropout:
             sentence_tensor = self.dropout(sentence_tensor)
-        if self.locked_dropout:
+        if hasattr(self, "locked_dropout"):
             sentence_tensor = self.locked_dropout(sentence_tensor)
-        if self.word_dropout:
+        if hasattr(self, "word_dropout"):
             sentence_tensor = self.word_dropout(sentence_tensor)
 
         # reproject if set
@@ -2729,8 +2729,8 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
         # after-RNN dropout
         if self.dropout:
             outputs = self.dropout(outputs)
-        if self.locked_dropout:
-            sentence_tensor = self.locked_dropout(sentence_tensor)
+        if hasattr(self, "locked_dropout"):
+            outputs = self.locked_dropout(outputs)
 
         # extract embeddings from RNN
         for sentence_no, length in enumerate(lengths):

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -2670,6 +2670,12 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
         """Add embeddings to all sentences in the given list of sentences. If embeddings are already added, update
          only if embeddings are non-static."""
 
+        # TODO: remove in future versions
+        if not hasattr(self, "locked_dropout"):
+            self.locked_dropout = None
+        if not hasattr(self, "word_dropout"):
+            self.word_dropout = None
+
         if type(sentences) is Sentence:
             sentences = [sentences]
 
@@ -2710,9 +2716,9 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
         # before-RNN dropout
         if self.dropout:
             sentence_tensor = self.dropout(sentence_tensor)
-        if hasattr(self, "locked_dropout"):
+        if self.locked_dropout:
             sentence_tensor = self.locked_dropout(sentence_tensor)
-        if hasattr(self, "word_dropout"):
+        if self.word_dropout:
             sentence_tensor = self.word_dropout(sentence_tensor)
 
         # reproject if set
@@ -2729,7 +2735,7 @@ class DocumentRNNEmbeddings(DocumentEmbeddings):
         # after-RNN dropout
         if self.dropout:
             outputs = self.dropout(outputs)
-        if hasattr(self, "locked_dropout"):
+        if self.locked_dropout:
             outputs = self.locked_dropout(outputs)
 
         # extract embeddings from RNN


### PR DESCRIPTION
This PR makes some small modifications to `DocumentRNNEmbeddings` and the `ClassificationDataset`. 

The `DocumentRNNEmbeddings` are modified to have the same dropout logic as the SequenceTagger, consisting of dropout, locked dropout and word dropout. The `ClassificationDataset` now automatically samples a test set if only a train dataset is provided.