### PR TITLE
Add support for CamemBERT embeddings

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -25,6 +25,8 @@ from torch.nn import TransformerEncoderLayer, TransformerEncoder
 from transformers import (
     BertTokenizer,
     BertModel,
+    CamembertTokenizer,
+    CamembertModel,
     RobertaTokenizer,
     RobertaModel,
     TransfoXLTokenizer,
@@ -1529,6 +1531,78 @@ class RoBERTaEmbeddings(TokenEmbeddings):
         embedded_dummy = self.embed(dummy_sentence)
         self.__embedding_length: int = len(
             embedded_dummy[0].get_token(1).get_embedding()
+        )
+
+    @property
+    def embedding_length(self) -> int:
+        return self.__embedding_length
+
+    def _add_embeddings_internal(self, sentences: List[Sentence]) -> List[Sentence]:
+        self.model.to(flair.device)
+        self.model.eval()
+
+        sentences = _get_transformer_sentence_embeddings(
+            sentences=sentences,
+            tokenizer=self.tokenizer,
+            model=self.model,
+            name=self.name,
+            layers=self.layers,
+            pooling_operation=self.pooling_operation,
+            use_scalar_mix=self.use_scalar_mix,
+            bos_token="<s>",
+            eos_token="</s>",
+        )
+
+        return sentences
+
+
+class CamembertEmbeddings(TokenEmbeddings):
+    def __init__(
+        self,
+        pretrained_model_name_or_path: str = "camembert-base",
+        layers: str = "-1",
+        pooling_operation: str = "first",
+        use_scalar_mix: bool = False,
+    ):
+        """CamemBERT, a Tasty French Language Model, as proposed by Martin et al. 2019.
+        :param pretrained_model_name_or_path: name or path of RoBERTa model
+        :param layers: comma-separated list of layers
+        :param pooling_operation: defines pooling operation for subwords
+        :param use_scalar_mix: defines the usage of scalar mix for specified layer(s)
+        """
+        super().__init__()
+
+        self.tokenizer = CamembertTokenizer.from_pretrained(
+            pretrained_model_name_or_path
+        )
+        self.model = CamembertModel.from_pretrained(
+            pretrained_model_name_or_path=pretrained_model_name_or_path,
+            output_hidden_states=True,
+        )
+        self.name = pretrained_model_name_or_path
+        self.layers: List[int] = [int(layer) for layer in layers.split(",")]
+        self.pooling_operation = pooling_operation
+        self.use_scalar_mix = use_scalar_mix
+        self.static_embeddings = True
+
+        dummy_sentence: Sentence = Sentence()
+        dummy_sentence.add_token(Token("hello"))
+        embedded_dummy = self.embed(dummy_sentence)
+        self.__embedding_length: int = len(
+            embedded_dummy[0].get_token(1).get_embedding()
+        )
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["tokenizer"] = None
+        return state
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+
+        # 1-camembert-base -> camembert-base
+        self.tokenizer = self.tokenizer = CamembertTokenizer.from_pretrained(
+            "-".join(self.name.split("-")[1:])
         )
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ sklearn
 sqlitedict>=1.6.0
 deprecated>=1.2.4
 hyperopt>=0.1.1
-transformers>=2.0.0
+transformers>=2.2.0
 bpemb>=0.2.9
 regex
 tabulate

--- a/resources/docs/embeddings/TRANSFORMER_EMBEDDINGS.md
+++ b/resources/docs/embeddings/TRANSFORMER_EMBEDDINGS.md
@@ -12,6 +12,7 @@ The following embeddings can be used in Flair:
 * `XLNetEmbeddings`
 * `XLMEmbeddings`
 * `RoBERTaEmbeddings`
+* `CamembertEmbeddings`
 
 This section shows how to use these Transformer-based architectures in Flair and is heavily based on the excellent
 [Transformers pre-trained models documentation](https://huggingface.co/transformers/pretrained_models.html).
@@ -314,7 +315,7 @@ The following arguments can be passed to the `RoBERTaEmbeddings` class:
 | `pooling_operation`             | `first`         | [Pooling operation section](#Pooling-operation)
 | `use_scalar_mix`                | `False`         | [Scalar mix section](#Scalar-mix)
 
-Following XLM models can be used:
+Following RoBERTa models can be used:
 
 | Model                | Details
 | -------------------- | -------------------------------------------------------------------------------------------------------
@@ -324,6 +325,42 @@ Following XLM models can be used:
 |                      | RoBERTa English model
 | `roberta-large-mnli` | 24-layer, 1024-hidden, 16-heads
 |                      | RoBERTa English model, finetuned on MNLI
+
+## CamemBERT Embeddings
+
+CamemBERT (a Tasty French Language Model) model was proposed by [Martin et. al (2019)](https://arxiv.org/abs/1911.03894),
+and was trained on a large French corpus.
+
+It can be used with the `CamembertEmbeddings` class:
+
+```python
+from flair.embeddings import CamembertEmbeddings
+
+# init embedding
+embedding = CamembertEmbeddings()
+
+# create a sentence
+sentence = Sentence("J'aime le camembert !")
+
+# embed words in sentence
+embedding.embed(sentence)
+```
+
+The following arguments can be passed to the `CamembertEmbeddings` class:
+
+| Argument                        | Default          | Description
+| ------------------------------- | ---------------- | ------------------------------------------------------------
+| `pretrained_model_name_or_path` | `camembert-base` | Defines name or path of CamemBERT model
+| `layers`                        | `-1`             | Defines the to be used layers of the Transformer-based model
+| `pooling_operation`             | `first`          | [Pooling operation section](#Pooling-operation)
+| `use_scalar_mix`                | `False`          | [Scalar mix section](#Scalar-mix)
+
+Following CamemBERT models can be used:
+
+| Model                | Details
+| -------------------- | -----------------------------------------------
+| `camembert-base`     | 12-layer, 768-hidden, 12-heads, 110M parameters
+|                      | CamemBERT using the RoBERTa-base architecture
 
 ### Pooling operation
 


### PR DESCRIPTION
Hi,

this PR adds support for the recently proposed French language model: CamemBERT.

Thanks to the awesome 🤗/Transformers library, CamemBERT can be used in Flair like in this example:

```python
from flair.data import Sentence
from flair.embeddings import CamembertEmbeddings

embedding = CamembertEmbeddings()

sentence = Sentence("J'aime le camembert !")
embedding.embed(sentence)

for token in sentence.tokens:
  print(token.embedding)
```

PR comes with:

* [x] new embedding layer: `CamembertEmbeddings`
* [x] documentation update
* [x] unit tests
* [x] upgrade 🤗/Transformers version to latest *2.2.0* release

I'll add an evaluation on WikiNER soon. Closes #1276.
 
![camembert](https://user-images.githubusercontent.com/20651387/69766258-7fbb8e80-1177-11ea-8c28-2794adc74ba2.png)