### PR TITLE
GH-1298: removed torchvision from requirements

### DIFF
--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -12,7 +12,6 @@ import hashlib
 import gensim
 import numpy as np
 import torch
-import torchvision as torchvision
 from bpemb import BPEmb
 from deprecated import deprecated
 
@@ -3178,6 +3177,18 @@ class PrecomputedImageEmbeddings(ImageEmbeddings):
 class NetworkImageEmbeddings(ImageEmbeddings):
     def __init__(self, name, pretrained=True, transforms=None):
         super().__init__()
+
+        try:
+            import torchvision as torchvision
+        except ModuleNotFoundError:
+            log.warning("-" * 100)
+            log.warning('ATTENTION! The library "torchvision" is not installed!')
+            log.warning(
+                'To use convnets pretraned on ImageNet, please first install with "pip install torchvision"'
+            )
+            log.warning("-" * 100)
+            pass
+
         model_info = {
             "resnet50": (torchvision.models.resnet50, lambda x: list(x)[:-1], 2048),
             "mobilenet_v2": (

--- a/flair/embeddings.py
+++ b/flair/embeddings.py
@@ -48,7 +48,6 @@ from .nn import LockedDropout, WordDropout
 from .data import Dictionary, Token, Sentence, Image
 from .file_utils import cached_path, open_inside_zip
 
-import PIL
 
 log = logging.getLogger("flair")
 
@@ -3129,6 +3128,8 @@ class NILCEmbeddings(WordEmbeddings):
 
 class IdentityImageEmbeddings(ImageEmbeddings):
     def __init__(self, transforms):
+        import PIL as pythonimagelib
+        self.PIL = pythonimagelib
         self.name = "Identity"
         self.transforms = transforms
         self.__embedding_length = None
@@ -3137,7 +3138,7 @@ class IdentityImageEmbeddings(ImageEmbeddings):
 
     def _add_embeddings_internal(self, images: List[Image]) -> List[Image]:
         for image in images:
-            image_data = PIL.Image.open(image.imageURL)
+            image_data = self.PIL.Image.open(image.imageURL)
             image_data.load()
             image.set_embedding(self.name, self.transforms(image_data))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ regex
 tabulate
 urllib3<1.25,>=1.20
 langdetect
-torchvision


### PR DESCRIPTION
This fixes the problem of having `torchvision` in `requirements.txt`. Now it is loaded only when needed.