### PR TITLE
Added hash embeddings with hashing trick

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -556,7 +556,6 @@ class HashEmbeddings(TokenEmbeddings):
         self.__embedding_length = embedding_length
 
         self.__hash_method = hash_method
-        self.__hash_function = hashlib.new(hash_method)
 
         # model architecture
         self.embedding_layer = torch.nn.Embedding(
@@ -578,8 +577,9 @@ class HashEmbeddings(TokenEmbeddings):
     def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
 
         def get_idx_for_item(text):
-            self.__hash_function.update(bytes(str(text), 'utf-8'))
-            return int(self.__hash_function.hexdigest(), 16) % self.__num_embeddings
+            hash_function = hashlib.new(self.__hash_method)
+            hash_function.update(bytes(str(text), 'utf-8'))
+            return int(self.hash_function.hexdigest(), 16) % self.__num_embeddings
 
         hash_sentences = []
         for i, sentence in enumerate(sentences):

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -590,7 +590,7 @@ class HashEmbeddings(TokenEmbeddings):
         def get_idx_for_item(text):
             hash_function = hashlib.new(self.__hash_method)
             hash_function.update(bytes(str(text), 'utf-8'))
-            return int(self.hash_function.hexdigest(), 16) % self.__num_embeddings
+            return int(hash_function.hexdigest(), 16) % self.__num_embeddings
 
         hash_sentences = []
         for i, sentence in enumerate(sentences):

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -7,6 +7,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import List, Union, Dict
 
+import hashlib
+
 import gensim
 import numpy as np
 import torch
@@ -534,6 +536,76 @@ class OneHotEmbeddings(TokenEmbeddings):
 
     def extra_repr(self):
         return "min_freq={}".format(self.min_freq)
+
+
+class HashEmbeddings(TokenEmbeddings):
+    """Standard embeddings with Hashing Trick."""
+
+    def __init__(
+        self,
+        num_embeddings: int = 1000,
+        embedding_length: int = 300,
+        hash_method='md5'
+    ):
+
+        super().__init__()
+        self.name = "hash"
+        self.static_embeddings = False
+
+        self.__num_embeddings = num_embeddings
+        self.__embedding_length = embedding_length
+
+        self.__hash_method = hash_method
+        self.__hash_function = hashlib.new(hash_method)
+
+        # model architecture
+        self.embedding_layer = torch.nn.Embedding(
+            self.__num_embeddings, self.__embedding_length
+        )
+        torch.nn.init.xavier_uniform_(self.embedding_layer.weight)
+
+        self.to(flair.device)
+
+
+    @property
+    def num_embeddings(self) -> int:
+        return self.__num_embeddings
+
+    @property
+    def embedding_length(self) -> int:
+        return self.__embedding_length
+
+    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+
+        def get_idx_for_item(text):
+            self.__hash_function.update(bytes(str(text), 'utf-8'))
+            return int(self.__hash_function.hexdigest(), 16) % self.__num_embeddings
+
+        hash_sentences = []
+        for i, sentence in enumerate(sentences):
+            context_idxs = [
+                get_idx_for_item(t.text) for t in sentence.tokens
+            ]
+
+            hash_sentences.extend(context_idxs)
+
+        hash_sentences = torch.tensor(hash_sentences, dtype=torch.long).to(
+            flair.device
+        )
+
+        embedded = self.embedding_layer.forward(hash_sentences)
+
+        index = 0
+        for sentence in sentences:
+            for token in sentence:
+                embedding = embedded[index]
+                token.set_embedding(self.name, embedding)
+                index += 1
+
+        return sentences
+
+    def __str__(self):
+        return self.name
 
 
 class MuseCrosslingualEmbeddings(TokenEmbeddings):


### PR DESCRIPTION
I tried to make a pull request before, but failed twice, since I couldn't do a proper merge from my master. Thus, I killed my fork and created a new one. Hopefully it will work better this time.

I have added hash embeddings using the hashing trick, see for example https://en.wikipedia.org/wiki/Feature_hashing#Feature_vectorization_using_hashing_trick

This code snippet explains how the suggested feature could be used:

from flair.embeddings import HashEmbeddings

word_embedding = HashEmbeddings()
sentence = corpus.train[0]
word_embedding.embed(sentence)

for token in sentence:
print(token)
print(token.embedding)

