### PR TITLE
Add label clearning heuristic to TARS

### DIFF
--- a/flair/models/tars_model.py
+++ b/flair/models/tars_model.py
@@ -852,7 +852,7 @@ class TARSClassifier(FewshotClassifier):
 
                     # only use label with highest confidence if enforcing single-label predictions
                     if not multi_label:
-                        if len(sentence.get_labels()) > 0:
+                        if len(sentence.get_labels(label_name)) > 0:
 
                             # get all label scores and do an argmax to get the best label
                             label_scores = torch.tensor([label.score for label in sentence.get_labels(label_name)],


### PR DESCRIPTION
The refactoring removed a heuristic in which underscores were removed from label names. This PR adds this back in.