### PR TITLE
GH-3686: show actual dictionary name when custom dict is passed to EntityMentionLinker

### DIFF
--- a/flair/models/entity_mention_linking.py
+++ b/flair/models/entity_mention_linking.py
@@ -945,9 +945,8 @@ class EntityMentionLinker(flair.nn.Model[Sentence]):
 
         candidate_generator.index(dictionary, preprocessor)
 
-        logger.info(
-            "EntityMentionLinker predicts: Dictionary `%s` (entity type: %s)", dictionary_name_or_path, entity_type
-        )
+        display_name = dictionary_name_or_path or getattr(dictionary, "database_name", None) or "custom"
+        logger.info("EntityMentionLinker predicts: Dictionary `%s` (entity type: %s)", display_name, entity_type)
 
         return cls(
             candidate_generator=candidate_generator,


### PR DESCRIPTION
When you pass a pre-built `InMemoryEntityLinkingDictionary` directly to `EntityMentionLinker.build()` via `dictionary=`, the log message prints `Dictionary None` because `dictionary_name_or_path` is never assigned in that code path.

This was a bit confusing when following Tutorial 4 — took me a while to figure out why predict() seemed to work but returned nothing.

The fix falls back to `dictionary.database_name` (which `InMemoryEntityLinkingDictionary` inherits from `EntityLinkingDictionary`) before defaulting to `"custom"`.

Closes #3686