### PR TITLE
GH-3676: make sentencepiece a lazy import for BytePairEmbeddings

### DIFF
--- a/flair/embeddings/token.py
+++ b/flair/embeddings/token.py
@@ -9,7 +9,6 @@ from typing import Any, Optional, Union
 import numpy as np
 import torch
 from deprecated.sphinx import deprecated
-from sentencepiece import SentencePieceProcessor
 from torch import nn
 
 import flair
@@ -1389,6 +1388,7 @@ class BytePairEmbeddings(TokenEmbeddings):
             cache_dir = flair.cache_root / "embeddings"
 
         if model_file_path is not None and embedding_file_path is None:
+            (SentencePieceProcessor,) = lazy_import("word-embeddings", "sentencepiece", "SentencePieceProcessor")
             self.spm = SentencePieceProcessor()
             self.spm.Load(str(model_file_path))
             vectors = np.zeros((self.spm.vocab_size() + 1, dim))


### PR DESCRIPTION
sentencepiece fails to build on Python 3.13 + macOS and the package seems unmaintained (last release Feb 2024). The direct `from sentencepiece import SentencePieceProcessor` at the top of `token.py` means the entire embeddings module fails to import even if nobody uses `BytePairEmbeddings`.

Moved the import into `BytePairEmbeddings.__init__()` using the existing `lazy_import()` helper that the class already uses for bpemb.

Kept `transformers[sentencepiece]` in requirements.txt since other HF tokenizers (T5, XLM-RoBERTa etc.) import sentencepiece internally and would break without it. This only fixes the direct import that blocks the module load.

Closes #3676