### PR TITLE
Add Japanese tokenizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 python:
   - "3.6"
 install:
-  - apt install mecab libmecab-dev mecab-ipadic
+  - sudo apt install mecab libmecab-dev mecab-ipadic
   - python setup.py develop -q
 before_script: cd tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
 python:
   - "3.6"
 install:
+  - sudo apt update -y
   - sudo apt install mecab libmecab-dev mecab-ipadic
   - python setup.py develop -q
 before_script: cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
 python:
   - "3.6"
 install:
+  - apt install mecab libmecab-dev mecab-ipadic
   - python setup.py develop -q
 before_script: cd tests
 script:

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 flair = {editable = true, path = "."}
-tiny-tokenizer = {extras = ["all"], version = "*"}
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 flair = {editable = true, path = "."}
+tiny-tokenizer = {extras = ["all"], version = "*"}
 
 [dev-packages]
 pytest = "*"

--- a/flair/data.py
+++ b/flair/data.py
@@ -428,9 +428,9 @@ def space_tokenizer(text: str) -> List[Token]:
     return tokens
 
 
-def build_tiny_tokenizer():
+def build_tiny_tokenizer(tokenizer: str = "MeCab"):
     sentence_tokenizer = SentenceTokenizer()
-    word_tokenizer = WordTokenizer('MeCab')
+    word_tokenizer = WordTokenizer(tokenizer)
 
     def tokenizer(text: str) -> List[Token]:
         """

--- a/flair/data.py
+++ b/flair/data.py
@@ -428,7 +428,10 @@ def space_tokenizer(text: str) -> List[Token]:
     return tokens
 
 
-def build_tiny_tokenizer(tokenizer: str = "MeCab"):
+def build_japanese_tokenizer(tokenizer: str = "MeCab"):
+    if tokenizer.lower() != "mecab":
+        raise NotImplementedError("Currently, MeCab is only supported.")
+
     sentence_tokenizer = SentenceTokenizer()
     word_tokenizer = WordTokenizer(tokenizer)
 

--- a/flair/data.py
+++ b/flair/data.py
@@ -9,6 +9,9 @@ import logging
 from collections import Counter
 from collections import defaultdict
 
+from tiny_tokenizer import WordTokenizer
+from tiny_tokenizer import SentenceTokenizer
+
 from segtok.segmenter import split_single
 from segtok.tokenizer import split_contractions
 from segtok.tokenizer import word_tokenizer
@@ -423,6 +426,53 @@ def space_tokenizer(text: str) -> List[Token]:
             Token(text=word, start_position=start_position, whitespace_after=False)
         )
     return tokens
+
+
+def build_tiny_tokenizer():
+    sentence_tokenizer = SentenceTokenizer()
+    word_tokenizer = WordTokenizer('MeCab')
+
+    def tokenizer(text: str) -> List[Token]:
+        """
+        Tokenizer using tiny_tokenizer, a third party library which supports
+        multiple Japanese tokenizer such as MeCab, KyTea and SudachiPy.
+        """
+        tokens: List[Token] = []
+        words: List[str] = []
+
+        sentences = sentence_tokenizer.tokenize(text)
+        for sentence in sentences:
+            tiny_tokenizer_tokens = word_tokenizer.tokenize(sentence)
+            words.extend(list(map(str, tiny_tokenizer_tokens)))
+
+        # determine offsets for whitespace_after field
+        index = text.index
+        current_offset = 0
+        previous_word_offset = -1
+        previous_token = None
+        for word in words:
+            try:
+                word_offset = index(word, current_offset)
+                start_position = word_offset
+            except:
+                word_offset = previous_word_offset + 1
+                start_position = (
+                    current_offset + 1 if current_offset > 0 else current_offset
+                )
+
+            token = Token(text=word, start_position=start_position, whitespace_after=True)
+            tokens.append(token)
+
+            if (previous_token is not None) and word_offset - 1 == previous_word_offset:
+                previous_token.whitespace_after = False
+
+            current_offset = word_offset + len(word)
+            previous_word_offset = current_offset - 1
+            previous_token = token
+
+        return tokens
+
+    return tokenizer
 
 
 def segtok_tokenizer(text: str) -> List[Token]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ langdetect
 torchvision
 ipython==7.6.1
 ipython-genutils==0.2.0
+tiny_tokenizer[all]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -47,9 +47,7 @@ def test_create_sentence_without_tokenizer():
 
 
 def test_create_sentence_using_japanese_tokenizer():
-    sentence: Sentence = Sentence(
-        "私はベルリンが好き",
-        use_tokenizer=build_japanese_tokenizer())
+    sentence: Sentence = Sentence("私はベルリンが好き", use_tokenizer=build_japanese_tokenizer())
 
     assert 5 == len(sentence.tokens)
     assert "私" == sentence.tokens[0].text

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,6 +12,7 @@ from flair.data import (
     Corpus,
     Span,
     segtok_tokenizer,
+    build_japanese_tokenizer,
 )
 
 
@@ -43,6 +44,19 @@ def test_create_sentence_without_tokenizer():
     assert "I" == sentence.tokens[0].text
     assert "love" == sentence.tokens[1].text
     assert "Berlin." == sentence.tokens[2].text
+
+
+def test_create_sentence_using_japanese_tokenizer():
+    sentence: Sentence = Sentence(
+        "私はベルリンが好き",
+        use_tokenizer=build_japanese_tokenizer())
+
+    assert 5 == len(sentence.tokens)
+    assert "私" == sentence.tokens[0].text
+    assert "は" == sentence.tokens[1].text
+    assert "ベルリン" == sentence.tokens[2].text
+    assert "が" == sentence.tokens[3].text
+    assert "好き" == sentence.tokens[4].text
 
 
 def test_token_indices():


### PR DESCRIPTION
This PR introduces support for Japanese tokenizer.
Japanese is a language that needs to segment a sentence into words.
It is done by several morphological analyzers such as MeCab, Kytea, Sudachi, and so on.

Users may want to use a different analyzer to compare analyzers and
select which tokenizer to use. (researcher may want to do this)
In this case, users have to pre-tokenize whole sentences for each analyzer
to feed into `flair.data.Sentence`, which is a little bit of cost consuming.

Currently, I'm developing `tiny_tokenizer` (https://github.com/himkt/tiny_tokenizer),
which is a wrapper of these morphological analyzers.
`tiny_tokenizer` unifies an interface to create `Tokenizer` and tokenize API.
Introducing `tiny_tokenizer`, we can deal with various morphological analyzers.

### example
This is the example of tiny_tokenizer.

```python
from flair.data import build_japanese_tokenizer
from flair.data import Sentence


tokenizer = build_japanese_tokenizer()
sentence = Sentence(
    "私はベルリンが好きです。まだ行ったことはありません。",
    use_tokenizer=tokenizer)
print(sentence)
```

### output

```
(pipenv) $ pipenv run python demo.py
私はベルリンが好きです。まだ行ったことはありません。
Sentence: "私 は ベルリン が 好き です 。 まだ 行っ た こと は あり ませ ん 。" - 16 Tokens
```

I want to ask flair developers whether this PR has a value.
~If it is valuable, I'll add tests. (and please give me reviews 🙇)~
[edited] I added a test.

### Note

This feature needs MeCab, KyTea and SudachiPy.
If you want to use MeCab, please run:

- ubuntu

```
sudo apt install mecab mecab-ipadic libmecab-dev
```

- mac [edited]

```
brew install mecab mecab-ipadic
```

Thanks!