### PR TITLE
Fix deprecated torch.cuda.amp.GradScaler usage in trainer

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -562,7 +562,7 @@ class ModelTrainer(Pluggable):
             self.context_stack = context_stack
             self.dispatch("after_setup", **parameters)
 
-            scaler = torch.cuda.amp.GradScaler(enabled=use_amp and flair.device.type != "cpu")
+            scaler = torch.amp.GradScaler('cuda', enabled=use_amp and flair.device.type != "cpu")
 
             final_eval_info = (
                 "model after last epoch (final-model.pt)"


### PR DESCRIPTION
Replace deprecated `torch.cuda.amp.GradScaler` with the new `torch.amp.GradScaler` API to resolve FutureWarning in PyTorch 2.4+.

**Changes:**
Updated `trainer.py` line 545 to use `torch.amp.GradScaler('cuda', ...)` instead of `torch.cuda.amp.GradScaler(...)`

**Issue:**
Fixes deprecation warning:
````python
FutureWarning: `torch.cuda.amp.GradScaler(args...)` is deprecated. 
Please use `torch.amp.GradScaler('cuda', args...)` instead.
````

**Compatibility:**
- Maintains backward compatibility (PyTorch 1.10+ supports both APIs)
- No functional changes - purely API migration
- Tested with existing training workflows
