### PR TITLE
GH-1176: add NER and POS for Danish by @AmaliePauli

### DIFF
--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -948,6 +948,14 @@ class SequenceTagger(flair.nn.Model):
             ]
         )
 
+        model_map["da-pos"] = "/".join(
+            [aws_resource_path_v04, "POS-danish", "da-pos-v0.1.pt"]
+        )
+
+        model_map["da-ner"] = "/".join(
+            [aws_resource_path_v04, "POS-danish", "da-pos-v0.1.pt"]
+        )
+
         model_map["de-pos"] = "/".join(
             [aws_resource_path_v04, "release-de-pos-0", "de-pos-ud-hdt-v0.4.pt"]
         )

--- a/flair/models/sequence_tagger_model.py
+++ b/flair/models/sequence_tagger_model.py
@@ -953,7 +953,7 @@ class SequenceTagger(flair.nn.Model):
         )
 
         model_map["da-ner"] = "/".join(
-            [aws_resource_path_v04, "POS-danish", "da-pos-v0.1.pt"]
+            [aws_resource_path_v04, "NER-danish", "da-ner-v0.1.pt"]
         )
 
         model_map["de-pos"] = "/".join(


### PR DESCRIPTION
This PR adds support for Danish POS and NER thanks to @AmaliePauli! 

Use like this: 

```python
from flair.data import Sentence
from flair.models import SequenceTagger

# example sentence
sentence = Sentence("København er en fantastisk by .")

# load Danish NER model and predict
ner_tagger = SequenceTagger.load('da-ner')
ner_tagger.predict(sentence)

# print annotations (NER)
print(sentence.to_tagged_string())

# load Danish POS model and predict
pos_tagger = SequenceTagger.load('da-pos')
pos_tagger.predict(sentence)

# print annotations (NER + POS)
print(sentence.to_tagged_string())
```


Closes #1176 