### PR TITLE
fix: correct link to  script in bug report template for GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -68,7 +68,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Please run the [collect_env.py](../blob/master/collect_env.py) and paste it's output in here
+      description: Please run the [collect_env.py](../../collect_env.py) and paste it's output in here
       placeholder: python collect_env.py
     validations:
       required: true


### PR DESCRIPTION
Hi,

the current link to the `collect_env.py` script in the bug report issue template is broken - this PR fixes it :)