### PR TITLE
Diagram visualization of the flair codebase

### DIFF
--- a/.codeboarding/flair_data_Corpus.md
+++ b/.codeboarding/flair_data_Corpus.md
@@ -1,0 +1,217 @@
+```mermaid
+
+graph LR
+
+    Corpus_Core_Management["Corpus Core Management"]
+
+    Data_Sampling_and_Splitting["Data Sampling and Splitting"]
+
+    Data_Filtering["Data Filtering"]
+
+    Vocabulary_and_Label_Dictionary_Generation["Vocabulary and Label Dictionary Generation"]
+
+    Corpus_Statistics["Corpus Statistics"]
+
+    Label_Noise_Injection["Label Noise Injection"]
+
+    Overall_Corpus_Access["Overall Corpus Access"]
+
+    Corpus_Core_Management -- "Uses" --> Data_Sampling_and_Splitting
+
+    Corpus_Core_Management -- "Uses" --> Data_Filtering
+
+    Corpus_Core_Management -- "Uses" --> Vocabulary_and_Label_Dictionary_Generation
+
+    Corpus_Core_Management -- "Uses" --> Corpus_Statistics
+
+    Corpus_Core_Management -- "Uses" --> Label_Noise_Injection
+
+    Corpus_Core_Management -- "Uses" --> Overall_Corpus_Access
+
+    Data_Sampling_and_Splitting -- "Modifies" --> Corpus_Core_Management
+
+    Data_Filtering -- "Modifies" --> Corpus_Core_Management
+
+    Vocabulary_and_Label_Dictionary_Generation -- "Uses" --> Corpus_Core_Management
+
+    Corpus_Statistics -- "Analyzes" --> Corpus_Core_Management
+
+    Label_Noise_Injection -- "Modifies" --> Corpus_Core_Management
+
+    Overall_Corpus_Access -- "Aggregates" --> Corpus_Core_Management
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `flair.data.Corpus` subsystem is a foundational component within the Flair framework, designed to efficiently manage and process datasets for various Natural Language Processing (NLP) tasks. Its core purpose is to encapsulate the training, development, and testing data splits, providing a unified interface for data manipulation, preparation, and analysis.
+
+
+
+### Corpus Core Management
+
+This is the central `Corpus` class itself, responsible for initializing, storing, and providing access to the train, development, and test dataset splits. It serves as the primary entry point for all data-related operations within the Flair framework.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2352-L2419" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.__init__` (2352:2419)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2422-L2424" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.train` (2422:2424)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2427-L2429" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.dev` (2427:2429)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2432-L2434" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.test` (2432:2434)</a>
+
+
+
+
+
+### Data Sampling and Splitting
+
+This component handles the dynamic adjustment of dataset splits. It can sample missing development or test sets from the training data during corpus initialization and provides methods for downsampling existing splits to a specified percentage. This ensures a complete dataset for training and facilitates experimentation with smaller subsets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2352-L2419" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.__init__` (2352:2419)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2445-L2478" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.downsample` (2445:2478)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2590-L2594" target="_blank" rel="noopener noreferrer">`flair.data.Corpus._downsample_to_proportion` (2590:2594)</a>
+
+
+
+
+
+### Data Filtering
+
+Focuses on data quality by providing utilities to clean the corpus. It can remove sentences that are empty (contain no tokens) or sentences that exceed a specified maximum character length. This helps in maintaining data integrity and preventing issues during model training.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2480-L2492" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.filter_empty_sentences` (2480:2492)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2494-L2509" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.filter_long_sentences` (2494:2509)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2530-L2544" target="_blank" rel="noopener noreferrer">`flair.data.Corpus._filter_empty_sentences` (2530:2544)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2512-L2527" target="_blank" rel="noopener noreferrer">`flair.data.Corpus._filter_long_sentences` (2512:2527)</a>
+
+
+
+
+
+### Vocabulary and Label Dictionary Generation
+
+This component is crucial for converting textual data and its associated labels into numerical representations that machine learning models can process. It generates `Dictionary` objects that map unique tokens (vocabulary) or unique label values to integer IDs, considering frequency thresholds.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2546-L2569" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.make_vocab_dictionary` (2546:2569)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2687-L2793" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.make_label_dictionary` (2687:2793)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2571-L2580" target="_blank" rel="noopener noreferrer">`flair.data.Corpus._get_most_common_tokens` (2571:2580)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2582-L2587" target="_blank" rel="noopener noreferrer">`flair.data.Corpus._get_all_tokens` (2582:2587)</a>
+
+
+
+
+
+### Corpus Statistics
+
+Provides analytical capabilities to obtain detailed statistics about the corpus. This includes information on the total number of documents, the distribution of documents per class, token counts per tag, and sentence length statistics. These statistics are vital for understanding the dataset's characteristics and for debugging.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2596-L2618" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.obtain_statistics` (2596:2618)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2621-L2644" target="_blank" rel="noopener noreferrer">`flair.data.Corpus._obtain_statistics_for` (2621:2644)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2647-L2649" target="_blank" rel="noopener noreferrer">`flair.data.Corpus._get_tokens_per_sentence` (2647:2649)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2652-L2658" target="_blank" rel="noopener noreferrer">`flair.data.Corpus._count_sentence_labels` (2652:2658)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2661-L2677" target="_blank" rel="noopener noreferrer">`flair.data.Corpus._count_token_labels` (2661:2677)</a>
+
+
+
+
+
+### Label Noise Injection
+
+Offers a specialized utility to artificially introduce noise into the labels of a specified dataset split. This is particularly useful for research purposes, such as evaluating the robustness of models to noisy training data or simulating real-world data imperfections.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2795-L2889" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.add_label_noise` (2795:2889)</a>
+
+
+
+
+
+### Overall Corpus Access
+
+Provides a convenient way to access all sentences across all three splits (train, dev, and test) as a single concatenated dataset. This is useful for operations that need to iterate over the entire corpus without distinguishing between individual splits.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2905-L2918" target="_blank" rel="noopener noreferrer">`flair.data.Corpus.get_all_sentences` (2905:2918)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/flair_data_DataPoint.md
+++ b/.codeboarding/flair_data_DataPoint.md
@@ -1,0 +1,117 @@
+```mermaid
+
+graph LR
+
+    DataPoint["DataPoint"]
+
+    Label["Label"]
+
+    torch_Tensor["torch.Tensor"]
+
+    flair_device["flair.device"]
+
+    DataPoint -- "composes" --> Label
+
+    DataPoint -- "utilizes" --> torch_Tensor
+
+    DataPoint -- "interacts with" --> flair_device
+
+    Label -- "is composed by" --> DataPoint
+
+    torch_Tensor -- "is utilized by" --> DataPoint
+
+    flair_device -- "is interacted with by" --> DataPoint
+
+    click DataPoint href "https://github.com/flairNLP/flair/blob/master/.codeboarding//DataPoint.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Analysis of the `flair.data.DataPoint` subsystem focusing on its fundamental, direct interactions within the Flair framework.
+
+
+
+### DataPoint
+
+The foundational abstract base class for all data units in Flair (e.g., `Token`, `Sentence`). It defines the common interface for storing embeddings, managing various annotation layers, and providing basic textual and positional information, ensuring a consistent way to attach numerical representations and symbolic labels.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L413-L706" target="_blank" rel="noopener noreferrer">`flair.data.DataPoint` (413:706)</a>
+
+
+
+
+
+### Label
+
+Represents a single annotation or label associated with a `DataPoint`. It encapsulates the label's string value, a confidence score, and any additional metadata. It is a core building block for the annotation system within Flair, directly instantiated and managed by `DataPoint`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L310-L410" target="_blank" rel="noopener noreferrer">`flair.data.Label` (310:410)</a>
+
+
+
+
+
+### torch.Tensor
+
+A multi-dimensional matrix containing elements of a single data type, provided by the PyTorch library. In the context of `DataPoint`, `torch.Tensor` is the fundamental data structure used to store numerical embeddings, which are the vectorized representations of the data point.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `torch.Tensor` (1:1)
+
+
+
+
+
+### flair.device
+
+A global object or mechanism within Flair that manages the computational device (CPU or GPU) on which tensors and models operate. It ensures that operations are performed on the correct hardware for efficiency and proper execution within the PyTorch ecosystem.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `flair.device` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/flair_embeddings_base_Embeddings.md
+++ b/.codeboarding/flair_embeddings_base_Embeddings.md
@@ -1,0 +1,221 @@
+```mermaid
+
+graph LR
+
+    Embeddings["Embeddings"]
+
+    embed["embed"]
+
+    _add_embeddings_internal["_add_embeddings_internal"]
+
+    _everything_embedded["_everything_embedded"]
+
+    from_params["from_params"]
+
+    to_params["to_params"]
+
+    load_embedding["load_embedding"]
+
+    save_embeddings["save_embeddings"]
+
+    Embeddings -- "defines" --> embed
+
+    Embeddings -- "defines (abstract)" --> _add_embeddings_internal
+
+    Embeddings -- "defines (abstract)" --> from_params
+
+    Embeddings -- "defines (abstract)" --> to_params
+
+    Embeddings -- "inherits from" --> torch_nn_Module
+
+    embed -- "calls" --> _everything_embedded
+
+    embed -- "calls" --> _add_embeddings_internal
+
+    _add_embeddings_internal -- "implemented by" --> ConcreteEmbeddingsSubclass
+
+    _everything_embedded -- "called by" --> embed
+
+    from_params -- "called by" --> load_embedding
+
+    from_params -- "implemented by" --> ConcreteEmbeddingsSubclass
+
+    to_params -- "called by" --> save_embeddings
+
+    to_params -- "implemented by" --> ConcreteEmbeddingsSubclass
+
+    load_embedding -- "calls" --> from_params
+
+    load_embedding -- "calls" --> torch_nn_Module_load_state_dict
+
+    save_embeddings -- "calls" --> to_params
+
+    save_embeddings -- "calls" --> torch_nn_Module_state_dict
+
+    click Embeddings href "https://github.com/flairNLP/flair/blob/master/.codeboarding//Embeddings.md" "Details"
+
+    click embed href "https://github.com/flairNLP/flair/blob/master/.codeboarding//embed.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This subsystem revolves around the `Embeddings` abstract base class, which serves as the foundational blueprint for all embedding models within the Flair framework. It establishes a consistent interface for embedding data points and provides mechanisms for model persistence.
+
+
+
+### Embeddings
+
+The abstract base class for all embedding modules in Flair. It defines the `embed` method, which takes `DataPoint` objects (typically `Sentence` or `Token`) and populates them with dense vector representations, handling whether embeddings are static or need recomputation. It also provides abstract methods for concrete implementations to define their specific embedding logic and serialization/deserialization.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L15-L104" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.Embeddings` (15:104)</a>
+
+
+
+
+
+### embed
+
+The primary public method of the `Embeddings` class. It takes a single `DataPoint` or a list of `DataPoint` objects and orchestrates the process of populating them with embeddings. It intelligently checks for existing embeddings to prevent redundant computations and delegates the actual embedding logic to `_add_embeddings_internal`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L40-L52" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.Embeddings:embed` (40:52)</a>
+
+
+
+
+
+### _add_embeddings_internal
+
+This is an abstract private method that *must* be implemented by any concrete subclass of `Embeddings`. It encapsulates the specific logic for computing and adding the particular type of embeddings to the provided data points. This design enforces that each embedding type defines its own unique embedding mechanism.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L58-L59" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.Embeddings:_add_embeddings_internal` (58:59)</a>
+
+
+
+
+
+### _everything_embedded
+
+A private helper method within the `Embeddings` class. Its responsibility is to efficiently check if all data points in a given sequence already have embeddings associated with them under the current embedding's name. This check is crucial for optimizing performance by preventing redundant and computationally expensive embedding computations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L54-L55" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.Embeddings:_everything_embedded` (54:55)</a>
+
+
+
+
+
+### from_params
+
+An abstract class method responsible for reconstructing an `Embeddings` object from a dictionary of parameters. This method is crucial for deserialization, enabling pre-trained embedding models to be loaded from saved configurations. Concrete embedding classes must provide their own implementation for parameter-based instantiation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L84-L85" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.Embeddings:from_params` (84:85)</a>
+
+
+
+
+
+### to_params
+
+An abstract method that serializes the embedding object's parameters into a dictionary. This is essential for saving the model's configuration and state, enabling persistence and later reconstruction. Concrete embedding classes must implement this method to define how their parameters are represented.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L87-L88" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.Embeddings:to_params` (87:88)</a>
+
+
+
+
+
+### load_embedding
+
+A class method that facilitates loading an embedding model. It takes a dictionary of parameters, potentially including a `state_dict`, and uses `from_params` to create an instance, then loads the state if provided. This method streamlines the process of loading pre-trained models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L91-L97" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.Embeddings:load_embedding` (91:97)</a>
+
+
+
+
+
+### save_embeddings
+
+This method is responsible for saving the embedding model's parameters and optionally its `state_dict`. It utilizes `to_params` to retrieve the model's configuration and includes the `state_dict` if specified. This method is vital for persisting trained or pre-trained embedding models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L99-L104" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.Embeddings:save_embeddings` (99:104)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/flair_nn_model_Model.md
+++ b/.codeboarding/flair_nn_model_Model.md
@@ -1,0 +1,171 @@
+```mermaid
+
+graph LR
+
+    Model_Management_Component["Model Management Component"]
+
+    File_Utility_Component["File Utility Component"]
+
+    Class_Utility_Component["Class Utility Component"]
+
+    Embeddings_Loading_Component["Embeddings Loading Component"]
+
+    Data_Handling_Component["Data Handling Component"]
+
+    Training_Utilities_Component["Training Utilities Component"]
+
+    Model_Management_Component -- "depends on" --> File_Utility_Component
+
+    Model_Management_Component -- "depends on" --> Class_Utility_Component
+
+    Model_Management_Component -- "depends on" --> Embeddings_Loading_Component
+
+    Model_Management_Component -- "depends on" --> Data_Handling_Component
+
+    Model_Management_Component -- "interacts with" --> Training_Utilities_Component
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `flair.nn.model.Model` serves as the abstract foundation for all neural network models within the Flair framework, specifically those designed for downstream NLP tasks. It establishes a unified interface and core functionalities for model lifecycle management, including training, evaluation, and persistence. Its design promotes modularity and extensibility, allowing various concrete NLP models to inherit and implement specific task logic while adhering to a common structure.
+
+
+
+### Model Management Component
+
+This is the central abstract component, embodied by `flair.nn.model.Model`. It defines the contract for all Flair neural network models, requiring implementations for `forward_loss` (training) and `evaluate` (performance assessment). It also manages model persistence (saving/loading of parameters, optimizer/scheduler states, and tokenizer information) and provides a mechanism for dynamic model discovery and loading.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/nn/model.py#L30-L448" target="_blank" rel="noopener noreferrer">`flair.nn.model.Model` (30:448)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/nn/model.py#L81-L86" target="_blank" rel="noopener noreferrer">`flair.nn.model.Model:forward_loss` (81:86)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/nn/model.py#L89-L123" target="_blank" rel="noopener noreferrer">`flair.nn.model.Model:evaluate` (89:123)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/nn/model.py#L275-L289" target="_blank" rel="noopener noreferrer">`flair.nn.model.Model:save` (275:289)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/nn/model.py#L310-L399" target="_blank" rel="noopener noreferrer">`flair.nn.model.Model:load` (310:399)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/nn/model.py#L193-L256" target="_blank" rel="noopener noreferrer">`flair.nn.model.Model:_init_model_with_state_dict` (193:256)</a>
+
+
+
+
+
+### File Utility Component
+
+This component provides essential utilities for file system interactions, particularly for loading and saving PyTorch model states (`.pt` files) and other data assets. It abstracts low-level file I/O, ensuring robust and consistent data persistence. The `Model` component directly utilizes `load_torch_state` for deserializing model files.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/file_utils.py#L377-L384" target="_blank" rel="noopener noreferrer">`flair.file_utils.load_torch_state` (377:384)</a>
+
+- `torch.save` (0:0)
+
+
+
+
+
+### Class Utility Component
+
+This component offers utilities for dynamic class discovery and manipulation, specifically `get_non_abstract_subclasses`. This capability is vital for the `Model.load()` method, allowing it to dynamically identify and instantiate the correct concrete model class from a saved state, even when the exact class is not explicitly known at compile time.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/class_utils.py#L13-L18" target="_blank" rel="noopener noreferrer">`flair.class_utils.get_non_abstract_subclasses` (13:18)</a>
+
+
+
+
+
+### Embeddings Loading Component
+
+This component is responsible for managing the loading, initialization, and preparation of various types of pre-trained embeddings (e.g., word, document, transformer embeddings). The `Model`'s internal initialization (`_init_model_with_state_dict`) calls `load_embeddings` to integrate these foundational linguistic representations, which are critical input features for most NLP models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L225-L228" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.load_embeddings` (225:228)</a>
+
+
+
+
+
+### Data Handling Component
+
+This component provides core data structures (`Sentence`, `Token`) and utilities for representing and manipulating textual data. The `Model`'s `forward_loss` and `evaluate` methods operate on these data structures, and the `Model` also manages an optional `Tokenizer` instance from this component for text preprocessing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L1177-L2141" target="_blank" rel="noopener noreferrer">`flair.data.Sentence` (1177:2141)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L814-L953" target="_blank" rel="noopener noreferrer">`flair.data.Token` (814:953)</a>
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L12-L63" target="_blank" rel="noopener noreferrer">`flair.tokenization.Tokenizer` (12:63)</a>
+
+
+
+
+
+### Training Utilities Component
+
+This component encapsulates common utilities and helper functions used across the training process. While `Model` itself doesn't directly implement the full training loop, it stores `optimizer_state_dict` and `scheduler_state_dict`, which are managed and utilized by higher-level training utilities (e.g., `flair.trainers.ModelTrainer`) from this component.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/training_utils.py#L0-L0" target="_blank" rel="noopener noreferrer">`flair.training_utils` (0:0)</a>
+
+- `flair.trainers.ModelTrainer` (0:0)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/flair_tokenization_Tokenizer.md
+++ b/.codeboarding/flair_tokenization_Tokenizer.md
@@ -1,0 +1,219 @@
+```mermaid
+
+graph LR
+
+    Tokenization_Module["Tokenization Module"]
+
+    Tokenizer_Class["Tokenizer Class"]
+
+    Tokenization_Method["Tokenization Method"]
+
+    Name_Property["Name Property"]
+
+    Serialization_Method["Serialization Method"]
+
+    Deserialization_Method["Deserialization Method"]
+
+    Equality_Comparison_Method["Equality Comparison Method"]
+
+    Hashing_Method["Hashing Method"]
+
+    Tokenization_Module -- "Contains" --> Tokenizer_Class
+
+    Tokenizer_Class -- "Part of" --> Tokenization_Module
+
+    Tokenizer_Class -- "Defines Interface" --> Tokenization_Method
+
+    Tokenizer_Class -- "Defines Property" --> Name_Property
+
+    Tokenizer_Class -- "Defines Interface" --> Serialization_Method
+
+    Tokenizer_Class -- "Defines Interface" --> Deserialization_Method
+
+    Tokenizer_Class -- "Implements" --> Equality_Comparison_Method
+
+    Tokenizer_Class -- "Implements" --> Hashing_Method
+
+    Equality_Comparison_Method -- "Uses" --> Serialization_Method
+
+    Hashing_Method -- "Uses" --> Serialization_Method
+
+    flair_data -- "Uses" --> Tokenization_Module
+
+    flair_datasets_base -- "Uses" --> Tokenization_Module
+
+    flair_datasets_biomedical -- "Uses" --> Tokenization_Module
+
+    flair_datasets_document_classification -- "Uses" --> Tokenization_Module
+
+    flair_datasets_sequence_labeling -- "Uses" --> Tokenization_Module
+
+    flair_datasets_text_text -- "Uses" --> Tokenization_Module
+
+    flair_splitter -- "Uses" --> Tokenization_Module
+
+    flair_models_relation_classifier_model -- "Uses" --> Tokenization_Module
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This overview details the core components of the `flair.tokenization.Tokenizer` subsystem, focusing on their structure, purpose, and interactions. The selected components are fundamental as they define the abstract contract for text tokenization within the Flair library, enabling extensibility and consistent handling of tokenizer instances.
+
+
+
+### Tokenization Module
+
+The top-level package (`flair.tokenization`) that encapsulates all text tokenization functionalities. It serves as the organizational container for the abstract `Tokenizer` class and its concrete implementations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L1-L64" target="_blank" rel="noopener noreferrer">`flair.tokenization` (1:64)</a>
+
+
+
+
+
+### Tokenizer Class
+
+An abstract base class (`ABC`) that defines the standard interface for all tokenizer implementations. It mandates the `tokenize`, `to_dict`, and `from_dict` methods, and provides default implementations for `__eq__` and `__hash__` for consistent object comparison and hashing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L12-L63" target="_blank" rel="noopener noreferrer">`flair.tokenization.Tokenizer` (12:63)</a>
+
+
+
+
+
+### Tokenization Method
+
+An abstract method within the `Tokenizer` class that concrete subclasses must implement. Its core purpose is to convert a raw text string into a list of string tokens.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L23-L24" target="_blank" rel="noopener noreferrer">`flair.tokenization.Tokenizer:tokenize` (23:24)</a>
+
+
+
+
+
+### Name Property
+
+A property of the `Tokenizer` class that provides a unique, human-readable identifier for a tokenizer's configuration. By default, it returns the class name but can be overridden for more specific naming.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L27-L28" target="_blank" rel="noopener noreferrer">`flair.tokenization.Tokenizer:name` (27:28)</a>
+
+
+
+
+
+### Serialization Method
+
+An abstract method that serializes the tokenizer's configuration and state into a dictionary. This method is crucial for defining the unique identity of a tokenizer instance, as its output is used for equality checks and hashing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L31-L37" target="_blank" rel="noopener noreferrer">`flair.tokenization.Tokenizer:to_dict` (31:37)</a>
+
+
+
+
+
+### Deserialization Method
+
+A class method that acts as a factory, reconstructing a `Tokenizer` object from a configuration dictionary. It complements the `to_dict` method, enabling the recreation of tokenizer instances from their serialized state.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L41-L43" target="_blank" rel="noopener noreferrer">`flair.tokenization.Tokenizer:from_dict` (41:43)</a>
+
+
+
+
+
+### Equality Comparison Method
+
+Defines how two `Tokenizer` objects are compared for equality. It relies on the `to_dict()` method to compare the serialized states, ensuring that equality is based on configuration rather than object identity.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L45-L50" target="_blank" rel="noopener noreferrer">`flair.tokenization.Tokenizer:__eq__` (45:50)</a>
+
+
+
+
+
+### Hashing Method
+
+Provides a hash value for `Tokenizer` objects, allowing them to be used in hash-based data structures. It computes the hash based on the sorted representation of the dictionary returned by `to_dict()`, ensuring consistent hashing for identical configurations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L52-L63" target="_blank" rel="noopener noreferrer">`flair.tokenization.Tokenizer:__hash__` (52:63)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,217 @@
+```mermaid
+
+graph LR
+
+    flair_data_DataPoint["flair.data.DataPoint"]
+
+    flair_data_Sentence["flair.data.Sentence"]
+
+    flair_data_Corpus["flair.data.Corpus"]
+
+    flair_tokenization_Tokenizer["flair.tokenization.Tokenizer"]
+
+    flair_data_Dictionary["flair.data.Dictionary"]
+
+    flair_embeddings_base_Embeddings["flair.embeddings.base.Embeddings"]
+
+    flair_nn_model_Model["flair.nn.model.Model"]
+
+    flair_trainers_trainer_ModelTrainer["flair.trainers.trainer.ModelTrainer"]
+
+    flair_data_Sentence -- "inherits from" --> flair_data_DataPoint
+
+    flair_embeddings_base_Embeddings -- "populates" --> flair_data_DataPoint
+
+    flair_data_Corpus -- "collects and manages" --> flair_data_Sentence
+
+    flair_tokenization_Tokenizer -- "processes raw text into" --> flair_data_Sentence
+
+    flair_trainers_trainer_ModelTrainer -- "consumes data from" --> flair_data_Corpus
+
+    flair_data_Corpus -- "builds" --> flair_data_Dictionary
+
+    flair_data_Sentence -- "uses" --> flair_tokenization_Tokenizer
+
+    flair_nn_model_Model -- "stores and utilizes" --> flair_tokenization_Tokenizer
+
+    flair_nn_model_Model -- "uses" --> flair_data_Dictionary
+
+    flair_nn_model_Model -- "composes" --> flair_embeddings_base_Embeddings
+
+    flair_trainers_trainer_ModelTrainer -- "orchestrates" --> flair_nn_model_Model
+
+    flair_nn_model_Model -- "consumes" --> flair_data_DataPoint
+
+    click flair_data_DataPoint href "https://github.com/flairNLP/flair/blob/master/.codeboarding//flair_data_DataPoint.md" "Details"
+
+    click flair_data_Corpus href "https://github.com/flairNLP/flair/blob/master/.codeboarding//flair_data_Corpus.md" "Details"
+
+    click flair_tokenization_Tokenizer href "https://github.com/flairNLP/flair/blob/master/.codeboarding//flair_tokenization_Tokenizer.md" "Details"
+
+    click flair_embeddings_base_Embeddings href "https://github.com/flairNLP/flair/blob/master/.codeboarding//flair_embeddings_base_Embeddings.md" "Details"
+
+    click flair_nn_model_Model href "https://github.com/flairNLP/flair/blob/master/.codeboarding//flair_nn_model_Model.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The architecture of `flair` is designed around a clear separation of concerns, with core components handling data representation, preprocessing, embedding, model definition, and training orchestration. Together, these components form a cohesive and modular architecture that allows Flair to efficiently handle various NLP tasks, from data loading and preprocessing to model training and prediction.
+
+
+
+### flair.data.DataPoint
+
+The foundational abstract base class for all data units in Flair (e.g., `Token`, `Sentence`). It defines the common interface for storing embeddings, managing various annotation layers, and providing basic textual and positional information, ensuring a consistent way to attach numerical representations and symbolic labels.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L413-L706" target="_blank" rel="noopener noreferrer">`flair.data.DataPoint` (413:706)</a>
+
+
+
+
+
+### flair.data.Sentence
+
+A concrete implementation of `DataPoint` representing a sequence of tokens, typically a single sentence. It manages the raw text, a list of `Token` objects, and can hold various linguistic annotations (sentence-level labels, spans). It handles lazy tokenization, ensuring tokens are generated only when needed.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L1177-L2141" target="_blank" rel="noopener noreferrer">`flair.data.Sentence` (1177:2141)</a>
+
+
+
+
+
+### flair.data.Corpus
+
+The central container for managing datasets, typically split into training, development (dev), and testing sets. It provides methods for sampling, filtering, and generating `Dictionary` objects from the data, and ensures all necessary splits are available for a training run.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L2333-L2930" target="_blank" rel="noopener noreferrer">`flair.data.Corpus` (2333:2930)</a>
+
+
+
+
+
+### flair.tokenization.Tokenizer
+
+An abstract base class that defines the contract for tokenizing raw text. Subclasses implement specific tokenization algorithms, providing the `tokenize` method to split a string into a list of string tokens. It's essential for preparing raw text for further processing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/tokenization.py#L12-L63" target="_blank" rel="noopener noreferrer">`flair.tokenization.Tokenizer` (12:63)</a>
+
+
+
+
+
+### flair.data.Dictionary
+
+A utility class responsible for creating and managing a mapping between unique string items (like words, characters, or labels) and their corresponding integer IDs. This is crucial for converting symbolic data into numerical representations required by neural networks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/data.py#L70-L307" target="_blank" rel="noopener noreferrer">`flair.data.Dictionary` (70:307)</a>
+
+
+
+
+
+### flair.embeddings.base.Embeddings
+
+The abstract base class for all embedding modules in Flair. It defines the `embed` method, which takes `DataPoint` objects (typically `Sentence` or `Token`) and populates them with dense vector representations, handling whether embeddings are static or need recomputation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/embeddings/base.py#L15-L104" target="_blank" rel="noopener noreferrer">`flair.embeddings.base.Embeddings` (15:104)</a>
+
+
+
+
+
+### flair.nn.model.Model
+
+The abstract base class for all neural network models in Flair that perform downstream NLP tasks (e.g., `SequenceTagger`, `TextClassifier`). It defines core functionalities required for training and inference, including `label_type`, `forward_loss` (for computing loss), and `evaluate` (for performance assessment). It also manages model saving/loading.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/nn/model.py#L30-L448" target="_blank" rel="noopener noreferrer">`flair.nn.model.Model` (30:448)</a>
+
+
+
+
+
+### flair.trainers.trainer.ModelTrainer
+
+The central orchestration component responsible for managing the entire training and evaluation lifecycle of a Flair model. It takes a `flair.nn.Model` and a `flair.data.Corpus`, handles the training loop (epochs, mini-batches), manages the optimizer and learning rate scheduler, and performs evaluations on development and test sets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/flairNLP/flair/blob/master/flair/trainers/trainer.py#L43-L1035" target="_blank" rel="noopener noreferrer">`flair.trainers.trainer.ModelTrainer` (43:1035)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR adds diagram representation of the codebase for flair.
You can see how it renders here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/flair/on_boarding.md

With over 2k forks it is clear that a lot of people play around with the codebase. This said most of them probably want to just adjust certain aspect of the codebase, and with the proposed diagrams they can navigate it much faster and contribute with better understanding. Let me know if you share my view here.

Usually I'd open a discussion first, but they are not enabled for this repo! This said any feedback is more than welcome!

I saw that you are using .rst files for docs (Sphinx?). We have a free ghub action to keep the diagrams up-to-date. So if you like what you see I'd be more than happy to integrate it for you!

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers.