### PR TITLE
NER_GERMAN_GERMEVAL: Make sure every sentence is independent

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -2952,6 +2952,7 @@ class NER_GERMAN_GERMEVAL(ColumnCorpus):
             columns,
             comment_symbol="#",
             in_memory=in_memory,
+            every_sentence_is_independent=True,
             **corpusargs,
         )
 


### PR DESCRIPTION
Sets the flag that every sentence in Germeval is independent.