### PR TITLE
Fix tokenizer insert empty token to sentence object

### DIFF
--- a/flair/data.py
+++ b/flair/data.py
@@ -453,8 +453,11 @@ def segtok_tokenizer(text: str) -> List[Token]:
                 current_offset + 1 if current_offset > 0 else current_offset
             )
 
-        token = Token(text=word, start_position=start_position, whitespace_after=True)
-        tokens.append(token)
+        if word:
+            token = Token(text=word,
+                          start_position=start_position,
+                          whitespace_after=True)
+            tokens.append(token)
 
         if (previous_token is not None) and word_offset - 1 == previous_word_offset:
             previous_token.whitespace_after = False


### PR DESCRIPTION
Fix [issue#1188](https://github.com/zalandoresearch/flair/issues/1188)
This issue is about tokenizer of segtok library.
In segtok, `someword`+ `n't`, e.g. `don't`, `didn't`...
It will be tokenized as `someword` and `n't`.
However, if user has split it, it will insert empty between `someword` and `n't`.
Example:
"do n't" -> "do", "", "n't"
"did n't" -> "did", "", "n't"

**To Reproduce**
```python
from flair.data import segtok_tokenizer

text = r'do n’t'
tokens = segtok_tokenizer(text)
print(tokens) #[Token: do, Token: , Token: n’t]
```

This commit fix this problem.